### PR TITLE
STYLE: Remove support for __alpha__ architecture

### DIFF
--- a/core/tests/make_test_config.pl
+++ b/core/tests/make_test_config.pl
@@ -247,7 +247,6 @@ for $var_exp (
   '__CYGWIN__',         # cygwin
   '__MINGW32__',        # MinGW
   '_WIN32',             # windows
-  '__alpha__',          # Alpha
   '__APPLE__',          # MacOS X
   'macintosh',          #
   'unix',               #

--- a/core/tests/test_config.cxx
+++ b/core/tests/test_config.cxx
@@ -1462,14 +1462,6 @@ void test_config()
 #endif
   vcl_cout << vcl_endl;
 
-  vcl_cout << "__alpha__ ";
-#ifdef __alpha__
-  vcl_cout << "is set to " << quote(__alpha__);
-#else
-  vcl_cout << "is not set";
-#endif
-  vcl_cout << vcl_endl;
-
   vcl_cout << "__APPLE__ ";
 #ifdef __APPLE__
   vcl_cout << "is set to " << quote(__APPLE__);

--- a/core/vnl/tests/test_bignum.cxx
+++ b/core/vnl/tests/test_bignum.cxx
@@ -9,10 +9,8 @@
 
 #include <vcl_iostream.h>
 #include <vcl_limits.h> // for vcl_numeric_limits<double>::infinity()
-#ifndef __alpha__ // On Alpha, compiler runs out of memory when including these
-# include <vcl_sstream.h>
-# include <vcl_iomanip.h>
-#endif
+#include <vcl_sstream.h>
+#include <vcl_iomanip.h>
 #include <vnl/vnl_bignum.h>
 #include <vnl/vnl_bignum_traits.h>
 #include <vnl/vnl_numeric_traits.h> // for vnl_numeric_traits<double>::maxval
@@ -88,7 +86,6 @@ static void run_constructor_tests()
   {vnl_bignum b("123e5"); TEST("vnl_bignum b(\"123e5\");", b, 12300000L);}
   {vnl_bignum b("-123e+4"); TEST("vnl_bignum b(\"-123e+4\");", b, -1230000L);}
   {vnl_bignum b("123e12"); TEST("vnl_bignum b(\"123e12\");", (double)b, 123e12);}
-#ifndef __alpha__ // On Alpha, compiler runs out of memory when using <sstream>
   {vnl_bignum b("-1e120"); vcl_stringstream s; s << b; vcl_cout << b << '\n';
    // verify that b outputs as  "-1000...00" (120 zeros)
    bool t = s.str()[0] == '-' && s.str()[1] == '1';
@@ -102,9 +99,6 @@ static void run_constructor_tests()
    TEST("vnl_bignum b(\"-1e120\") outputs a length 122 string", s.str().length(), 122);
    vcl_cout << "length of string: " << s.str().length() << vcl_endl;
   }
-#else
-  {vnl_bignum b("-1e120"); vcl_cout << b << '\n';}
-#endif
   {vnl_bignum b("0x0"); TEST("vnl_bignum b(\"0x0\");", b, 0x0);}
   {vnl_bignum b("0x9"); TEST("vnl_bignum b(\"0x9\");", b, 0x9);}
   {vnl_bignum b("0xa"); TEST("vnl_bignum b(\"0xa\");", b, 0xa);}
@@ -122,7 +116,6 @@ static void run_constructor_tests()
   {vnl_bignum b("Infinity"); TEST("vnl_bignum b(\"Infinity\");", b.is_plus_infinity(), true);}
   {vnl_bignum b("-Infin"); TEST("vnl_bignum b(\"-Infin\");", b.is_minus_infinity(), true);}
 
-#ifndef __alpha__ // On Alpha, compiler runs out of memory when using <sstream>
   vcl_cout << "reading from istream:\n";
   {vcl_stringstream is(vcl_ios_in | vcl_ios_out); vnl_bignum b;
    is << "+1"; is >> b; TEST("\"+1\" >> b;", b, 1L);}
@@ -158,7 +151,6 @@ static void run_constructor_tests()
    is << '9'; is >> b; TEST("\"9\" >> b;", b, 9L);}
   {vcl_stringstream is(vcl_ios_in | vcl_ios_out); vnl_bignum b;
    is << " 9"; is >> b; TEST("\" 9\" >> b;", b, 9L);}
