### PR TITLE
ENH: Overload vnl_complexify for additional containers.

### DIFF
--- a/core/vnl/tests/CMakeLists.txt
+++ b/core/vnl/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ ADD_EXECUTABLE( vnl_test_all
   test_bignum.cxx
   test_decnum.cxx
   test_complex.cxx
+  test_complexify.cxx
   test_inverse.cxx
   test_diag_matrix.cxx
   test_diag_matrix_fixed.cxx
@@ -63,6 +64,7 @@ TARGET_LINK_LIBRARIES(vnl_basic_operation_timings vnl)
 ADD_TEST( vnl_test_bignum                 ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_bignum                 )
 ADD_TEST( vnl_test_decnum                 ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_decnum                 )
 ADD_TEST( vnl_test_complex                ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_complex                )
+ADD_TEST( vnl_test_complexify             ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_complexify             )
 ADD_TEST( vnl_test_diag_matrix            ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_diag_matrix            )
 ADD_TEST( vnl_test_diag_matrix_fixed      ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_diag_matrix_fixed      )
 ADD_TEST( vnl_test_file_matrix            ${EXECUTABLE_OUTPUT_PATH}/vnl_test_all test_file_matrix            )

--- a/core/vnl/tests/test_complexify.cxx
+++ b/core/vnl/tests/test_complexify.cxx
@@ -1,0 +1,107 @@
+#include <cstdlib>
+#include <testlib/testlib_test.h>
+
+#include <vcl_iostream.h>
+#include <vcl_complex.h>
+#include <vnl/vnl_complexify.h>
+
+#include <vnl/vnl_vector.h>
+#include <vnl/vnl_vector_fixed.h>
+
+#include <vnl/vnl_matrix.h>
+#include <vnl/vnl_matrix_fixed.h>
+
+#include <vnl/vnl_diag_matrix.h>
+#include <vnl/vnl_diag_matrix_fixed.h>
+
+#include <vnl/vnl_sym_matrix.h>
+
+void test_complexify()
+{
+
+  typedef float TReal;
+  const unsigned int length = 2;
+  const TReal value = 7.5;
+
+  vcl_cout << "Testing vnl_vector" << vcl_endl;
+  vnl_vector<TReal> r_vector(length,value);
+  vnl_vector<vcl_complex<TReal> > c_vector
+    = vnl_complexify(r_vector);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_vector real",7.5,c_vector.get(i).real());
+    TEST("vnl_vector imag",0.0,c_vector.get(i).imag());
+    }
+
+  vcl_cout << "Testing vnl_vector_fixed" << vcl_endl;
+  vnl_vector_fixed<TReal,length> r_vector_fixed(value);
+  vnl_vector_fixed<vcl_complex<TReal>,length > c_vector_fixed
+    = vnl_complexify(r_vector_fixed);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_vector_fixed real",7.5,c_vector_fixed.get(i).real());
+    TEST("vnl_vector_fixed imag",0.0,c_vector_fixed.get(i).imag());
+    }
+
+  vcl_cout << "Testing vnl_matrix" << vcl_endl;
+  vnl_matrix<TReal> r_matrix(length,length,value);
+  vnl_matrix<vcl_complex<TReal> > c_matrix
+    = vnl_complexify(r_matrix);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_matrix real",7.5,c_matrix.get(r,c).real());
+      TEST("vnl_matrix imag",0.0,c_matrix.get(r,c).imag());
+      }
+    }
+
+  vcl_cout << "Testing vnl_matrix_fixed" << vcl_endl;
+  vnl_matrix_fixed<TReal,length,length> r_matrix_fixed(value);
+  vnl_matrix_fixed<vcl_complex<TReal>,length,length > c_matrix_fixed
+    = vnl_complexify(r_matrix_fixed);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_matrix_fixed real",7.5,c_matrix_fixed.get(r,c).real());
+      TEST("vnl_matrix_fixed imag",0.0,c_matrix_fixed.get(r,c).imag());
+      }
+    }
+
+  vcl_cout << "Testing vnl_diag_matrix" << vcl_endl;
+  vnl_diag_matrix<TReal> r_diag_matrix(length,value);
+  vnl_diag_matrix<vcl_complex<TReal> > c_diag_matrix
+    = vnl_complexify(r_diag_matrix);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_diag_matrix real",7.5,c_diag_matrix.get(i,i).real());
+    TEST("vnl_diag_matrix imag",0.0,c_diag_matrix.get(i,i).imag());
+    }
+
+  vcl_cout << "Testing vnl_diag_matrix_fixed" << vcl_endl;
+  vnl_diag_matrix_fixed<TReal,length> r_diag_matrix_fixed(value);
+  vnl_diag_matrix_fixed<vcl_complex<TReal>,length > c_diag_matrix_fixed
+    = vnl_complexify(r_diag_matrix_fixed);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_diag_matrix_fixed real",7.5,c_diag_matrix_fixed.get(i,i).real());
+    TEST("vnl_diag_matrix_fixed imag",0.0,c_diag_matrix_fixed.get(i,i).imag());
+    }
+
+  vcl_cout << "Testing vnl_sym_matrix" << vcl_endl;
+  vnl_sym_matrix<TReal> r_sym_matrix(length,value);
+  vnl_sym_matrix<vcl_complex<TReal> > c_sym_matrix
+    = vnl_complexify(r_sym_matrix);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_sym_matrix real",7.5,c_sym_matrix(r,c).real()); // no get()
+      TEST("vnl_sym_matrix imag",0.0,c_sym_matrix(r,c).imag());
+      }
+    }
+
+}
+
+TESTMAIN( test_complexify );

