### PR TITLE
ENH: Add methods to flatten vnl_matrix.

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -59,6 +59,20 @@ void test_int()
   TEST("m0.set_diagonal(vnl_vector<int>))",
        (m0.set_diagonal(vnl_vector<int>(2,2,m0values)),
         (m0.get(0,0)==7 && m0.get(1,1)==9 && m0.get(0,1)==2 && m0.get(1,0)==2)), true);
+  
+  // Flip the matrix, otherwise it is the same whichever way it is flattened
+  m0.flipud();
+  // | 2 9 |
+  // | 7 2 |
+  vnl_vector<int> flat;
+  TEST("m0.flatten_row_major()",
+       (flat = m0.flatten_row_major(),
+       (flat.get(0)==2 && flat.get(1)==9 && flat.get(2)==7 && flat.get(3)==2)), true);
+  TEST("m0.flatten_column_major()",
+       (flat = m0.flatten_column_major(),
+       (flat.get(0)==2 && flat.get(1)==7 && flat.get(2)==9 && flat.get(3)==2)), true);
+  m0.flipud();
+
   int m3values [] = {1,2,3};
   vnl_matrix<int> m3(1,3,3, m3values);
   TEST("m3(1,3,3,{1,2,3})",

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -402,6 +402,12 @@ class vnl_matrix
   //: Return a vector with the content of the (main) diagonal
   vnl_vector<T> get_diagonal() const;
 
+  //: Flatten row-major (C-style)
+  vnl_vector<T> flatten_row_major() const;
+
+  //: Flatten column-major (Fortran-style)
+  vnl_vector<T> flatten_column_major() const;
+
   // ==== mutators ====
 
   //: Sets this matrix to an identity matrix, then returns "*this".

--- a/core/vnl/vnl_matrix.txx
+++ b/core/vnl/vnl_matrix.txx
@@ -1041,6 +1041,26 @@ vnl_vector<T> vnl_matrix<T>::get_diagonal() const
   return v;
 }
 
+//: Flatten row-major (C-style)
+template <class T>
+vnl_vector<T> vnl_matrix<T>::flatten_row_major() const
+{
+  vnl_vector<T> v(this->num_rows * this->num_cols);
+  v.copy_in(this->data_block());
+  return v;
+}
+
+//: Flatten column-major (Fortran-style)
+template <class T>
+vnl_vector<T> vnl_matrix<T>::flatten_column_major() const
+{
+  vnl_vector<T> v(this->num_rows * this->num_cols);
+  for (unsigned int r = 0; r < this->num_rows; ++r)
+    for (unsigned int c = 0; c < this->num_cols; ++c)
+      v[c*this->num_cols+r] = this->data[r][c];
+  return v;
+}
+
 //--------------------------------------------------------------------------------
 
 //: Set row[row_index] to data at given address. No bounds check.


### PR DESCRIPTION
Two methods are added: flatten_row_major(), and flatten_column_major().  This provides functionality similar to other numeric libraries, such as numpy's [flatten()](http://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.matrix.flatten.html#numpy.matrix.flatten).

Unit tests are provided.