### PR TITLE
COMP: Fix compilation linkage issue

### DIFF
--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_eye_scene.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_eye_scene.cxx
@@ -156,6 +156,7 @@ void boxm2_vecf_eye_scene::reset_indices(){
     }
   }
 }
+
 boxm2_vecf_eye_scene::boxm2_vecf_eye_scene(vcl_string const& scene_file, bool initialize):
   base_model_(new boxm2_scene(scene_file)), alpha_data_(0), app_data_(0), nobs_data_(0), sphere_(0), sphere_dist_(0), iris_(0), pupil_(0)
 {

--- a/contrib/brl/bseg/boxm2/vecf/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/vecf/tests/CMakeLists.txt
@@ -2,17 +2,16 @@ ADD_EXECUTABLE( boxm2_vecf_test_all
   test_driver.cxx
   test_eye.cxx
   test_orbit.cxx
-  test_fit_orbit.cxx	
+  test_fit_orbit.cxx
   test_fit_margin.cxx
-  test_pc_viewer.cxx	
-  test_mandible.cxx	
+  test_pc_viewer.cxx
+  test_mandible.cxx
  )
-
-#depends on OPENCL being found...
-INCLUDE( ${VXL_CMAKE_DIR}/NewCMake/FindOpenCL.cmake )
-IF(OPENCL_FOUND)
-
 TARGET_LINK_LIBRARIES(boxm2_vecf_test_all testlib  boxm2_vecf brdb vpgl_algo vpgl_pro vil_pro sdet vnl vgl vil vul vpl )
+
+##- #depends on OPENCL being found...
+##- INCLUDE( ${VXL_CMAKE_DIR}/NewCMake/FindOpenCL.cmake )
+##- IF(OPENCL_FOUND)
 
 ADD_TEST( boxm2_vecf_test_eye      ${EXECUTABLE_OUTPUT_PATH}/boxm2_vecf_test_all  test_eye  )
 ADD_TEST( boxm2_vecf_test_orbit      ${EXECUTABLE_OUTPUT_PATH}/boxm2_vecf_test_all  test_orbit  )
@@ -24,4 +23,4 @@ ADD_TEST( boxm2_vecf_test_mandible      ${EXECUTABLE_OUTPUT_PATH}/boxm2_vecf_tes
 #ADD_EXECUTABLE( boxm2_vecf_test_include test_include.cxx )
 #TARGET_LINK_LIBRARIES( boxm2_vecf_test_include boxm2_vecf )
 
-ENDIF(OPENCL_FOUND)
+##- ENDIF(OPENCL_FOUND)


### PR DESCRIPTION
The TARGET_LINK_LIBRARIES was placed inside
a conditional for dependance on OPENCL.  That
seems like an incorrect dependancy because
the code builds without OPENCL and all test pass.