### PR TITLE
BUG: Fix valgrind mismatch delete

### DIFF
--- a/core/vil/file_formats/vil_bmp.cxx
+++ b/core/vil/file_formats/vil_bmp.cxx
@@ -353,7 +353,7 @@ bool vil_bmp_image::write_header()
         ptr[3] = 0; // unused byte
       }
       is_->write(map, n*4);
-      delete map;
+      delete [] map;
     }
   return true;
 }


### PR DESCRIPTION
== Mismatched free() / delete / delete []
== by 0x5123DB6: vil_bmp_image::write_header() (vil_bmp.cxx:356)
== by 0x5122FD4: vil_bmp_image::vil_bmp_image(vil_stream*, unsigned int, unsigned int, unsigned int, vil_pixel_format) (vil_bmp.cxx:113)