### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - mkdir $HOME/install
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/install
+          -DCMAKE_CXX_STANDARD=11
           ../
   - make -j2
   - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+#Travis CI configuration for VXL
+# See http://travis-ci.org/vxl/vxl
+
+sudo: false
+
+language: cpp
+compiler:
+  - gcc
+  - clang
+
+cache: ccache
+
+addons:
+  apt:
+    packages:
+    - ccache
+
+script:
+  - mkdir build
+  - mkdir $HOME/install
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/install
+          ../
+  - make -j2
+  - ctest
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ compiler:
   - gcc
   - clang
 
-cache: ccache
+cache:
+  - ccache
+  - directories:
+    - $HOME/deps
+
+before_script:
+  - bash .travis/install-deps.sh
 
 addons:
   apt:
@@ -16,6 +22,7 @@ addons:
     - ccache
 
 script:
+  - export PATH=$HOME/deps/bin:$PATH
   - mkdir build
   - mkdir $HOME/install
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,11 @@ compiler:
   - clang
 
 cache:
-  - ccache
-  - directories:
-    - $HOME/deps
+  directories:
+  - $HOME/deps
 
 before_script:
   - bash .travis/install-deps.sh
-
-addons:
-  apt:
-    packages:
-    - ccache
 
 script:
   - export PATH=$HOME/deps/bin:$PATH

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+INSTALL_DIR=$HOME/deps
+export PATH=$INSTALL_DIR/bin:$PATH
+
+# check if directory is cached
+if [ ! -f "$INSTALL_DIR/bin/cmake" ]; then
+  cd /tmp
+  wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.sh
+  bash cmake-3.4.0-Linux-x86_64.sh --skip-license --prefix="$INSTALL_DIR/"
+else
+  echo 'Using cached CMake directory.';
+fi


### PR DESCRIPTION
I've turned on Travis CI support for VXL, and here is an initial script to get it working.  Because VXL is so large, we may want to consider enabling `ccache` in the future to see if we can speed up builds.