### PR TITLE
fix compiler error due to missing support of snprintf on VC11

### DIFF
--- a/vcl/vcl_cstdio.h
+++ b/vcl/vcl_cstdio.h
@@ -29,7 +29,7 @@
 # include <cstdio>
 # define vcl_generic_cstdio_STD /* */
 # include "generic/vcl_cstdio.h"
-#elif defined(VCL_VC_7)|| defined(VCL_VC_8)|| defined(VCL_VC_9) || defined(VCL_VC_10)
+#elif defined(VCL_VC_7)|| defined(VCL_VC_8)|| defined(VCL_VC_9) || defined(VCL_VC_10) || defined(VCL_VC_11)
 # define vcl_snprintf _snprintf
 # include "vcl_cstddef.h" // for size_t
 # include "iso/vcl_cstdio.h"


### PR DESCRIPTION
snprintf is not included in Visual Studio 2012, 2013