--- a/core/vnl/tests/test_driver.cxx
+++ b/core/vnl/tests/test_driver.cxx
@@ -2,6 +2,7 @@
 
 DECLARE( test_bignum );
 DECLARE( test_decnum );
+DECLARE( test_complexify );
 DECLARE( test_complex );
 DECLARE( test_inverse );
 DECLARE( test_diag_matrix );
@@ -49,6 +50,7 @@ register_tests()
 {
   REGISTER( test_bignum );
   REGISTER( test_decnum );
+  REGISTER( test_complexify );
   REGISTER( test_complex );
   REGISTER( test_inverse );
   REGISTER( test_diag_matrix );

--- a/core/vnl/vnl_complex_ops.txx
+++ b/core/vnl/vnl_complex_ops.txx
@@ -30,7 +30,8 @@ void vnl_complexify(T const *re, T const *im, vcl_complex<T> *dst, unsigned n)
 }
 
 template <class T>
-vnl_vector<vcl_complex<T> > vnl_complexify(vnl_vector<T> const &v)
+vnl_vector<vcl_complex<T> >
+  vnl_complexify(vnl_vector<T> const &v)
 {
   vnl_vector<vcl_complex<T> > vc(v.size());
   vnl_complexify(v.begin(), vc.begin(), v.size());
@@ -38,7 +39,8 @@ vnl_vector<vcl_complex<T> > vnl_complexify(vnl_vector<T> const &v)
 }
 
 template <class T>
-vnl_vector<vcl_complex<T> > vnl_complexify(vnl_vector<T> const &re, vnl_vector<T> const &im)
+vnl_vector<vcl_complex<T> >
+  vnl_complexify(vnl_vector<T> const &re, vnl_vector<T> const &im)
 {
   assert(re.size() == im.size());
   vnl_vector<vcl_complex<T> > vc(re.size());
@@ -47,7 +49,8 @@ vnl_vector<vcl_complex<T> > vnl_complexify(vnl_vector<T> const &re, vnl_vector<T
 }
 
 template <class T>
-vnl_matrix<vcl_complex<T> > vnl_complexify(vnl_matrix<T> const &M)
+vnl_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_matrix<T> const &M)
 {
   vnl_matrix<vcl_complex<T> > Mc(M.rows(), M.cols());
   vnl_complexify(M.begin(), Mc.begin(), M.size());
@@ -55,7 +58,8 @@ vnl_matrix<vcl_complex<T> > vnl_complexify(vnl_matrix<T> const &M)
 }
 
 template <class T>
