### PR TITLE
WIP: Overload vnl_complexify for additional containers.

### DIFF
--- a/core/vnl/Templates/vnl_sym_matrix+vcl_complex_double--.cxx
+++ b/core/vnl/Templates/vnl_sym_matrix+vcl_complex_double--.cxx
@@ -1,0 +1,4 @@
+#include <vcl_complex.h>
+#include <vnl/vnl_sym_matrix.txx>
+
+VNL_SYM_MATRIX_INSTANTIATE(vcl_complex<double>);

--- a/core/vnl/Templates/vnl_sym_matrix+vcl_complex_float--.cxx
+++ b/core/vnl/Templates/vnl_sym_matrix+vcl_complex_float--.cxx
@@ -1,0 +1,4 @@
+#include <vcl_complex.h>
+#include <vnl/vnl_sym_matrix.txx>
+
+VNL_SYM_MATRIX_INSTANTIATE(vcl_complex<float>);

--- a/core/vnl/tests/test_complexify.cxx
+++ b/core/vnl/tests/test_complexify.cxx
@@ -21,10 +21,12 @@ void test_complexify()
 
   typedef float TReal;
   const unsigned int length = 2;
-  const TReal value = 7.5;
+  const TReal r = 7.5;
+  const TReal i = 8.5;
 
   vcl_cout << "Testing vnl_vector" << vcl_endl;
-  vnl_vector<TReal> r_vector(length,value);
+  const vnl_vector<TReal> r_vector(length,r);
+  const vnl_vector<TReal> i_vector(length,i);
   vnl_vector<vcl_complex<TReal> > c_vector
     = vnl_complexify(r_vector);
   for (unsigned int i = 0; i < length; ++i)
@@ -32,9 +34,17 @@ void test_complexify()
     TEST("vnl_vector real",7.5,c_vector.get(i).real());
     TEST("vnl_vector imag",0.0,c_vector.get(i).imag());
     }
+  c_vector
+    = vnl_complexify(r_vector,i_vector);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_vector real",7.5,c_vector.get(i).real());
+    TEST("vnl_vector imag",8.5,c_vector.get(i).imag());
+    }
 
   vcl_cout << "Testing vnl_vector_fixed" << vcl_endl;
-  vnl_vector_fixed<TReal,length> r_vector_fixed(value);
+  const vnl_vector_fixed<TReal,length> r_vector_fixed(r);
+  const vnl_vector_fixed<TReal,length> i_vector_fixed(i);
   vnl_vector_fixed<vcl_complex<TReal>,length > c_vector_fixed
     = vnl_complexify(r_vector_fixed);
   for (unsigned int i = 0; i < length; ++i)
@@ -42,9 +52,17 @@ void test_complexify()
     TEST("vnl_vector_fixed real",7.5,c_vector_fixed.get(i).real());
     TEST("vnl_vector_fixed imag",0.0,c_vector_fixed.get(i).imag());
     }
+  c_vector_fixed
+    = vnl_complexify(r_vector_fixed,i_vector_fixed);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_vector_fixed real",7.5,c_vector_fixed.get(i).real());
+    TEST("vnl_vector_fixed imag",8.5,c_vector_fixed.get(i).imag());
+    }
 
   vcl_cout << "Testing vnl_matrix" << vcl_endl;
-  vnl_matrix<TReal> r_matrix(length,length,value);
+  const vnl_matrix<TReal> r_matrix(length,length,r);
+  const vnl_matrix<TReal> i_matrix(length,length,i);
   vnl_matrix<vcl_complex<TReal> > c_matrix
     = vnl_complexify(r_matrix);
   for (unsigned int c = 0; c < length; ++c)
@@ -55,9 +73,20 @@ void test_complexify()
       TEST("vnl_matrix imag",0.0,c_matrix.get(r,c).imag());
       }
     }
+  c_matrix
+    = vnl_complexify(r_matrix,i_matrix);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_matrix real",7.5,c_matrix.get(r,c).real());
+      TEST("vnl_matrix imag",8.5,c_matrix.get(r,c).imag());
+      }
+    }
 
   vcl_cout << "Testing vnl_matrix_fixed" << vcl_endl;
-  vnl_matrix_fixed<TReal,length,length> r_matrix_fixed(value);
+  const vnl_matrix_fixed<TReal,length,length> r_matrix_fixed(r);
+  const vnl_matrix_fixed<TReal,length,length> i_matrix_fixed(i);
   vnl_matrix_fixed<vcl_complex<TReal>,length,length > c_matrix_fixed
     = vnl_complexify(r_matrix_fixed);
   for (unsigned int c = 0; c < length; ++c)
