### PR TITLE
Fix boxm plane ransac test

### DIFF
--- a/contrib/brl/bseg/boxm/util/tests/test_boxm_plane_ransac.cxx
+++ b/contrib/brl/bseg/boxm/util/tests/test_boxm_plane_ransac.cxx
@@ -68,7 +68,7 @@ static void test_boxm_plane_ransac()
   boxm_plane_ransac<float>(planes, weights, l, residual, cell_global_box, threshold, ortho_thres, volume_ratio);
 
   TEST_NEAR("test_boxm_plane_ransac: found the right plane set",
-            (l.x0()-line.x0()).sqr_length() + (l.direction()-line.direction()).sqr_length(),
+            (l.point()-line.point()).sqr_length() + (l.direction()-line.direction()).sqr_length(),
             0.0f, 0.01f);
 }
 

--- a/core/vgl/algo/vgl_intersection.txx
+++ b/core/vgl/algo/vgl_intersection.txx
@@ -63,12 +63,12 @@ vgl_intersection(const vcl_list<vgl_plane_3d<T> >& planes)
   vnl_vector<double> t = svd.nullvector();
 
   double tx = t[0], ty = t[1], tz = t[2];
-
+  double atx = vcl_fabs(tx), aty = vcl_fabs(ty), atz = vcl_fabs(tz);
   // determine maximum component of t
   char component = 'x';
-  if (ty>tx&&ty>tz)
+  if (aty>atx&&aty>atz)
     component = 'y';
-  if (tz>tx&&tz>ty)
+  if (atz>atx&&atz>aty)
     component = 'z';
   vgl_point_3d<double> p0d;
   switch (component)
