### PR TITLE
COMP:  putback is not reliable for istreams

### DIFF
--- a/core/vnl/vnl_na.cxx
+++ b/core/vnl/vnl_na.cxx
@@ -6,9 +6,12 @@
 // \file
 
 #include "vnl_na.h"
+
 #include <vxl_config.h>
 #include <vcl_istream.h>
-#include <vcl_ios.h>
+#include <vcl_sstream.h>
+#include <vcl_cctype.h>
+#include <vcl_string.h>
 #include <vnl/vnl_math.h>
 
 //: A particular qNaN to indicate not available.
@@ -84,32 +87,68 @@ float vnl_na_nan_to_na(float v)
   return vnl_math::isnan(v) ? vnl_na(float()) : v;
 }
 
-
 //: Read a floating point number or "NA" from a stream.
-template <class T> inline void vnl_na_extract_type(vcl_istream &is, T& x)
+template <class T> inline void vnl_na_extract_type(vcl_istream &is, T& value)
 {
   if (!is) return;
-  is >> x;
+  vcl_stringstream oneToken("");
+  unsigned int char_processed_count = 0;
+  bool period_found = false;
+  bool current_location_is_delimiter = false;
 
-  if (!!is || is.eof()) return;
-  is.clear();
-
-  char c=' ';
-  is >> c;
-  if (c != 'N' && c!='n')
-  {
-    is.putback(c);
-    is.clear(vcl_ios::badbit);
-    return;
+  while (!is.eof()) {
+    vcl_stringstream::char_type c;
+    vcl_istream::int_type p = is.peek();
+    if ( char_processed_count == 0 ) { //The first character is the start of the token of interest.
+      if (vcl_isspace(p)) {
+        is.get(c); // Gobble up the peeked at character
+        continue; //Gobble up preceeding white space
+      }
+      if ( p == 'N' || p == 'n' ) {
+        is.get(c);// Gobble up the N
+        p = is.peek();
+        if (p == 'A' || p == 'a') {
+          is.get(c); // Gobble up the A
+          value = vnl_na(T());
+          return;
+        }
+        else
+        {
+          vcl_string checkForNAString;
+          is >> checkForNAString; //Gobble up the rest of the token, whatever that is
+          value = 999.999; // Invalid parsing occured
+          return;
+        }
+      }
+    }
+    // Find if character is candidate for float values
+    if (vcl_isdigit(p) || p == '-' || p == '+' || p == '.') {
+      // After the first character, sign character is delimiter
+      if ((char_processed_count != 0) && ((p == '-') || (p == '+'))) {
+        current_location_is_delimiter = true;
+      }
+      if (p == '.') {
+        if (period_found) //Second period encountered is a delimiter
+        {
+          current_location_is_delimiter = true;
+        }
+        period_found = true;
+      }
+    }
+    else // All other characters are delimiters
+    {
+      current_location_is_delimiter = true;
+    }
+    if ( current_location_is_delimiter) {
+      break;
+    }
+    else {
+      is.get(c); //Gobble up peeked character
+      oneToken << c;
+    }
+    ++char_processed_count;
   }
-  is >> c;
-  if (c != 'A' && c!='a')
-  {
-    is.putback(c);
-    is.clear(vcl_ios::badbit);
-    return;
-  }
-  x = vnl_na(T());
+  oneToken >> value;
 }
 
 void vnl_na_extract(vcl_istream &is, double& x) { vnl_na_extract_type(is, x); }


### PR DESCRIPTION
The istream interface explicitly states[1] the putback (& unget, and
all other methods that write to the stream) :
"... may either fail, be ignored, or overwrite the character at that position"
               ^^^^A^^^^^^^^^^^^^

In the case of the clang compiler, it was failing.

A new implementation was created that does not require writing to the
stream.  This new implementation passes all the tests.

[1] http://www.cplusplus.com/reference/istream/istream/putback/