@@ -68,9 +97,20 @@ void test_complexify()
       TEST("vnl_matrix_fixed imag",0.0,c_matrix_fixed.get(r,c).imag());
       }
     }
+  c_matrix_fixed
+    = vnl_complexify(r_matrix_fixed,i_matrix_fixed);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_matrix_fixed real",7.5,c_matrix_fixed.get(r,c).real());
+      TEST("vnl_matrix_fixed imag",8.5,c_matrix_fixed.get(r,c).imag());
+      }
+    }
 
   vcl_cout << "Testing vnl_diag_matrix" << vcl_endl;
-  vnl_diag_matrix<TReal> r_diag_matrix(length,value);
+  const vnl_diag_matrix<TReal> r_diag_matrix(length,r);
+  const vnl_diag_matrix<TReal> i_diag_matrix(length,i);
   vnl_diag_matrix<vcl_complex<TReal> > c_diag_matrix
     = vnl_complexify(r_diag_matrix);
   for (unsigned int i = 0; i < length; ++i)
@@ -78,9 +118,17 @@ void test_complexify()
     TEST("vnl_diag_matrix real",7.5,c_diag_matrix.get(i,i).real());
     TEST("vnl_diag_matrix imag",0.0,c_diag_matrix.get(i,i).imag());
     }
+  c_diag_matrix
+    = vnl_complexify(r_diag_matrix,i_diag_matrix);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_diag_matrix real",7.5,c_diag_matrix.get(i,i).real());
+    TEST("vnl_diag_matrix imag",8.5,c_diag_matrix.get(i,i).imag());
+    }
 
   vcl_cout << "Testing vnl_diag_matrix_fixed" << vcl_endl;
-  vnl_diag_matrix_fixed<TReal,length> r_diag_matrix_fixed(value);
+  const vnl_diag_matrix_fixed<TReal,length> r_diag_matrix_fixed(r);
+  const vnl_diag_matrix_fixed<TReal,length> i_diag_matrix_fixed(i);
   vnl_diag_matrix_fixed<vcl_complex<TReal>,length > c_diag_matrix_fixed
     = vnl_complexify(r_diag_matrix_fixed);
   for (unsigned int i = 0; i < length; ++i)
@@ -88,9 +136,17 @@ void test_complexify()
     TEST("vnl_diag_matrix_fixed real",7.5,c_diag_matrix_fixed.get(i,i).real());
     TEST("vnl_diag_matrix_fixed imag",0.0,c_diag_matrix_fixed.get(i,i).imag());
     }
+  c_diag_matrix_fixed
+    = vnl_complexify(r_diag_matrix_fixed,i_diag_matrix_fixed);
+  for (unsigned int i = 0; i < length; ++i)
+    {
+    TEST("vnl_diag_matrix_fixed real",7.5,c_diag_matrix_fixed.get(i,i).real());
+    TEST("vnl_diag_matrix_fixed imag",8.5,c_diag_matrix_fixed.get(i,i).imag());
+    }
 
   vcl_cout << "Testing vnl_sym_matrix" << vcl_endl;
-  vnl_sym_matrix<TReal> r_sym_matrix(length,value);
+  const vnl_sym_matrix<TReal> r_sym_matrix(length,r);
+  const vnl_sym_matrix<TReal> i_sym_matrix(length,i);
   vnl_sym_matrix<vcl_complex<TReal> > c_sym_matrix
     = vnl_complexify(r_sym_matrix);
   for (unsigned int c = 0; c < length; ++c)
@@ -99,6 +155,16 @@ void test_complexify()
       {
       TEST("vnl_sym_matrix real",7.5,c_sym_matrix(r,c).real()); // no get()
       TEST("vnl_sym_matrix imag",0.0,c_sym_matrix(r,c).imag());
+      }
+    }
+  c_sym_matrix
+    = vnl_complexify(r_sym_matrix,i_sym_matrix);
+  for (unsigned int c = 0; c < length; ++c)
+    {
+    for (unsigned int r = 0; r < length; ++r)
+      {
+      TEST("vnl_sym_matrix real",7.5,c_sym_matrix(r,c).real()); // no get()
+      TEST("vnl_sym_matrix imag",8.5,c_sym_matrix(r,c).imag());
       }
     }
 

