### PR TITLE
Increase default template-depth.

### DIFF
--- a/core/vil/io/CMakeLists.txt
+++ b/core/vil/io/CMakeLists.txt
@@ -11,7 +11,7 @@ AUX_SOURCE_DIRECTORY(Templates vil_io_sources)
 IF(CMAKE_COMPILER_IS_GNUCXX)
   SET_SOURCE_FILES_PROPERTIES(Templates/vsl_vector_io+vcl_vector+vil_image_view+float---.cxx
                               PROPERTIES
-                              COMPILE_FLAGS -ftemplate-depth-35)
+                              COMPILE_FLAGS -ftemplate-depth-50)
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 ADD_LIBRARY(vil_io ${vil_io_sources})

--- a/core/vnl/io/CMakeLists.txt
+++ b/core/vnl/io/CMakeLists.txt
@@ -20,9 +20,10 @@ SET(vnl_io_sources
 AUX_SOURCE_DIRECTORY(Templates vnl_io_sources)
 
 IF(CMAKE_COMPILER_IS_GNUCXX)
-  SET_SOURCE_FILES_PROPERTIES(Templates/vsl_vector_io+vcl_vector+vcl_vector+vnl_vector+double----.cxx
-                              PROPERTIES
-                              COMPILE_FLAGS -ftemplate-depth-35)
+  SET_SOURCE_FILES_PROPERTIES(
+    Templates/vsl_vector_io+vcl_vector+vcl_vector+vnl_vector+double----.cxx
+    PROPERTIES
+    COMPILE_FLAGS -ftemplate-depth-50)
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 ADD_LIBRARY(vnl_io ${vnl_io_sources} )


### PR DESCRIPTION
When CMAKE_CXX_STANDARD is set to 11, we have issues with the current template-depth values set for 2 files. Increasing the depth to 50 fixes the compiler errors.