### PR TITLE
BUG: Fixed the runtime crash of test code on OSX 10.6

### DIFF
--- a/core/vnl/tests/test_numeric_traits.cxx
+++ b/core/vnl/tests/test_numeric_traits.cxx
@@ -48,7 +48,7 @@ void test_static_const_definition()
 #undef ALL
 }
 
-extern "C" { long increment(long x) { return x+1; } }
+extern "C" { long double increment(long double x) { return x+1; } }
 
 void test_numeric_traits()
 {

--- a/core/vnl/tests/test_pow_log.cxx
+++ b/core/vnl/tests/test_pow_log.cxx
@@ -11,7 +11,13 @@ inline static int int_pow(int a, unsigned int b)
 {
   if (b==0) return 1;
   else if (b==1) return a;
-  else return int_pow(a*a,b/2) * int_pow(a, b%2);
+  else
+    {
+    long asquare = static_cast<long>(a)*static_cast<long>(a);
+    long r1      = static_cast<long>(int_pow(static_cast<int>(asquare),b/2));
+    long r2      = static_cast<long>(int_pow(a, b%2));
+    return static_cast<int>(r1*r2);
+    }
 }
 
 // A recursive implementation for a^b with a double and b integer;


### PR DESCRIPTION
- Fixed the runtime crash of vnl_test_numeric_traits

- Fixed the runtime crash of test_pow_log on OSX 10.6