### PR TITLE
ENH: Add methods to flatten vnl_matrix_fixed

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -11,7 +11,7 @@ void test_int()
 {
   vcl_cout << "***********************\n"
            << "Testing vnl_matrix<int>\n"
-           << "***********************\n";
+           << "***********************" << vcl_endl;
   vnl_matrix<int> m0(2,2);
   TEST("vnl_matrix<int> m0(2,2)", (m0.rows()==2 && m0.columns()==2), true);
   vnl_matrix<int> m1(3,4);
@@ -251,7 +251,7 @@ void test_float()
 {
   vcl_cout << "*************************\n"
            << "Testing vnl_matrix<float>\n"
-           << "*************************\n";
+           << "*************************" << vcl_endl;
   vnl_matrix<float> d0(2,2);
   TEST("vnl_matrix<float> d0(2,2)", (d0.rows()==2 && d0.columns()==2), true);
   vnl_matrix<float> d1(3,4);
@@ -392,7 +392,7 @@ void test_double()
 {
   vcl_cout << "**************************\n"
            << "Testing vnl_matrix<double>\n"
-           << "**************************\n";
+           << "**************************" << vcl_endl;
   vnl_matrix<double> d0(2,2);
   TEST("vnl_matrix<double> d0(2,2)", (d0.rows()==2 && d0.columns()==2), true);
   vnl_matrix<double> d1(3,4);

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -76,6 +76,9 @@ test_multiply()
 static
 void test_int()
 {
+  vcl_cout << "*********************************\n"
+           << "Testing vnl_matrix_fixed<int,x,x>\n"
+           << "*********************************" << vcl_endl;
   vnl_matrix_fixed<int,2,2> m0;
   TEST("vnl_matrix_fixed<int,2,2> m0", (m0.rows()==2 && m0.columns()==2), true);
   vnl_matrix_fixed<int,3,4> m1;
@@ -181,6 +184,16 @@ void test_int()
        ((m6*=m7),
         (m6.get(0,0)==19 && m6.get(0,1)==22 && m6.get(1,0)==43 && m6.get(1,1)==50)), true);
 
+  // | 19 22 |
+  // | 43 50 |
+  vnl_vector<int> flat;
+  TEST("m6.flatten_row_major()",
+       (flat = m6.flatten_row_major(),
+       (flat.get(0)==19 && flat.get(1)==22 && flat.get(2)==43 && flat.get(3)==50)), true);
+  TEST("m6.flatten_column_major()",
+       (flat = m6.flatten_column_major(),
+       (flat.get(0)==19 && flat.get(1)==43 && flat.get(2)==22 && flat.get(3)==50)), true);
+
   // additional tests
   int mvalues [] = {0,-2,2,0};
   vnl_int_2x2 m(mvalues); m0 = m;
@@ -213,6 +226,9 @@ void test_int()
 static
 void test_float()
 {
+  vcl_cout << "***********************************\n"
+           << "Testing vnl_matrix_fixed<float,x,x>\n"
+           << "***********************************" << vcl_endl;
   vnl_matrix_fixed<float,2,2> d0;
   TEST("vnl_matrix_fixed<float,2,2> d0", (d0.rows()==2 && d0.columns()==2), true);
   vnl_matrix_fixed<float,3,4> d1;
@@ -313,6 +329,9 @@ void test_float()
 static
 void test_double()
 {
+  vcl_cout << "************************************\n"
+           << "Testing vnl_matrix_fixed<double,x,x>\n"
+           << "************************************" << vcl_endl;
   vnl_matrix_fixed<double,2,2> d0;
   TEST("vnl_matrix_fixed<double,2,2> d0", (d0.rows()==2 && d0.columns()==2), true);
   vnl_matrix_fixed<double,3,4> d1;

--- a/core/vnl/vnl_matrix.txx
+++ b/core/vnl/vnl_matrix.txx
@@ -1055,8 +1055,8 @@ template <class T>
 vnl_vector<T> vnl_matrix<T>::flatten_column_major() const
 {
   vnl_vector<T> v(this->num_rows * this->num_cols);
-  for (unsigned int r = 0; r < this->num_rows; ++r)
-    for (unsigned int c = 0; c < this->num_cols; ++c)
+  for (unsigned int c = 0; c < this->num_cols; ++c)
+    for (unsigned int r = 0; r < this->num_rows; ++r)
       v[c*this->num_cols+r] = this->data[r][c];
   return v;
 }

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -474,6 +474,12 @@ class vnl_matrix_fixed  VNL_MATRIX_FIXED_VCL60_WORKAROUND
   //: Return a vector with the content of the (main) diagonal
   vnl_vector<T> get_diagonal() const;
 
+  //: Flatten row-major (C-style)
+  vnl_vector_fixed<T,num_rows*num_cols> flatten_row_major() const;
+
+  //: Flatten column-major (Fortran-style)
+  vnl_vector_fixed<T,num_rows*num_cols> flatten_column_major() const;
+
   // ==== mutators ====
 
   //: Sets this matrix to an identity matrix, then returns "*this".

--- a/core/vnl/vnl_matrix_fixed.txx
+++ b/core/vnl/vnl_matrix_fixed.txx
@@ -432,6 +432,26 @@ vnl_vector<T> vnl_matrix_fixed<T,nrows,ncols>::get_diagonal() const
   return v;
 }
 
+//: Flatten row-major (C-style)
+template <class T, unsigned nrows, unsigned ncols>
+vnl_vector_fixed<T,nrows*ncols> vnl_matrix_fixed<T,nrows,ncols>::flatten_row_major() const
+{
+  vnl_vector_fixed<T,nrows*ncols> v;
+  v.copy_in(this->data_block());
+  return v;
+}
+
+//: Flatten column-major (Fortran-style)
+template <class T, unsigned nrows, unsigned ncols>
+vnl_vector_fixed<T,nrows*ncols> vnl_matrix_fixed<T,nrows,ncols>::flatten_column_major() const
+{
+  vnl_vector_fixed<T,nrows*ncols> v;
+  for (unsigned int c = 0; c < ncols; ++c)
+    for (unsigned int r = 0; r < nrows; ++r)
+      v[c*ncols+r] = this->data_[r][c];
+  return v;
+}
+
 //--------------------------------------------------------------------------------
 
 template<class T, unsigned nrows, unsigned ncols>


### PR DESCRIPTION
Unit tests are provided.  The `vnl_matrix` implementation is also cleaned slightly (should have fewer cache misses).