### PR TITLE
COMP: Remove compiler warning about string literal

### DIFF
--- a/v3p/netlib/triangle.c
+++ b/v3p/netlib/triangle.c
@@ -3285,11 +3285,11 @@ void internalerror()
 /*****************************************************************************/
 
 #ifdef ANSI_DECLARATORS
-void parsecommandline(int argc, char **argv, struct behavior *b)
+void parsecommandline(int argc, const char * const * const argv, struct behavior *b)
 #else /* not ANSI_DECLARATORS */
 void parsecommandline(argc, argv, b)
 int argc;
-char **argv;
+const char * const * const argv;
 struct behavior *b;
 #endif /* not ANSI_DECLARATORS */
 
@@ -15671,11 +15671,11 @@ struct behavior *b;
 #ifdef TRILIBRARY
 
 #ifdef ANSI_DECLARATORS
-void triangulate(char *triswitches, struct triangulateio *in,
+void triangulate(const char *const triswitches, struct triangulateio *in,
                  struct triangulateio *out, struct triangulateio *vorout)
 #else /* not ANSI_DECLARATORS */
 void triangulate(triswitches, in, out, vorout)
-char *triswitches;
+const char *const triswitches;
 struct triangulateio *in;
 struct triangulateio *out;
 struct triangulateio *vorout;

--- a/v3p/netlib/triangle.h
+++ b/v3p/netlib/triangle.h
@@ -290,7 +290,7 @@ struct triangulateio {
 #define ANSI_DECLARATORS
 #ifdef ANSI_DECLARATORS
 #define VOID void
-void triangulate(char *, struct triangulateio *, struct triangulateio *,
+void triangulate(const char * const, struct triangulateio *, struct triangulateio *,
                  struct triangulateio *);
 void trifree(VOID *memptr);
 #else /* not ANSI_DECLARATORS */


### PR DESCRIPTION
vxl/contrib/gel/gtrl/gtrl_triangulation.cxx:74:16: warning: conversion from string literal to 'char *' is deprecated
      [-Wc++11-compat-deprecated-writable-strings]
  triangulate( "-z -i -q", &in, &out, 0);
               ^
1 warning generated.