### PR TITLE
Add support for automatic coverage and memory check

### DIFF
--- a/vxl_common.cmake
+++ b/vxl_common.cmake
@@ -34,13 +34,13 @@
 #   ctest -S ~/Dashboards/Scripts/my_dashboard.cmake -V
 #
 # By default the source and build trees will be placed in the path
-# "../My Tests/" relative to your script location.
+# "../MyTests/" relative to your script location.
 #
 # The following variables may be set before including this script
 # to configure it:
 #
 #   dashboard_model       = Nightly | Experimental | Continuous
-#   dashboard_root_name   = Change name of "My Tests" directory
+#   dashboard_root_name   = Change name of "MyTests" directory
 #   dashboard_source_name = Name of source directory (vxl)
 #   dashboard_binary_name = Name of binary directory (vxl-build)
 #   dashboard_cache       = Initial CMakeCache.txt file content
@@ -72,7 +72,7 @@ set(CTEST_PROJECT_NAME vxl)
 
 # Select the top dashboard directory.
 if(NOT DEFINED dashboard_root_name)
-  set(dashboard_root_name "My Tests")
+  set(dashboard_root_name "MyTests")
 endif()
 if(NOT DEFINED CTEST_DASHBOARD_ROOT)
   get_filename_component(CTEST_DASHBOARD_ROOT "${CTEST_SCRIPT_DIRECTORY}/../${dashboard_root_name}" ABSOLUTE)
@@ -260,13 +260,14 @@ foreach(v
     CTEST_CONFIGURE_COMMAND
     CTEST_SCRIPT_DIRECTORY
     CTEST_USE_LAUNCHERS
+    CTEST_COVERAGE_COMMAND
     )
   set(vars "${vars}  ${v}=[${${v}}]\n")
 endforeach(v)
 
 # Print dashboard_cache variables
 if(DEFINED dashboard_cache)
-  message("dashboard_cache initilazation:\n${dashboard_cache}\n")
+  message("\ndashboard_cache initilazation:\n${dashboard_cache}\n")
 endif()
 message("Dashboard script configuration:\n${vars}\n")
 


### PR DESCRIPTION
This adds some features to the dashboard script, making it easier to submit coverage and valgrind builds to the dashboard via automated ctest scripts. 
@hjmjohnson 