--- a/core/vnl/vnl_complex_ops.txx
+++ b/core/vnl/vnl_complex_ops.txx
@@ -29,43 +29,101 @@ void vnl_complexify(T const *re, T const *im, vcl_complex<T> *dst, unsigned n)
     dst[i] = vcl_complex<T>(re[i], im[i]);
 }
 
-template <class T>
-vnl_vector<vcl_complex<T> >
-  vnl_complexify(vnl_vector<T> const &v)
-{
-  vnl_vector<vcl_complex<T> > vc(v.size());
-  vnl_complexify(v.begin(), vc.begin(), v.size());
-  return vc;
-}
+// Real Alone:
+// - vnl_vector
+// - vnl_vector_fixed -- in header
+// - vnl_matrix
+// - vnl_matrix_fixed -- in header
+// - vnl_diag_matrix
+// - vnl_diag_matrix_fixed -- in header
+// - vnl_sym_matrix
 
 template <class T>
 vnl_vector<vcl_complex<T> >
-  vnl_complexify(vnl_vector<T> const &re, vnl_vector<T> const &im)
+  vnl_complexify(vnl_vector<T> const &R)
 {
-  assert(re.size() == im.size());
-  vnl_vector<vcl_complex<T> > vc(re.size());
-  vnl_complexify(re.begin(), im.begin(), vc.begin(), re.size());
-  return vc;
+  vnl_vector<vcl_complex<T> > C(R.size());
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
 }
 
 template <class T>
 vnl_matrix<vcl_complex<T> >
-  vnl_complexify(vnl_matrix<T> const &M)
+  vnl_complexify(vnl_matrix<T> const &R)
 {
-  vnl_matrix<vcl_complex<T> > Mc(M.rows(), M.cols());
-  vnl_complexify(M.begin(), Mc.begin(), M.size());
-  return Mc;
+  vnl_matrix<vcl_complex<T> > C(R.rows(), R.cols());
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
+}
+
+template <class T>
+vnl_diag_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_diag_matrix<T> const& R)
+{
+  vnl_diag_matrix<vcl_complex<T> > C(R.rows(), R.cols());
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
+}
+
+template <class T>
+vnl_sym_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_sym_matrix<T> const& R)
+{
+  vnl_sym_matrix<vcl_complex<T> > C(R.size());
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
+}
+
+//----------------------------------------------------------------------
+
+// Real + Imaginary:
+// - vnl_vector
+// - vnl_vector_fixed -- in header
+// - vnl_matrix
+// - vnl_matrix_fixed -- in header
+// - vnl_diag_matrix
+// - vnl_diag_matrix_fixed -- in header
+// - vnl_sym_matrix
+
+template <class T>
+vnl_vector<vcl_complex<T> >
+  vnl_complexify(vnl_vector<T> const &R, vnl_vector<T> const &I)
+{
+  assert(R.size() == I.size());
+  vnl_vector<vcl_complex<T> > C(R.size());
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
 }
 
 template <class T>
 vnl_matrix<vcl_complex<T> >
-  vnl_complexify(vnl_matrix<T> const &re, vnl_matrix<T> const &im)
+  vnl_complexify(vnl_matrix<T> const &R, vnl_matrix<T> const &I)
 {
-  assert(re.rows() == im.rows());
-  assert(re.cols() == im.cols());
-  vnl_matrix<vcl_complex<T> > Mc(re.rows(), re.cols());
-  vnl_complexify(re.begin(), im.begin(), Mc.begin(), re.size());
-  return Mc;
+  assert(R.rows() == I.rows());
+  assert(R.cols() == I.cols());
+  vnl_matrix<vcl_complex<T> > C(R.rows(), R.cols());
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
+}
+
+template <class T>
+vnl_diag_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_diag_matrix<T> const &R, vnl_diag_matrix<T> const &I)
+{
+  assert(R.rows() == I.rows());
+  vnl_diag_matrix<vcl_complex<T> > C(R.rows());
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
+}
+
+template <class T>
+vnl_sym_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_sym_matrix<T> const &R, vnl_sym_matrix<T> const &I)
+{
+  assert(R.rows() == I.rows());
+  vnl_sym_matrix<vcl_complex<T> > C(R.rows());
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
 }
 
 //----------------------------------------------------------------------
