### PR TITLE
COMP: Need to build zlib if not installed.

### DIFF
--- a/v3p/CMakeLists.txt
+++ b/v3p/CMakeLists.txt
@@ -16,12 +16,14 @@ if (VXL_FORCE_V3P_CLIPPER)
   add_subdirectory(clipper)
 endif ()
 
+include(${VXL_CMAKE_DIR}/FindZLIB.cmake)
 CMAKE_DEPENDENT_OPTION( VXL_FORCE_V3P_ZLIB "Use V3P instead of any native ZLIB library?" OFF
                         "BUILD_CORE_IMAGING" OFF)
 mark_as_advanced( VXL_FORCE_V3P_ZLIB )
-if (VXL_FORCE_V3P_ZLIB)
+if (VXL_FORCE_V3P_ZLIB OR ( NOT VXL_USING_NATIVE_ZLIB ) )
   add_subdirectory(zlib)
 endif()
+
 
 if(BUILD_CORE_IMAGING)
   option( VXL_FORCE_V3P_BZLIB2 "Use V3P instead of any native BZip2 library?" OFF)

--- a/v3p/zlib/CMakeLists.txt
+++ b/v3p/zlib/CMakeLists.txt
@@ -2,10 +2,6 @@
 
 project( zlib C )
 
-include(${VXL_CMAKE_DIR}/FindZLIB.cmake)
-
-if(NOT VXL_USING_NATIVE_ZLIB)
-
 set( zlib_sources
   zlib.h
   zconf.h
@@ -35,5 +31,4 @@ endif()
 add_library( z ${zlib_sources} )
 install_targets( /lib z )
 
-endif()
 


### PR DESCRIPTION
On windows, zlib is often not installed in a path
that can be automatically found by cmake.  In those cases,
install a private version of zlib.