### PR TITLE
COMP: Provde macro to hide unused debug variables

### DIFF
--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -571,7 +571,7 @@ class vnl_matrix
 
   //: abort if size is not as expected
   // This function does or tests nothing if NDEBUG is defined
-  void assert_size(unsigned r, unsigned c) const
+  void assert_size(unsigned VXL_USED_IN_DEBUG(r), unsigned VXL_USED_IN_DEBUG(c)) const
   {
 #ifndef NDEBUG
     assert_size_internal(r, c);

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -116,7 +116,7 @@ class vnl_matrix_fixed
   // vnl_matrix, so that algorithms can template over the matrix type
   // itself.  It is illegal to call this constructor without
   // <tt>n==num_rows</tt> and <tt>m==num_cols</tt>.
-  vnl_matrix_fixed( unsigned n, unsigned m )
+  vnl_matrix_fixed( unsigned VXL_USED_IN_DEBUG(n), unsigned VXL_USED_IN_DEBUG(m) )
   {
     assert( n == num_rows && m == num_cols );
   }
@@ -606,7 +606,7 @@ class vnl_matrix_fixed
 
   //: abort if size is not as expected
   // This function does or tests nothing if NDEBUG is defined
-  void assert_size(unsigned nr_rows, unsigned nr_cols) const
+  void assert_size(unsigned VXL_USED_IN_DEBUG(nr_rows), unsigned VXL_USED_IN_DEBUG(nr_cols) ) const
   {
 #ifndef NDEBUG
     assert_size_internal(nr_rows, nr_cols);

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -391,7 +391,7 @@ class vnl_vector
 
   //: Check that size()==sz if not, abort();
   // This function does or tests nothing if NDEBUG is defined
-  void assert_size(unsigned sz) const {
+  void assert_size(unsigned VXL_USED_IN_DEBUG(sz) ) const {
 #ifndef NDEBUG
     assert_size_internal(sz);
 #endif

--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -203,4 +203,13 @@ typedef int saw_VCL_FOR_SCOPE_HACK;
 # define VXL_CXX11 0
 #endif
 
+
+//----------------------------------------------------------------------------
+// Check if the compiler (claims to) support C++11.
+#if defined(NDEBUG)
+# define VXL_USED_IN_DEBUG(x)
+#else
+# define VXL_USED_IN_DEBUG(x) x
+#endif
+
 #endif // vcl_compiler_h_


### PR DESCRIPTION
Some variables are only used in debug mode.  Provide a macro
to hide those variables when compiling without assertions.