### PR TITLE
COMP: Remove compiler warnings

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/tests/test_biarc.cxx
+++ b/contrib/brl/bbas/bvgl/algo/tests/test_biarc.cxx
@@ -15,7 +15,7 @@ MAIN( test_biarc )
   START (" Test bvgl_biarc class");
   vcl_cout << "Test Constructors" << vcl_endl;
   bvgl_biarc biarc1 = bvgl_biarc();
-  TEST("Default Constructor", &biarc1 != 0, true);
+  // This must always be true TEST("Default Constructor", &biarc1 != 0, true);
   biarc1 = bvgl_biarc(vgl_point_2d<double >(0, 0), 0, vgl_point_2d< double >(5, 5), vnl_math::pi/2);
   bvgl_biarc biarc2 = bvgl_biarc(biarc1);
   bool test_copy = (biarc1.start() == biarc2.start()) && (biarc1.k1() == biarc2.k1())

--- a/contrib/brl/bbas/bvgl/algo/tests/test_eulerspiral.cxx
+++ b/contrib/brl/bbas/bvgl/algo/tests/test_eulerspiral.cxx
@@ -26,7 +26,7 @@ MAIN( test_eulerspiral )
   START (" Test bvgl_eulerspiral class");
   vcl_cout << "Test Constructors" << vcl_endl;
   bvgl_eulerspiral es1 = bvgl_eulerspiral();
-  TEST("Default Constructor", &es1 != 0, true);
+  // this is always true TEST("Default Constructor", &es1 != 0, true);
   
   // construct from intrinsic params
   bvgl_eulerspiral es2 = bvgl_eulerspiral(vgl_point_2d< double >(0, 0), 0.0, 1, 1, 2);

--- a/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx
+++ b/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx
@@ -130,8 +130,8 @@ bool volm_desc_matcher::create_prob_map(vcl_string const& geo_hypo_folder,
   // check the distance from ground trugh location to the closest in geo_index
   if (leaf_gt) {
     gt_closest = leaf_gt->hyps_->locs_[hyp_gt];
-    double x_dist = abs(gt_loc.x()-gt_closest.x())*sec_to_meter;
-    double y_dist = abs(gt_loc.y()-gt_closest.y())*sec_to_meter;
+    const double x_dist = vnl_math::abs(gt_loc.x()-gt_closest.x())*sec_to_meter;
+    const double y_dist = vnl_math::abs(gt_loc.y()-gt_closest.y())*sec_to_meter;
     vgl_vector_2d<double> gt_dist_vec(x_dist, y_dist);
     double gt_dist = sqrt(gt_dist_vec.sqr_length());
   } 


### PR DESCRIPTION
vxl/contrib/brl/bbas/bvgl/algo/tests/test_biarc.cxx:18:32: warning: comparison of address of 'biarc1' not equal to a null pointer
      is always true [-Wtautological-pointer-compare]
  TEST("Default Constructor", &biarc1 != 0, true);
                               ^~~~~~    ~
vxl/contrib/brl/bbas/bvgl/algo/tests/test_eulerspiral.cxx:29:32: warning: comparison of address of 'es1' not equal to a null
      pointer is always true [-Wtautological-pointer-compare]
  TEST("Default Constructor", &es1 != 0, true);
                               ^~~    ~

Prefer vnl_math::abs
vxl/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx:133:21: warning: using integer absolute value function 'abs' when argument
      is of floating point type [-Wabsolute-value]
    double x_dist = abs(gt_loc.x()-gt_closest.x())*sec_to_meter;
                    ^
vxl/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx:133:21: note: use function 'std::abs' instead
    double x_dist = abs(gt_loc.x()-gt_closest.x())*sec_to_meter;
                    ^~~
                    std::abs
vxl/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx:134:21: warning: using integer absolute value function 'abs' when argument
      is of floating point type [-Wabsolute-value]
    double y_dist = abs(gt_loc.y()-gt_closest.y())*sec_to_meter;
                    ^
vxl/contrib/brl/bbas/volm/desc/volm_desc_matcher.cxx:134:21: note: use function 'std::abs' instead
    double y_dist = abs(gt_loc.y()-gt_closest.y())*sec_to_meter;
                    ^~~
                    std::abs