### PR TITLE
test variable, not evaluated variable in CMakeLists.txt

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/CMakeLists.txt
+++ b/contrib/brl/bbas/bvgl/algo/CMakeLists.txt
@@ -9,12 +9,12 @@ CONFIGURE_FILE(
 )
 
 # Copy the Eulerspiral lookup-table file to the BRL library folder
-if(${LIBRARY_OUTPUT_PATH})
+if(LIBRARY_OUTPUT_PATH)
   CONFIGURE_FILE(
     ${brl_SOURCE_DIR}/bbas/bvgl/algo/bvgl_eulerspiral_lookup_table.bvl
     ${LIBRARY_OUTPUT_PATH}/bvgl_eulerspiral_lookup_table.bvl COPYONLY
   )
-endif(${LIBRARY_OUTPUT_PATH})
+endif(LIBRARY_OUTPUT_PATH)
 
 ADD_DEFINITIONS(-DBVGL_WHERE_BRL_LIB_DIR_H_EXISTS)
 INCLUDE_DIRECTORIES( ${brl_BINARY_DIR}/bbas/bvgl/algo/ )


### PR DESCRIPTION
Fixed what seems to be a bug in the brl/bbas/bvgl/algo  CMakeLists.txt, which was preventing an auxiliary file from being copied to the library directory.  This in turn caused the "sdet_test_sel" test to crash.

The crash is fixed, but now there are some failing tests that were not previously running.