### PR TITLE
ENH: Add Floored and Truncated Modulus to VNL

### DIFF
--- a/core/vnl/tests/test_math.cxx
+++ b/core/vnl/tests/test_math.cxx
@@ -415,6 +415,188 @@ static void test_math()
   conv_eps = vnl_math::angle_minuspi_to_pi(-eps);
   vcl_cout << "conv_eps = " << conv_eps << vcl_endl;
   TEST("vnl_math::angle_minuspi_to_pi(-10eps)", conv_eps, -eps);
+
+  ///////////////
+  // TRUNCATED //
+  ///////////////
+
+  vcl_cout << "Truncated Remainder:" << vcl_endl;
+  // Truncated Remainder (% for integers, fmod for floating point)
+  // This behavior is most familiar to c++ programmers, but is unusual
+  // in mathematical terms.
+
+    {
+
+    vcl_cout << "+ +" << vcl_endl;
+
+    unsigned short x_short_u     = 7;
+    unsigned short y_short_u     = 2;
+      signed short x_short_s     = 7;
+      signed short y_short_s     = 2;
+    unsigned int   x_int_u       = 7;
+    unsigned int   y_int_u       = 2;
+      signed int   x_int_s       = 7;
+      signed int   y_int_s       = 2;
+    unsigned long  x_long_u      = 7;
+    unsigned long  y_long_u      = 2;
+      signed long  x_long_s      = 7;
+      signed long  y_long_s      = 2;
+    float          x_float       = 7;
+    float          y_float       = 2;
+    double         x_double      = 7;
+    double         y_double      = 2;
+    long double    x_long_double = 7;
+    long double    y_long_double = 2;
+
+    TEST("vnl_math::remainder_truncated(x_short_u    ,y_short_u    )",vnl_math::remainder_truncated(x_short_u    ,y_short_u    ),+1);
+    TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),+1);
+    TEST("vnl_math::remainder_truncated(x_int_u      ,y_int_u      )",vnl_math::remainder_truncated(x_int_u      ,y_int_u      ),+1);
+    TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),+1);
+    TEST("vnl_math::remainder_truncated(x_long_u     ,y_long_u     )",vnl_math::remainder_truncated(x_long_u     ,y_long_u     ),+1);
+    TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),+1);
+    TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),+1);
+    TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),+1);
+    TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),+1);
+
+    vcl_cout << "+ -" << vcl_endl;
+
+    y_short_s     *= -1;
+    y_int_s       *= -1;
+    y_long_s      *= -1;
+    y_float       *= -1;
+    y_double      *= -1;
+    y_long_double *= -1;
+
+    TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),+1);
+    TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),+1);
+    TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),+1);
+    TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),+1);
+    TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),+1);
+    TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),+1);
+
+    vcl_cout << "- -" << vcl_endl;
+
+    x_short_s     *= -1;
+    x_int_s       *= -1;
+    x_long_s      *= -1;
+    x_float       *= -1;
+    x_double      *= -1;
+    x_long_double *= -1;
+
+    TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),-1);
+    TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),-1);
+    TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),-1);
+    TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),-1);
+    TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),-1);
+    TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),-1);
+
+    vcl_cout << "- +" << vcl_endl;
+
+    y_short_s     *= -1;
+    y_int_s       *= -1;
+    y_long_s      *= -1;
+    y_float       *= -1;
+    y_double      *= -1;
+    y_long_double *= -1;
+
+    TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),-1);
+    TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),-1);
+    TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),-1);
+    TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),-1);
+    TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),-1);
+    TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),-1);
+    }
+
+  /////////////
+  // FLOORED //
+  /////////////
+
+  vcl_cout << "Floored Remainder:" << vcl_endl;
+  // This definition is identical to truncated_remainder for two positive arguments.
+  // When one or both of the arguments are negative, this attempts to mimick Python's modulus behavior.
+
+    {
+
+    vcl_cout << "+ +" << vcl_endl;
+
+    unsigned short x_short_u     = 7;
+    unsigned short y_short_u     = 2;
+      signed short x_short_s     = 7;
+      signed short y_short_s     = 2;
+    unsigned int   x_int_u       = 7;
+    unsigned int   y_int_u       = 2;
+      signed int   x_int_s       = 7;
+      signed int   y_int_s       = 2;
+    unsigned long  x_long_u      = 7;
+    unsigned long  y_long_u      = 2;
+      signed long  x_long_s      = 7;
+      signed long  y_long_s      = 2;
+    float          x_float       = 7;
+    float          y_float       = 2;
+    double         x_double      = 7;
+    double         y_double      = 2;
+    long double    x_long_double = 7;
+    long double    y_long_double = 2;
+
+    TEST("vnl_math::remainder_floored(x_short_u    ,y_short_u    )",vnl_math::remainder_floored(x_short_u    ,y_short_u    ),+1);
+    TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),+1);
+    TEST("vnl_math::remainder_floored(x_int_u      ,y_int_u      )",vnl_math::remainder_floored(x_int_u      ,y_int_u      ),+1);
+    TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),+1);
+    TEST("vnl_math::remainder_floored(x_long_u     ,y_long_u     )",vnl_math::remainder_floored(x_long_u     ,y_long_u     ),+1);
+    TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),+1);
+    TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),+1);
+    TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),+1);
+    TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),+1);
+
+    vcl_cout << "+ -" << vcl_endl;
+
+    y_short_s     *= -1;
+    y_int_s       *= -1;
+    y_long_s      *= -1;
+    y_float       *= -1;
+    y_double      *= -1;
+    y_long_double *= -1;
+
+    TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),-1);
+    TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),-1);
+    TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),-1);
+    TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),-1);
+    TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),-1);
+    TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),-1);
+
+    vcl_cout << "- -" << vcl_endl;
+
+    x_short_s     *= -1;
+    x_int_s       *= -1;
+    x_long_s      *= -1;
+    x_float       *= -1;
+    x_double      *= -1;
+    x_long_double *= -1;
+
+    TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),-1);
+    TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),-1);
+    TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),-1);
+    TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),-1);
+    TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),-1);
+    TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),-1);
+
+    vcl_cout << "- +" << vcl_endl;
+
+    y_short_s     *= -1;
+    y_int_s       *= -1;
+    y_long_s      *= -1;
+    y_float       *= -1;
+    y_double      *= -1;
+    y_long_double *= -1;
+
+    TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),+1);
+    TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),+1);
+    TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),+1);
+    TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),+1);
+    TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),+1);
+    TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),+1);
+    }
+
 }
 
 TESTMAIN(test_math);

