### PR TITLE
fix cmake configure error due to folder removal

### DIFF
--- a/contrib/oxl/CMakeLists.txt
+++ b/contrib/oxl/CMakeLists.txt
@@ -21,5 +21,4 @@ add_subdirectory(osl)
 # using vgui:
 IF( BUILD_VGUI )
   add_subdirectory(xcv)
-  add_subdirectory(apps)
 ENDIF( BUILD_VGUI )


### PR DESCRIPTION
fix the cmake configure error due to first wave deprecation removal cleanup.