@@ -140,6 +198,10 @@ template vnl_vector<vcl_complex<T > > vnl_complexify(vnl_vector<T > const &); \
 template vnl_vector<vcl_complex<T > > vnl_complexify(vnl_vector<T > const &, vnl_vector<T > const &); \
 template vnl_matrix<vcl_complex<T > > vnl_complexify(vnl_matrix<T > const &); \
 template vnl_matrix<vcl_complex<T > > vnl_complexify(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template vnl_diag_matrix<vcl_complex<T > > vnl_complexify(vnl_diag_matrix<T > const &); \
+template vnl_diag_matrix<vcl_complex<T > > vnl_complexify(vnl_diag_matrix<T > const &,vnl_diag_matrix<T > const&); \
+template vnl_sym_matrix<vcl_complex<T > > vnl_complexify(vnl_sym_matrix<T > const &); \
+template vnl_sym_matrix<vcl_complex<T > > vnl_complexify(vnl_sym_matrix<T > const &,vnl_sym_matrix<T > const&); \
 \
 template void vnl_real(vcl_complex<T > const*, T*, unsigned int); \
 template void vnl_imag(vcl_complex<T > const*, T*, unsigned int); \

--- a/core/vnl/vnl_complexify.h
+++ b/core/vnl/vnl_complexify.h
@@ -29,6 +29,15 @@ template <class T>
 void
   vnl_complexify(T const* R,             vcl_complex<T>* C, unsigned n);
 
+// Real Alone:
+// - vnl_vector
+// - vnl_vector_fixed
+// - vnl_matrix
+// - vnl_matrix_fixed
+// - vnl_diag_matrix
+// - vnl_diag_matrix_fixed
+// - vnl_sym_matrix
+
 //: Return complexified version of real vector R.
 // \relatesalso vnl_vector
 template <class T>
@@ -39,18 +48,12 @@ vnl_vector<vcl_complex<T> >
 // \relatesalso vnl_vector_fixed
 template <class T, unsigned int n>
 vnl_vector_fixed<vcl_complex<T>,n>
-  vnl_complexify(vnl_vector_fixed<T,n> const& v)
+  vnl_complexify(vnl_vector_fixed<T,n> const& R)
 {
-  vnl_vector_fixed<vcl_complex<T>,n> vc;
-  vnl_complexify(v.begin(), vc.begin(), v.size());
-  return vc;
+  vnl_vector_fixed<vcl_complex<T>,n> C;
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
 }
-
-//: Return complex vector R+j*I from two real vectors R and I.
-// \relatesalso vnl_vector
-template <class T>
-vnl_vector<vcl_complex<T> >
-  vnl_complexify(vnl_vector<T> const& R, vnl_vector<T> const& I);
 
 //: Return complexified version of real matrix R.
 // \relatesalso vnl_matrix
@@ -62,44 +65,62 @@ vnl_matrix<vcl_complex<T> >
 // \relatesalso vnl_matrix_fixed
 template <class T, unsigned int r, unsigned int c>
 vnl_matrix_fixed<vcl_complex<T>,r,c >
-  vnl_complexify(vnl_matrix_fixed<T,r,c> const& M)
+  vnl_complexify(vnl_matrix_fixed<T,r,c> const& R)
 {
-  vnl_matrix_fixed<vcl_complex<T>,r,c> Mc;
-  vnl_complexify(M.begin(), Mc.begin(), M.size());
-  return Mc;
+  vnl_matrix_fixed<vcl_complex<T>,r,c> C;
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
 }
 
 //: Return complexified version of real diagonal matrix R.
 // \relatesalso vnl_diag_matrix
 template <class T>
 vnl_diag_matrix<vcl_complex<T> >
-  vnl_complexify(vnl_diag_matrix<T> const& M)
-{
-  vnl_diag_matrix<vcl_complex<T> > Mc(M.rows(), M.cols());
-  vnl_complexify(M.begin(), Mc.begin(), M.size());
-  return Mc;
-}
+  vnl_complexify(vnl_diag_matrix<T> const& R);
 
 //: Return complexified version of real fixed diagonal matrix R.
 // \relatesalso vnl_diag_matrix_fixed
 template <class T, unsigned int n>
 vnl_diag_matrix_fixed<vcl_complex<T>,n >
-  vnl_complexify(vnl_diag_matrix_fixed<T,n> const& M)
+  vnl_complexify(vnl_diag_matrix_fixed<T,n> const& R)
 {
-  vnl_diag_matrix_fixed<vcl_complex<T>,n> Mc;
-  vnl_complexify(M.begin(), Mc.begin(), M.size());
-  return Mc;
+  vnl_diag_matrix_fixed<vcl_complex<T>,n> C;
+  vnl_complexify(R.begin(), C.begin(), R.size());
+  return C;
 }
 
 //: Return complexified version of real symmetric matrix R.
 // \relatesalso vnl_sym_matrix
 template <class T>
 vnl_sym_matrix<vcl_complex<T> >
-  vnl_complexify(vnl_sym_matrix<T> const& M)
+  vnl_complexify(vnl_sym_matrix<T> const& R);
+
+//----------------------------------------------------------------------
+
+// Real + Imaginary:
+// - vnl_vector
+// - vnl_vector_fixed
+// - vnl_matrix
+// - vnl_matrix_fixed
+// - vnl_diag_matrix
+// - vnl_diag_matrix_fixed
+// - vnl_sym_matrix
+
+//: Return complex vector R+j*I from two real vectors R and I.
+// \relatesalso vnl_vector
+template <class T>
+vnl_vector<vcl_complex<T> >
+  vnl_complexify(vnl_vector<T> const& R, vnl_vector<T> const& I);
+
+//: Return complex fixed vector R+j*I from two real fixed vectors R and I.
+// \relatesalso vnl_vector_fixed
+template <class T, unsigned int n>
+vnl_vector_fixed<vcl_complex<T>,n >
+  vnl_complexify(vnl_vector_fixed<T,n> const& R, vnl_vector_fixed<T,n> const& I)
 {
-  vnl_sym_matrix<vcl_complex<T> > Mc(M.size());
-  vnl_complexify(M.begin(), Mc.begin(), M.size());
-  return Mc;
+  vnl_vector_fixed<vcl_complex<T>,n > C;
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
 }
 
 //: Return complex matrix R+j*I from two real matrices R and I.
@@ -107,5 +128,39 @@ vnl_sym_matrix<vcl_complex<T> >
 template <class T>
 vnl_matrix<vcl_complex<T> >
   vnl_complexify(vnl_matrix<T> const& R, vnl_matrix<T> const& I);
+
+//: Return complex fixed matrix R+j*I from two real fixed matrices R and I.
+// \relatesalso vnl_matrix_fixed
+template <class T, unsigned int r, unsigned int c>
+vnl_matrix_fixed<vcl_complex<T >,r,c>
+  vnl_complexify(vnl_matrix_fixed<T,r,c> const& R, vnl_matrix_fixed<T,r,c> const& I)
+{
+  vnl_matrix_fixed<vcl_complex<T>,r,c > C;
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
+}
+
+//: Return complex diagonal matrix R+j*I from two real diagonal matrices R and I.
+// \relatesalso vnl_diag_matrix
+template <class T>
+vnl_diag_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_diag_matrix<T> const& R, vnl_diag_matrix<T> const& I);
+
+//: Return complex fixed diagonal matrix R+j*I from two real fixed diagonal matrices R and I.
+// \relatesalso vnl_matrix_fixed
+template <class T, unsigned int n>
+vnl_diag_matrix_fixed<vcl_complex<T>,n>
+  vnl_complexify(vnl_diag_matrix_fixed<T,n> const& R, vnl_diag_matrix_fixed<T,n> const& I)
+{
+  vnl_diag_matrix_fixed<vcl_complex<T>,n > C;
+  vnl_complexify(R.begin(), I.begin(), C.begin(), R.size());
+  return C;
+}
+
+//: Return complex diagonal matrix R+j*I from two real diagonal matrices R and I.
+// \relatesalso vnl_diag_matrix
+template <class T>
+vnl_sym_matrix<vcl_complex<T> >
+  vnl_complexify(vnl_sym_matrix<T> const& R, vnl_sym_matrix<T> const& I);
 
 #endif // vnl_complexify_h_


### PR DESCRIPTION
@yanggehua brought up a linker error that he was experiencing [1], having to do with template instantiation.  I wasn't able to reproduce this error, but I was able to reproduce a similar one (see the commented out unit test, which complains about undefined reference to `operator=`).  I think this may have to do with the fact that `VNL_SYM_MATRIX_INSTANTIATE` [2] does not instantiate it, but I wasn't able to figure out the syntax for adding it.

@thewtex @hjmjohnson I'm not very familiar with vxl's system for instantiating templates--any guidance is appreciated!

[1] https://github.com/vxl/vxl/issues/107
[2] https://github.com/vxl/vxl/blob/master/core/vnl/vnl_sym_matrix.txx