@@ -140,11 +140,12 @@ vgl_intersection(const vcl_list<vgl_plane_3d<T> >& planes, vcl_vector<T> ws,
   // the direction of the resulting line
   vnl_vector<double> t = svd.nullvector();
   double tx = t[0], ty = t[1], tz = t[2];
+  double atx = vcl_fabs(tx), aty = vcl_fabs(ty), atz = vcl_fabs(tz);
   // determine maximum component of t
   char component = 'x';
-  if (ty>tx&&ty>tz)
+  if (aty>atx&&aty>atz)
     component = 'y';
-  if (tz>tx&&tz>ty)
+  if (atz>atx&&atz>aty)
     component = 'z';
   vgl_point_3d<double> p0d;
   switch (component)

--- a/core/vgl/tests/test_infinite_line_3d.cxx
+++ b/core/vgl/tests/test_infinite_line_3d.cxx
@@ -4,6 +4,7 @@
 #include <vcl_iostream.h>
 #include <testlib/testlib_test.h>
 #include <vgl/vgl_infinite_line_3d.h>
+#include <vgl/vgl_distance.h>
 
 
 static void test_constructor()
@@ -26,16 +27,83 @@ static void test_constructor()
 
 static void test_operations()
 {
+  {
   vgl_vector_3d<double> t(0,0,1);
   vgl_point_3d<double> p(1,2,3), p0, pt;
   vgl_infinite_line_3d<double> inf_l(p, t);
   p0 = inf_l.point();
-  TEST("Closest point to origin", p0==vgl_point_3d<double>(1,2,0), true);
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(1,2,0)), 0, 1e-6);
   pt = inf_l.point_t(1.0);
-  TEST("Parametric point ", pt==vgl_point_3d<double>(1,2,1), true);
+  TEST_NEAR("Parametric point ", vgl_distance(pt, vgl_point_3d<double>(1,2,1)), 0, 1e-6);
   vgl_point_3d<double> x(1.0, 2.0, -3.0);
   bool con = inf_l.contains(x);
   TEST("Contains ", con, true);
+  }
+
+  {
+  vgl_vector_3d<double> t(1,0,0);
+  vgl_point_3d<double> p(1,2,3), p0, pt;
+  vgl_infinite_line_3d<double> inf_l(p, t);
+  p0 = inf_l.point();
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(0,2,3)), 0, 1e-6);
+  pt = inf_l.point_t(1.0);
+  TEST_NEAR("Parametric point ", vgl_distance(pt,vgl_point_3d<double>(1,2,3)), 0, 1e-6);
+  vgl_point_3d<double> x(-1.0, 2.0, 3.0);
+  bool con = inf_l.contains(x);
+  TEST("Contains ", con, true);
+  }
+
+  {
+  vgl_vector_3d<double> t(0,1,0);
+  vgl_point_3d<double> p(1,2,3), p0, pt;
+  vgl_infinite_line_3d<double> inf_l(p, t);
+  p0 = inf_l.point();
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(1,0,3)), 0, 1e-6);
+  pt = inf_l.point_t(1.0);
+  TEST_NEAR("Parametric point ", vgl_distance(pt,vgl_point_3d<double>(1,1,3)), 0, 1e-6);
+  vgl_point_3d<double> x(1.0, -2.0, 3.0);
+  bool con = inf_l.contains(x);
+  TEST("Contains ", con, true);
+  }
+
+  {
+  vgl_vector_3d<double> t(0,0,-1);
+  vgl_point_3d<double> p(1,2,3), p0, pt;
+  vgl_infinite_line_3d<double> inf_l(p, t);
+  p0 = inf_l.point();
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(1,2,0)), 0, 1e-6);
+  pt = inf_l.point_t(1.0);
+  TEST_NEAR("Parametric point ", vgl_distance(pt, vgl_point_3d<double>(1,2,1)), 0, 1e-6);
+  vgl_point_3d<double> x(1.0, 2.0, -3.0);
+  bool con = inf_l.contains(x);
+  TEST("Contains ", con, true);
+  }
+
+  {
+  vgl_vector_3d<double> t(-1,0,0);
+  vgl_point_3d<double> p(1,2,3), p0, pt;
+  vgl_infinite_line_3d<double> inf_l(p, t);
+  p0 = inf_l.point();
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(0,2,3)), 0, 1e-6);
+  pt = inf_l.point_t(1.0);
+  TEST_NEAR("Parametric point ", vgl_distance(pt,vgl_point_3d<double>(1,2,3)), 0, 1e-6);
+  vgl_point_3d<double> x(-1.0, 2.0, 3.0);
+  bool con = inf_l.contains(x);
+  TEST("Contains ", con, true);
+  }
+
+  {
+  vgl_vector_3d<double> t(0,-1,0);
+  vgl_point_3d<double> p(1,2,3), p0, pt;
+  vgl_infinite_line_3d<double> inf_l(p, t);
+  p0 = inf_l.point();
+  TEST_NEAR("Closest point to origin", vgl_distance(p0,vgl_point_3d<double>(1,0,3)), 0, 1e-6);
+  pt = inf_l.point_t(1.0);
+  TEST_NEAR("Parametric point ", vgl_distance(pt,vgl_point_3d<double>(1,1,3)), 0, 1e-6);
+  vgl_point_3d<double> x(1.0, -2.0, 3.0);
+  bool con = inf_l.contains(x);
+  TEST("Contains ", con, true);
+  }
 }
 
 void test_infinite_line_3d()


### PR DESCRIPTION
This PR contains some new tests for the vgl_infinite_line_3d class, a bugfix vgl_intersection.txx, and a bugfix in test_boxm_plane_ransac that fixes sporadic failures of that test.

The basic problem is that the unique "uv" basis vectors computed by vgl_infinite_line_3d become ill-defined as the direction of the line approaches +x.  A previous PR (now closed) only moved the singularity to a new direction.  Rather than test the 2D point x0_, which is a function of the uv basis vectors, test the 3D point closest to the origin, which is always well-defined.  x0_ should probably be removed from the public interface of vgl_infinite_line_3d in the future for this reason.
