### PR TITLE
vgl_plane_3d instantiation for int

### DIFF
--- a/core/vgl/Templates/vgl_plane_3d+int-.cxx
+++ b/core/vgl/Templates/vgl_plane_3d+int-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of vgl_plane_3d<int>
+#include <vgl/vgl_plane_3d.txx>
+VGL_PLANE_3D_INSTANTIATE(int);


### PR DESCRIPTION
This instantiation is still needed to avoid linking errors on some
platforms.  It was previously removed because integer math will give
unexpected results inside the vgl_plane_3d class. Another strategy will
be needed to avoid this.