### PR TITLE
optionally build without ffmpeg support

### DIFF
--- a/contrib/brl/bseg/boxm2/class/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/class/CMakeLists.txt
@@ -10,7 +10,7 @@ set(boxm2_class_sources
    )
 
 add_library(boxm2_class  ${boxm2_class_sources})
-target_link_libraries(boxm2_class boxm2 bvgl vpgl vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl)
+target_link_libraries(boxm2_class boxm2 bvgl vpgl vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl)
 
 #install the .h .txx and libs
 install_targets(/lib boxm2_class)

--- a/contrib/brl/bseg/boxm2/reg/ocl/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/reg/ocl/CMakeLists.txt
@@ -15,7 +15,7 @@ set(boxm2_ocl_reg_sources
    )
 
 add_library(boxm2_ocl_reg  ${boxm2_ocl_reg_sources})
-target_link_libraries(boxm2_ocl_reg boxm2_io  boxm2_ocl bocl brip baio vpgl vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
+target_link_libraries(boxm2_ocl_reg boxm2_io  boxm2_ocl bocl brip baio vpgl vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
 
 #install the .h .txx and libs
 install_targets(/lib boxm2_ocl_reg)

--- a/contrib/brl/bseg/boxm2/util/boxm2_convert_nvm_txt.cxx
+++ b/contrib/brl/bseg/boxm2/util/boxm2_convert_nvm_txt.cxx
@@ -3,7 +3,6 @@
 //:
 // \file
 #include <vsph/vsph_camera_bounds.h>
-#include <vidl/vidl_image_list_istream.h>
 #include <vgl/vgl_box_3d.h>
 #include <vgl/algo/vgl_rotation_3d.h>
 #include <vnl/vnl_double_3.h>

--- a/contrib/brl/bseg/boxm2/vecf/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/vecf/CMakeLists.txt
@@ -52,7 +52,7 @@ set(boxm2_vecf_sources
 aux_source_directory(Templates boxm2_vecf_sources)
 
 add_library(boxm2_vecf  ${boxm2_vecf_sources})
-target_link_libraries(boxm2_vecf boxm2_io boxm2_cpp_algo brip baio bvrml vpgl vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map rsdl)
+target_link_libraries(boxm2_vecf boxm2_io boxm2_cpp_algo brip baio bvrml vpgl vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map rsdl)
 include( ${VXL_CMAKE_DIR}/NewCMake/FindOpenCL.cmake )
 if(OPENCL_FOUND)
   target_link_libraries(boxm2_vecf boxm2_ocl boxm2_ocl_algo  bocl )

--- a/contrib/brl/bseg/boxm2/vecf/ocl/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/vecf/ocl/CMakeLists.txt
@@ -30,7 +30,7 @@ set(boxm2_vecf_ocl_sources
 aux_source_directory(Templates boxm2_vecf_ocl_sources)
 
 add_library(boxm2_vecf_ocl  ${boxm2_vecf_ocl_sources})
-target_link_libraries(boxm2_vecf_ocl boxm2_vecf boxm2_io  boxm2_ocl boxm2_ocl_algo bocl brip baio vpgl vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
+target_link_libraries(boxm2_vecf_ocl boxm2_vecf boxm2_io  boxm2_ocl boxm2_ocl_algo bocl brip baio vpgl vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
 
 #install the .h .txx and libs
 install_targets(/lib boxm2_vecf_ocl)

--- a/contrib/brl/bseg/boxm2/volm/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/volm/CMakeLists.txt
@@ -34,7 +34,7 @@ if(EXPAT_FOUND)
     aux_source_directory(Templates boxm2_volm_sources)
 
     add_library(boxm2_volm ${boxm2_volm_sources})
-    target_link_libraries(boxm2_volm boxm2 boxm2_io brip baio vpgl volm vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
+    target_link_libraries(boxm2_volm boxm2 boxm2_io brip baio vpgl volm vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl depth_map)
     if(OPENCL_FOUND)
     target_link_libraries(boxm2_volm bocl)
     endif()

--- a/contrib/brl/bseg/boxm2/volm/desc/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/volm/desc/CMakeLists.txt
@@ -13,7 +13,7 @@ set(boxm2_volm_desc_sources
 
 add_library(boxm2_volm_desc ${boxm2_volm_desc_sources})
 
-target_link_libraries(boxm2_volm_desc boxm2_volm boxm2 boxm2_io brip baio vpgl volm volm_desc vnl vidl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl)
+target_link_libraries(boxm2_volm_desc boxm2_volm boxm2 boxm2_io brip baio vpgl volm volm_desc vnl vil_algo vil vgl_algo vgl_xio vgl vbl vul vsl vcl)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/core/vidl/CMakeLists.txt
+++ b/core/vidl/CMakeLists.txt
@@ -8,7 +8,11 @@ doxygen_add_library(core/vidl
   DESCRIPTION "Video Sequence Library"
 )
 
+set(WITH_FFMPEG TRUE CACHE BOOL "Include FFMPEG support if available")
+if(WITH_FFMPEG)
 include( ${VXL_CMAKE_DIR}/NewCMake/FindFFMPEG.cmake )
+endif(WITH_FFMPEG)
+
 include( ${VXL_CMAKE_DIR}/NewCMake/FindDC1394.cmake )
 include( ${VXL_CMAKE_DIR}/NewCMake/FindDirectShow.cmake )
 find_file(VIDEODEV_FOUND videodev.h /usr/include/linux/)

--- a/core/vidl/CMakeLists.txt
+++ b/core/vidl/CMakeLists.txt
@@ -8,7 +8,7 @@ doxygen_add_library(core/vidl
   DESCRIPTION "Video Sequence Library"
 )
 
-set(WITH_FFMPEG TRUE CACHE BOOL "Include FFMPEG support if available")
+option(WITH_FFMPEG "Include FFMPEG support if available" ON)
 if(WITH_FFMPEG)
 include( ${VXL_CMAKE_DIR}/NewCMake/FindFFMPEG.cmake )
 endif(WITH_FFMPEG)


### PR DESCRIPTION
Since supporting whatever version of ffmpeg happens to be available seems to be a tricky issue, I added a "WITH_FFMPEG" cmake option that will not bother searching for it if turned off.  The option is on by default so default behavior shouldn't change.   @mleotta mentioned in pull request #98  that there may be support for ffmpeg version checking added in the future, so this option could probably be removed at that point. 