### PR TITLE
Incorrect function signature in f2ch.add

### DIFF
--- a/v3p/netlib/libf2c/f2ch.add
+++ b/v3p/netlib/libf2c/f2ch.add
@@ -126,7 +126,7 @@ extern double r_tan(float *);
 extern double r_tanh(float *);
 extern void s_cat(char *, char **, integer *, integer *, ftnlen);
 extern integer s_cmp(char *, char *, ftnlen, ftnlen);
-extern void s_copy(char *, char *, ftnlen, ftnlen);
+extern int s_copy(char *, char *, ftnlen, ftnlen);
 extern int s_paus(char *, ftnlen);
 extern integer s_rdfe(cilist *);
 extern integer s_rdue(cilist *);


### PR DESCRIPTION
The s_copy function returns an integer, but the function prototype signature
specified void as the return type. When compiling with the intel compiler and
-ipo flag, undefined symbols were encountered.