-vnl_matrix<vcl_complex<T> > vnl_complexify(vnl_matrix<T> const &re, vnl_matrix<T> const &im)
+vnl_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_matrix<T> const &re, vnl_matrix<T> const &im)
 {
   assert(re.rows() == im.rows());
   assert(re.cols() == im.cols());

--- a/core/vnl/vnl_complexify.h
+++ b/core/vnl/vnl_complexify.h
@@ -13,30 +13,99 @@
 
 #include <vcl_complex.h>
 #include <vnl/vnl_vector.h>
+#include <vnl/vnl_vector_fixed.h>
 #include <vnl/vnl_matrix.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_diag_matrix.h>
+#include <vnl/vnl_diag_matrix_fixed.h>
+#include <vnl/vnl_sym_matrix.h>
 
 //: Overwrite complex array C (of length n) with pairs from real arrays R and I.
-template <class T> void
+template <class T>
+void
   vnl_complexify(T const* R, T const* I, vcl_complex<T>* C, unsigned n);
 //: Overwrite complex array C (sz n) with complexified version of real array R.
-template <class T> void
+template <class T>
+void
   vnl_complexify(T const* R,             vcl_complex<T>* C, unsigned n);
 
 //: Return complexified version of real vector R.
 // \relatesalso vnl_vector
-template <class T> vnl_vector<vcl_complex<T> >
+template <class T>
+vnl_vector<vcl_complex<T> >
   vnl_complexify(vnl_vector<T> const& R);
+
+//: Return complexified version of real fixed vector R.
+// \relatesalso vnl_vector_fixed
+template <class T, unsigned int n>
+vnl_vector_fixed<vcl_complex<T>,n>
+  vnl_complexify(vnl_vector_fixed<T,n> const& v)
+{
+  vnl_vector_fixed<vcl_complex<T>,n> vc;
+  vnl_complexify(v.begin(), vc.begin(), v.size());
+  return vc;
+}
+
 //: Return complex vector R+j*I from two real vectors R and I.
 // \relatesalso vnl_vector
-template <class T> vnl_vector<vcl_complex<T> >
+template <class T>
+vnl_vector<vcl_complex<T> >
   vnl_complexify(vnl_vector<T> const& R, vnl_vector<T> const& I);
+
 //: Return complexified version of real matrix R.
 // \relatesalso vnl_matrix
-template <class T> vnl_matrix<vcl_complex<T> >
+template <class T>
+vnl_matrix<vcl_complex<T> >
   vnl_complexify(vnl_matrix<T> const& R);
+
+//: Return complexified version of real fixed matrix R.
+// \relatesalso vnl_matrix_fixed
+template <class T, unsigned int r, unsigned int c>
+vnl_matrix_fixed<vcl_complex<T>,r,c >
+  vnl_complexify(vnl_matrix_fixed<T,r,c> const& M)
+{
+  vnl_matrix_fixed<vcl_complex<T>,r,c> Mc;
+  vnl_complexify(M.begin(), Mc.begin(), M.size());
+  return Mc;
+}
+
+//: Return complexified version of real diagonal matrix R.
+// \relatesalso vnl_diag_matrix
+template <class T>
+vnl_diag_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_diag_matrix<T> const& M)
+{
+  vnl_diag_matrix<vcl_complex<T> > Mc(M.rows(), M.cols());
+  vnl_complexify(M.begin(), Mc.begin(), M.size());
+  return Mc;
+}
+
+//: Return complexified version of real fixed diagonal matrix R.
+// \relatesalso vnl_diag_matrix_fixed
+template <class T, unsigned int n>
+vnl_diag_matrix_fixed<vcl_complex<T>,n >
+  vnl_complexify(vnl_diag_matrix_fixed<T,n> const& M)
+{
+  vnl_diag_matrix_fixed<vcl_complex<T>,n> Mc;
+  vnl_complexify(M.begin(), Mc.begin(), M.size());
+  return Mc;
+}
+
+//: Return complexified version of real symmetric matrix R.
+// \relatesalso vnl_sym_matrix
+template <class T>
+vnl_sym_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_sym_matrix<T> const& M)
+{
+  vnl_sym_matrix<vcl_complex<T> > Mc(M.size());
+  vnl_complexify(M.begin(), Mc.begin(), M.size());
+  return Mc;
+}
+
 //: Return complex matrix R+j*I from two real matrices R and I.
 // \relatesalso vnl_matrix
-template <class T> vnl_matrix<vcl_complex<T> >
+template <class T>
+vnl_matrix<vcl_complex<T> >
   vnl_complexify(vnl_matrix<T> const& R, vnl_matrix<T> const& I);
 
 #endif // vnl_complexify_h_

--- a/core/vnl/vnl_diag_matrix_fixed.h
+++ b/core/vnl/vnl_diag_matrix_fixed.h
@@ -46,7 +46,7 @@ class vnl_diag_matrix_fixed
 
 
   //: Construct a diagonal matrix with diagonal elements equal to value.
-  vnl_diag_matrix_fixed(T const& value) : diagonal_(N, value) {}
+  vnl_diag_matrix_fixed(T const& value) : diagonal_(value) {}
 
   //: Construct a diagonal matrix from a vnl_vector_fixed.
   //  The vector elements become the diagonal elements.


### PR DESCRIPTION
This patch overloads `vnl_complexify` for the following containers:
-- `vnl_vector_fixed`
-- `vnl_matrix_fixed`
-- `vnl_diag_matrix`
-- `vnl_diag_matrix_fixed`
-- `vnl_sym_matrix`

A new unit test, `test_complexify`, is added.

Finally, a bug in one of the `vnl_diag_matrix_fixed` constructors is fixed.