### PR TITLE
compute volume if the value is not valid

### DIFF
--- a/contrib/brl/bbas/bsta/bsta_joint_histogram_3d.txx
+++ b/contrib/brl/bbas/bsta/bsta_joint_histogram_3d.txx
@@ -226,6 +226,9 @@ T bsta_joint_histogram_3d<T>::p(unsigned a, unsigned b, unsigned c) const
 template <class T>
 T bsta_joint_histogram_3d<T>::p(T a, T b, T c) const
 {
+  if (!volume_valid_) {
+    compute_volume();
+  }
   int bina, binb, binc;
   if(!bin_at_val(a,b,c,bina,binb,binc))
     return 0;


### PR DESCRIPTION
There seems to be a lazy-computed value being used prematurely.  This fixes the "bsta_histogram_io" test failure on my machine.