### PR TITLE
Improve cxx11 for external use

### DIFF
--- a/core/vxl_config.h.in
+++ b/core/vxl_config.h.in
@@ -226,8 +226,4 @@
 /* true if VXL is built shared */
 #cmakedefine VXL_BUILD_SHARED
 
-
-/* true if VXL is built shared */
-#cmakedefine VXL_BUILD_SHARED
-
 #endif /* vxl_config_h_ */

--- a/core/vxl_config.h.in
+++ b/core/vxl_config.h.in
@@ -2,7 +2,6 @@
 #define vxl_config_h_
 
 /* this file either is or was generated from vxl_config.h.in */
-#
 /* -------------------- machine word characteristics */
 
 /* machine byte order */

--- a/vcl/vcl_config_compiler.h.in
+++ b/vcl/vcl_config_compiler.h.in
@@ -87,6 +87,18 @@
 //----------------------------------------------------------------------
 // constant initializer issues.
 
+/* When using C++11 or greater, constexpr
+ * may be necessary for static const float initialization
+ * and is benificial in other cases where
+ * a value can be constant. */
+#if  __cplusplus >= 201103L
+# define VCL_CONSTEXPR constexpr
+# define VCL_CAN_STATIC_CONST_INIT_INT 1
+# define VCL_CAN_STATIC_CONST_INIT_FLOAT 1
+#else
+# define VCL_CONSTEXPR const
+#endif
+
 //: VCL_STATIC_CONST_INIT_INT_DECL(x)
 //
 // ANSI allows


### PR DESCRIPTION
@thewtex This makes ITK and VXL consistent so taht these changes persist after
the next VXL upstream merge.