### PR TITLE
ENH: Add three methods to vnl_vector

### DIFF
--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -140,11 +140,129 @@ void vnl_vector_test_int()
   }
   {
     int vvalues [] = {1,0,0,0};
-    vnl_vector<int> v (4,4,vvalues);
+    vnl_vector<int> v(4,4,vvalues);
     TEST("v.squared_magnitude", (v.squared_magnitude()==1), true);
     TEST("v.magnitude", (v.magnitude()==1), true);
     // normalize not sensible for ints
     //TEST("v.normalize", (v1 = 3 * v, v1.normalize(), v1), v);
+  }
+
+  //////////
+  // FLIP //
+  //////////
+
+  {
+  int vvalues [] = {0,1,2,3};
+  vnl_vector<int> v(4,4,vvalues);
+  TEST("v",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+  v.flip();
+  TEST("v.flip()",
+       (3 == v[0] && 2 == v[1] && 1 == v[2] && 0 == v[3]), true);
+  v.flip(0,v.size());
+  TEST("v.flip(0,v.size())",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+  v.flip(0,3);
+  TEST("v.flip(0,3)",
+       (2 == v[0] && 1 == v[1] && 0 == v[2] && 3 == v[3]), true);
+  v.flip(1,4);
+  TEST("v.flip(1,4)",
+       (2 == v[0] && 3 == v[1] && 0 == v[2] && 1 == v[3]), true);
+  }
+
+  //////////
+  // ROLL //
+  //////////
+
+  {
+  int vvalues [] = {0,1,2,3};
+  vnl_vector<int> v(4,4,vvalues);
+  vnl_vector<int> v_temp;
+
+  //
+  // Check special cases
+  //
+
+  v_temp = v;
+  TEST("v[0]",
+       (0 == v_temp[0] && 1 == v_temp[1] && 2 == v_temp[2] && 3 == v_temp[3]), true);
+  v_temp = v.roll(0);
+  TEST("v.roll(0)",
+       (0 == v_temp[0] && 1 == v_temp[1] && 2 == v_temp[2] && 3 == v_temp[3]), true);
+  v_temp = v.roll(v.size());
+  TEST("v.roll(v.size())",
+       (0 == v_temp[0] && 1 == v_temp[1] && 2 == v_temp[2] && 3 == v_temp[3]), true);
+  v_temp = v.roll(-v.size());
+  TEST("v.roll(-v.size())",
+       (0 == v_temp[0] && 1 == v_temp[1] && 2 == v_temp[2] && 3 == v_temp[3]), true);
+
+  //
+  // Check:
+  // -- Positive, in range
+  // -- Positive, out of range
+  // -- Negative, in range
+  // -- Negative, out of range
+  //
+
+  v_temp = v.roll(1); // Positive, in range
+  TEST("v.roll(1)",
+       (3 == v_temp[0] && 0 == v_temp[1] && 1 == v_temp[2] && 2 == v_temp[3]), true);
+  v_temp = v.roll(5); // Positive, in range
+  TEST("v.roll(5)",
+       (3 == v_temp[0] && 0 == v_temp[1] && 1 == v_temp[2] && 2 == v_temp[3]), true);
+  v_temp = v.roll(-1); // Positive, in range
+  TEST("v.roll(-1)",
+       (1 == v_temp[0] && 2 == v_temp[1] && 3 == v_temp[2] && 0 == v_temp[3]), true);
+  v_temp = v.roll(-5); // Positive, in range
+  TEST("v.roll(-5)",
+       (1 == v_temp[0] && 2 == v_temp[1] && 3 == v_temp[2] && 0 == v_temp[3]), true);
+  }
+
+  //////////////////
+  // ROLL INPLACE //
+  //////////////////
+
+  {
+  int vvalues [] = {0,1,2,3};
+  vnl_vector<int> v(4,4,vvalues);
+  vnl_vector<int> v_temp = v;
+
+  //
+  // Check special cases
+  //
+
+  TEST("v[0]",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+  v.roll_inplace(0);
+  TEST("v.roll_inplace(0)",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+  v.roll_inplace(v.size());
+  TEST("v.roll_inplace(v.size())",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+  v.roll_inplace(-v.size());
+  TEST("v.roll_inplace(-v.size())",
+       (0 == v[0] && 1 == v[1] && 2 == v[2] && 3 == v[3]), true);
+
+  //
+  // Check:
+  // -- Positive, in range
+  // -- Positive, out of range
+  // -- Negative, in range
+  // -- Negative, out of range
+  //
+
+  v = v_temp, v.roll_inplace(1); // Positive, in range
+  TEST("v.roll_inplace(1)",
+       (3 == v[0] && 0 == v[1] && 1 == v[2] && 2 == v[3]), true);
+  v = v_temp, v.roll_inplace(5); // Positive, in range
+  TEST("v.roll_inplace(5)",
+       (3 == v[0] && 0 == v[1] && 1 == v[2] && 2 == v[3]), true);
+  v = v_temp, v.roll_inplace(-1); // Positive, in range
+  TEST("v.roll_inplace(-1)",
+       (1 == v[0] && 2 == v[1] && 3 == v[2] && 0 == v[3]), true);
+  v = v_temp, v.roll_inplace(-5); // Positive, in range
+  TEST("v.roll_inplace(-5)",
+       (1 == v[0] && 2 == v[1] && 3 == v[2] && 0 == v[3]), true);
   }
 }
 

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -339,7 +339,25 @@ class vnl_vector
 
   //: Reverse the order of the elements
   //  Element i swaps with element size()-1-i
-  vnl_vector& flip();
+  vnl_vector<T>& flip();
+
+  //: Reverse the order of the elements from index b to 1-e, inclusive.
+  //  When b = 0 and e = size(), this is equivalent to flip();
+  vnl_vector<T>& flip(const unsigned int &b, const unsigned int &e);
+
+  //: Roll the vector forward by the specified shift.
+  //  The shift is cyclical, such that the elements which
+  //  are displaced from the end reappear at the beginning.
+  //  Negative shifts and shifts >= the length of the array are supported.
+  //  A new vector is returned; the underlying data is unchanged.
+  vnl_vector<T> roll(const int &shift) const;
+
+  //: Roll the vector forward by the specified shift.
+  //  The shift is cyclical, such that the elements which
+  //  are displaced from the end reappear at the beginning.
+  //  Negative shifts and shifts >= the length of the array are supported.
+  //  
+  vnl_vector& roll_inplace(const int &shift);
 
   //: Set this to that and that to this
   void swap(vnl_vector<T> & that);

--- a/core/vnl/vnl_vector.txx
+++ b/core/vnl/vnl_vector.txx
@@ -715,12 +715,56 @@ template <class T>
 vnl_vector<T>&
 vnl_vector<T>::flip()
 {
-  for (unsigned i=0;i<num_elmts/2;i++) {
+  for (unsigned i=0;i<num_elmts/2;++i) {
     T tmp=data[i];
     data[i]=data[num_elmts-1-i];
     data[num_elmts-1-i]=tmp;
   }
   return *this;
+}
+
+template <class T>
+vnl_vector<T>&
+vnl_vector<T>::flip(const unsigned int &b, const unsigned int &e)
+{
+
+#if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
+  assert (!(b > this->num_elmts || e > this->num_elmts || b > e));
+#endif
+
+  for (unsigned i=b;i<(e-b)/2+b;++i) {
+    T tmp=data[i];
+    const unsigned int endIndex = e - 1 - (i-b);
+    data[i]=data[endIndex];
+    data[endIndex]=tmp;
+  }
+  return *this;
+
+}
+
+template <class T>
+vnl_vector<T>
+vnl_vector<T>::roll(const int &shift) const
+{
+  vnl_vector<T> v(this->num_elmts);
+  const unsigned int wrapped_shift = shift % this->num_elmts;
+  if (0 == wrapped_shift)
+    return v.copy_in(this->data_block());
+  for (unsigned int i = 0; i < this->num_elmts; ++i)
+    {
+    v[(i + wrapped_shift)%this->num_elmts] = this->data_block()[i];
+    }
+  return v;
+}
+
+template <class T>
+vnl_vector<T>&
+vnl_vector<T>::roll_inplace(const int &shift)
+{
+  const unsigned int wrapped_shift = shift % this->num_elmts;
+  if (0 == wrapped_shift)
+    return *this;
+  return this->flip().flip(0,wrapped_shift).flip(wrapped_shift,this->num_elmts);
 }
 
 template <class T>


### PR DESCRIPTION
The following methods have been added to vnl_vector:
`roll(const int &shift)`
`roll_inplace(const int &shift)`
`flip(const unsigned int &b, const unsigned int &e)`

`roll()` and` roll_inplace()` mimick `roll` in python's numpy.
Bounded `flip(b,e)` reverses the specified portion of the vector.
This is used in the implementation of `roll_inplace`, but is also
a useful function in and of itself.