### PR TITLE
Update CDash upload site location in CTestConfig.cmake.

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -3,6 +3,6 @@ set(CTEST_PROJECT_NAME "VXL")
 set(CTEST_NIGHTLY_START_TIME "22:00:00 EST")
 
 set(CTEST_DROP_METHOD "http")
-set(CTEST_DROP_SITE "www.cdash.org")
-set(CTEST_DROP_LOCATION "/CDash/submit.php?project=vxl")
+set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=vxl")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
CDash has moved to open.cdash.org.