### PR TITLE
MSVC doesn't define << operator which takes std::basic_ostream.

### DIFF
--- a/contrib/brl/bseg/bvxm/pro/processes/bvxm_create_scene_xml_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/processes/bvxm_create_scene_xml_process.cxx
@@ -240,7 +240,7 @@ bool bvxm_create_scene_xml_large_scale_process(bprb_func_process& pro)
     scene_world << world_dir << "/scene_" << i;
     if (!(vul_file::exists(scene_world.str()) && vul_file::is_directory(scene_world.str())))
       if (!vul_file::make_directory(scene_world.str())) {
-        vcl_cerr << pro.name() << ": creating scene world folder " << scene_world << " failed!\n";
+        vcl_cerr << pro.name() << ": creating scene world folder " << scene_world.str() << " failed!\n";
         return false;
       }
     bvxm_world_params params;


### PR DESCRIPTION
For the vcl_err message, we need to use scene_world.str() instead of the
stream itself.