--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -676,6 +676,28 @@ extern float       hypot(float       x, float       y);
 extern double      hypot(double      x, double      y);
 extern long double hypot(long double x, long double y);
 
+// truncated remainder
+inline int                remainder_truncated(int x, int y)                               { return x % y; }
+inline unsigned int       remainder_truncated(unsigned int x, unsigned int y)             { return x % y; }
+inline long               remainder_truncated(long x, long y)                             { return x % y; }
+inline unsigned long      remainder_truncated(unsigned long x, unsigned long y)           { return x % y; }
+inline long long          remainder_truncated(long long x, long long y)                   { return x % y; }
+inline unsigned long long remainder_truncated(unsigned long long x, unsigned long long y) { return x % y; }
+inline float              remainder_truncated(float x, float y)                           { return fmod(x,y); }
+inline double             remainder_truncated(double x, double y)                         { return fmod(x,y); }
+inline long double        remainder_truncated(long double x, long double y)               { return fmod(x,y); }
+
+// floored remainder
+inline int                remainder_floored(int x, int y)                               { return ((x % y) + y) % y; }
+inline unsigned int       remainder_floored(unsigned int x, unsigned int y)             { return x % y; }
+inline long               remainder_floored(long x, long y)                             { return ((x % y) + y) % y; }
+inline unsigned long      remainder_floored(unsigned long x, unsigned long y)           { return x % y; }
+inline long long          remainder_floored(long long x, long long y)                   { return ((x % y) + y) % y; }
+inline unsigned long long remainder_floored(unsigned long long x, unsigned long long y) { return x % y; }
+inline float              remainder_floored(float x, float y)                           { return fmod(fmod(x,y)+y,y); }
+inline double             remainder_floored(double x, double y)                         { return fmod(fmod(x,y)+y,y); }
+inline long double        remainder_floored(long double x, long double y)               { return fmod(fmod(x,y)+y,y); }
+
 } // end of namespace vnl_math
 
 #if VNL_CONFIG_LEGACY_METHODS // Legacy definitions, for backward compatibility; deprecated!


### PR DESCRIPTION
The % operator and the library function fmod implement
the remainder operation such that the result has the same
sign as the dividend.  While this is a valid mathematical
interpretation, it is also common for the mathematical modulus
to be defined such that the result takes the sign of the divisor.
This second definition is implemented in some other languages,
such as Python.  Still others, such as Haskell, provide separate
functions for these two definitions.

This patch provides two functions, vnl_math_remainder_truncated
and vnl_math_remainder_floored, for these two definitions,
respectively.  Moreover, they are overloaded to provide a
consistent interface for integer and floating point arguments.

Unit tests have been provided.

NOTE:  The following unit tests failed on my system (Ubuntu 14.04, G++ 5.3.0):

	722 - bocl_test_global_io_bandwidth (SEGFAULT)
	723 - bocl_test_command_queue (SEGFAULT)
	724 - bocl_test_kernel (SEGFAULT)
	725 - bocl_test_local_mem_access (SEGFAULT)
	772 - imesh_test_generate_mesh (OTHER_FAULT)
	908 - boxm2_ocl_test_kernel_filter (Failed)
	909 - boxm2_ocl_test_kernel_vector_filter (Failed)
