### PR TITLE
replace checks for "linux" preprocessor definition with "__linux__"

### DIFF
--- a/contrib/brl/bbas/bocl/bocl_cl.h
+++ b/contrib/brl/bbas/bocl/bocl_cl.h
@@ -13,7 +13,7 @@
 // \endverbatim
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || \
-    defined(UNIX) || defined(linux)
+    defined(UNIX) || defined(__linux__)
   #include <CL/cl.h>
   #include <CL/cl_gl.h>
   #define GL_SHARING_EXTENSION "cl_khr_gl_sharing"

--- a/contrib/brl/bbas/bocl/bocl_cl_gl.h
+++ b/contrib/brl/bbas/bocl/bocl_cl_gl.h
@@ -16,7 +16,7 @@
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #include <CL/cl_gl.h>
 #define GL_SHARING_EXTENSION "cl_khr_gl_sharing"
-#elif defined(UNIX) || defined(linux)
+#elif defined(UNIX) || defined(__linux__)
 #define GL_SHARING_EXTENSION "cl_khr_gl_sharing"
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 #include <OpenCL/cl_gl.h>

--- a/vcl/gcc/vcl_cmath.h
+++ b/vcl/gcc/vcl_cmath.h
@@ -4,7 +4,7 @@
 #include "../iso/vcl_cmath.h"
 
 // 1.5 fix system header.
-#if defined (linux) && defined (__OPTIMIZE__)
+#if defined (__linux__) && defined (__OPTIMIZE__)
 // * avoid infinite recursion when calling vnl_math::isfinite().
 // * avoid symbol in object file being called vnl_math::_isinf.
 # undef isinf

--- a/vcl/vcl_cerrno.h
+++ b/vcl/vcl_cerrno.h
@@ -12,7 +12,7 @@
 # include "iso/vcl_cerrno.h"
 #endif
 
-#if defined(linux) && !defined(__ANDROID__) // bug fix: errno.h erroneously declares __errno_location() as C++
+#if defined(__linux__) && !defined(__ANDROID__) // bug fix: errno.h erroneously declares __errno_location() as C++
 extern "C" inline int* __errno_location__Fv() { return __errno_location(); }
 extern "C" inline int* _Z16__errno_locationv() { return __errno_location(); }
 #endif


### PR DESCRIPTION
The "linux" preprocessor definition is nonconforming and is suppressed
by gcc when supplied with flags such as "-std=X" and "-pedantic".
The double underscore equivalent is supported at least as far back as
gcc v3.1.1.

see:
https://gcc.gnu.org/onlinedocs/gcc-3.1.1/cpp/System-specific-Predefined-Macros.html#System-specific%20Predefined%20Macros
http://sourceforge.net/p/predef/wiki/OperatingSystems/
