### PR TITLE
COMP: Fix syntax errors in vgui_satellite_tableu.h

### DIFF
--- a/core/vgui/vgui_satellite_tableau.h
+++ b/core/vgui/vgui_satellite_tableau.h
@@ -160,11 +160,11 @@ struct vgui_satellite_tableau : public vgui_tableau
 //----------------------------------------------------------------------------
 
 template <class object, class data>
-struct vgui_satellite_tableau_t_new : public vgui_tableau_sptr_t<vgui_satellite_tableau_t<object, data> vgui_tableau_sptr>
+struct vgui_satellite_tableau_t_new : public vgui_tableau_sptr_t<vgui_satellite_tableau_t<object, data> >
 {
   // no vgui_make_sptr: this file must be maintained manually.
   typedef vgui_satellite_tableau_t<object, data> impl;
-  typedef vgui_tableau_sptr_t<impl vgui_tableau_sptr> base;
+  typedef vgui_tableau_sptr_t<impl > base;
   typedef typename impl::method method;
   vgui_satellite_tableau_t_new(object *p, method m, data const &d,
                                vcl_string const&n=""):base(new impl(p,m,d,n)) {}
@@ -172,11 +172,11 @@ struct vgui_satellite_tableau_t_new : public vgui_tableau_sptr_t<vgui_satellite_
 
 //----------------------------------------------------------------------------
 template <class object>
-struct vgui_satellite_tableau_new : public vgui_tableau_sptr_t<vgui_satellite_tableau<object> vgui_tableau_sptr>
+struct vgui_satellite_tableau_new : public vgui_tableau_sptr_t<vgui_satellite_tableau<object> >
 {
   // no vgui_make_sptr: this file must be maintained manually.
   typedef vgui_satellite_tableau<object> impl;
-  typedef vgui_tableau_sptr_t<impl vgui_tableau_sptr> base;
+  typedef vgui_tableau_sptr_t<impl > base;
   typedef typename impl::method method;
   vgui_satellite_tableau_new(object *p, method m, vcl_string const &n = "")
     : base(new impl(p, m, n)) { }


### PR DESCRIPTION
vxl/core/vgui/vgui_satellite_tableau.h:163:105: error: type-id cannot have a name
struct vgui_satellite_tableau_t_new : public vgui_tableau_sptr_t<vgui_satellite_tableau_t<object, data> vgui_tableau_sptr>
                                                                                                        ^~~~~~~~~~~~~~~~~
/Users/johnsonhj/src/vxl/core/vgui/vgui_satellite_tableau.h:167:36: error: type-id cannot have a name
  typedef vgui_tableau_sptr_t<impl vgui_tableau_sptr> base;
                                   ^~~~~~~~~~~~~~~~~
vxl/core/vgui/vgui_satellite_tableau.h:175:95: error: type-id cannot have a name
struct vgui_satellite_tableau_new : public vgui_tableau_sptr_t<vgui_satellite_tableau<object> vgui_tableau_sptr>
                                                                                              ^~~~~~~~~~~~~~~~~
vxl/core/vgui/vgui_satellite_tableau.h:179:36: error: type-id cannot have a name
  typedef vgui_tableau_sptr_t<impl vgui_tableau_sptr> base;
                                   ^~~~~~~~~~~~~~~~~