-#endif
 
   vcl_cout << "vnl_bignum& constructor:\n";
   {vnl_bignum b50(vnl_bignum(0L));
@@ -394,19 +386,15 @@ static void run_division_tests()
           vnl_bignum b3(long((i+k)/(j+l)));
           if (b1/b2 != b3) {
             TEST("(vnl_bignum(i+k)/vnl_bignum(j+l)) == vnl_bignum(long((i+k)/(j+l)))", false, true);
-#ifndef __alpha__ // On Alpha, compiler runs out of memory when using <iomanip>
             vcl_cout<<vcl_hex<< "i=0x"<<i<<", j=0x"<<j<<", k=0x"<<k<<", l="<<l
                     <<vcl_dec<<", b1="<<b1<<", b2="<<b2<<", b3="<<b3<<'\n';
-#endif
             ++div_errors;
           }
           b3 = vnl_bignum(long((i+k)%(j+l)));
           if (b1%b2 != b3) {
             TEST("(vnl_bignum(i+k)%vnl_bignum(j+l)) == vnl_bignum(long((i+k)%(j+l)))", false, true);
-#ifndef __alpha__ // On Alpha, compiler runs out of memory when using <iomanip>
             vcl_cout<<vcl_hex<< "i=0x"<<i<<", j=0x"<<j<<", k=0x"<<k<<", l="<<l
                     <<vcl_dec<<", b1="<<b1<<", b2="<<b2<<", b3="<<b3<<'\n';
-#endif
             ++mod_errors;
           }
         }

--- a/core/vnl/tests/test_math.cxx
+++ b/core/vnl/tests/test_math.cxx
@@ -329,24 +329,20 @@ static void test_math()
            << "qnan_q = " << qnan_q << " =  "<< print_hex(qnan_q) << "    sizeof " << sizeof(qnan_q) << '\n'
            << vcl_endl;
 
-#ifndef __alpha__ // on alpha, infinity() == max()
   TEST("!isfinite(pinf_f)", vnl_math::isfinite(pinf_f), false);
   TEST("!isfinite(ninf_f)", vnl_math::isfinite(ninf_f), false);
   TEST(" isinf(pinf_f)   ",  vnl_math::isinf(pinf_f), true);
   TEST(" isinf(ninf_f)   ",  vnl_math::isinf(ninf_f), true);
-#endif
   TEST("!isnan(pinf_f)   ", vnl_math::isnan(pinf_f), false);
   TEST("!isnan(ninf_f)   ", vnl_math::isnan(ninf_f), false);
   TEST("!isfinite(qnan_f)", vnl_math::isfinite(qnan_f), false);
   TEST("!isinf(qnan_f)   ", vnl_math::isinf(qnan_f), false);
   TEST(" isnan(qnan_f)   ",  vnl_math::isnan(qnan_f), true);
 
-#ifndef __alpha__ // on alpha, infinity() == max()
   TEST("!isfinite(pinf_d)", vnl_math::isfinite(pinf_d), false);
   TEST("!isfinite(ninf_d)", vnl_math::isfinite(ninf_d), false);
   TEST(" isinf(pinf_d)   ",  vnl_math::isinf(pinf_d), true);
   TEST(" isinf(ninf_d)   ",  vnl_math::isinf(ninf_d), true);
-#endif
   TEST("!isnan(pinf_d)   ", vnl_math::isnan(pinf_d), false);
   TEST("!isnan(ninf_d)   ", vnl_math::isnan(ninf_d), false);
   TEST("!isfinite(qnan_d)", vnl_math::isfinite(qnan_d), false);
@@ -354,12 +350,10 @@ static void test_math()
   TEST(" isnan(qnan_d)   ",  vnl_math::isnan(qnan_d), true);
 
 #ifndef __ICC // "long double" has no standard internal representation on different platforms/compilers
-#ifndef __alpha__ // on alpha, infinity() == max()
   TEST("!isfinite(pinf_q)", vnl_math::isfinite(pinf_q), false);
   TEST("!isfinite(ninf_q)", vnl_math::isfinite(ninf_q), false);
   TEST(" isinf(pinf_q)   ",  vnl_math::isinf(pinf_q), true);
   TEST(" isinf(ninf_q)   ",  vnl_math::isinf(ninf_q), true);
-#endif
   TEST("!isnan(pinf_q)   ", vnl_math::isnan(pinf_q), false);
   TEST("!isnan(ninf_q)   ", vnl_math::isnan(ninf_q), false);
   TEST("!isfinite(qnan_q)", vnl_math::isfinite(qnan_q), false);

--- a/core/vnl/vnl_math.cxx
+++ b/core/vnl/vnl_math.cxx
@@ -82,7 +82,7 @@ bool isnan(float x) { return isnanf(x) != 0; }
 bool isnan(double x) { return isnan(x) != 0; }
 //: Return true iff x is "Not a Number"
 bool isnan(long double x) { return isnanl(x) != 0; }
-#elif !defined(VNL_HAS_NO_FINITE) && !defined(__alpha__) && !defined(VCL_WIN32)
+#elif !defined(VNL_HAS_NO_FINITE) && !defined(VCL_WIN32)
 //: Return true iff x is "Not a Number"
 bool isnan(float x) { return x != x; } // causes "floating exception" on alpha
 //: Return true iff x is "Not a Number"


### PR DESCRIPTION
The __alpha__ archetecture is no longer supported,
so simplify the code logic.