### PR TITLE
Define OF for minizip, when it isn't already.

### DIFF
--- a/contrib/brl/b3p/minizip/ioapi.h
+++ b/contrib/brl/b3p/minizip/ioapi.h
@@ -31,6 +31,14 @@
 #endif
 #endif
 
+#ifndef OF
+#ifdef _Z_OF
+#define OF(x) _Z_OF(x)
+#else
+#define OF(x) x
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/contrib/brl/b3p/minizip/iowin32.h
+++ b/contrib/brl/b3p/minizip/iowin32.h
@@ -9,7 +9,6 @@
 
 #include <windows.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/contrib/brl/b3p/minizip/zip.h
+++ b/contrib/brl/b3p/minizip/zip.h
@@ -44,6 +44,7 @@
 #ifndef _zip_H
 #define _zip_H
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
New versions of zlib switched macros from OF to _Z_OF. This patch checks for the definition of OF and either uses it, else uses _Z_OF if it's defined, or as a fallback, creates a default definition. The third case is probably not needed, however seems like a safer option than letting the build fail.

The *.kitware experimental dashboards include this branch and show it working