### PR TITLE
COMP: Fixes "Value stored to '' never read" warnings

### DIFF
--- a/contrib/brl/bbas/bmsh3d/bmsh3d_pt_set.cxx
+++ b/contrib/brl/bbas/bmsh3d/bmsh3d_pt_set.cxx
@@ -216,7 +216,6 @@ void rotate_points (bmsh3d_pt_set* pt_set,
     x =  x0*vcl_cos(ry) - z0*vcl_sin(ry);
     z =  x0*vcl_sin(ry) + z0*vcl_cos(ry);
     x0=x;
-    z0=z;
 
     //3)Rotation about Z
     x =  x0*vcl_cos(rz) + y0*vcl_sin(rz);

--- a/contrib/brl/bbas/volm/exe/volm_prepare_landclass_images.cxx
+++ b/contrib/brl/bbas/volm/exe/volm_prepare_landclass_images.cxx
@@ -261,7 +261,6 @@ int main(int argc,  char** argv)
     vil_rgb<vxl_byte> pixel_color = building_pixel_color;
 
     if (heights[ii] > 20) {  // specify the category
-      label = volm_label_table::BUILDING_TALL;
       pixel_id = building_tall_id;
       pixel_color = building_tall_pixel_color;
     }

--- a/contrib/brl/bbas/volm/exe/volm_refine_height_map.cxx
+++ b/contrib/brl/bbas/volm/exe/volm_refine_height_map.cxx
@@ -386,15 +386,10 @@ int main(int argc, char** argv)
   for (unsigned w_idx_i = 0; w_idx_i < num_w_i; w_idx_i++)
   {
     unsigned start_ni, end_ni;
-    start_ni = w_idx_i*dx();
-    end_ni = (w_idx_i+1)*dx();
     for (unsigned w_idx_j = 0; w_idx_j < num_w_j; w_idx_j++)
     {
       vcl_cout << '.';
       vcl_cout.flush();
-      // obtain window pixels
-      unsigned start_nj, end_nj;
-      start_nj = w_idx_j*dy(); end_nj = (w_idx_j+1)*dy();
 
       // obtain the window height
       float grd_height = 0.0f;
@@ -440,7 +435,6 @@ int main(int argc, char** argv)
   for (unsigned w_idx_i = 0; w_idx_i < num_w_i; w_idx_i++)
   {
     unsigned start_ni, end_ni;
-    start_ni = w_idx_i*dx(); end_ni = (w_idx_i+1)*dx();
     for (unsigned w_idx_j = 0; w_idx_j < num_w_j; w_idx_j++)
     {
       vcl_cout << '.';
@@ -478,7 +472,6 @@ int main(int argc, char** argv)
   for (unsigned w_idx_i = 0; w_idx_i < num_w_i; w_idx_i++)
   {
     unsigned start_ni, end_ni;
-    start_ni = w_idx_i*dx(); end_ni = (w_idx_i+1)*dx();
     for (unsigned w_idx_j = 0; w_idx_j < num_w_j; w_idx_j++)
     {
       vcl_cout << '.';

--- a/contrib/brl/bbas/volm/tests/test_candidate_region_parser.cxx
+++ b/contrib/brl/bbas/volm/tests/test_candidate_region_parser.cxx
@@ -72,7 +72,7 @@ static void test_candidate_region_parser()
   TEST("parse polygon with name \"Overhead Overlay\"", poly_outer_overhead.num_sheets(), 3);
 
   success = (outer.num_sheets() == n_out) && (inner.num_sheets() == n_in);
-  success = (poly_all_region.num_sheets() == (n_in + n_out));
+  success &= (poly_all_region.num_sheets() == (n_in + n_out));
   TEST("parse polygon with inner boundary", success, true);
   return;
 }

--- a/contrib/brl/bbas/volm/volm_satellite_resources.cxx
+++ b/contrib/brl/bbas/volm/volm_satellite_resources.cxx
@@ -811,7 +811,6 @@ volm_satellite_resources::highly_overlapping_resources(vcl_vector<unsigned>& ove
 
         // find the best score
         if(compactness_score > best_score) {
-          best_nimages = nimages;
           best_score = compactness_score;
           best_region_hull = region_hull;
           //vcl_cout << best_region_hull << vcl_endl;

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_get_bounding_box_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_get_bounding_box_process.cxx
@@ -92,6 +92,9 @@ bool vpgl_get_bounding_box_process(bprb_func_process& pro)
     good = good && vgl_intersection(ur, zp, urp);
     good = good && vgl_intersection(bl, zp, blp);
     good = good && vgl_intersection(br, zp, brp);
+    if (!good) {
+        vcl_cout << "ERROR: lines do not intersect" << __FILE__ << __LINE__ << vcl_endl;
+    }
 
     //convert the four corners into image coordinates
     typedef vgl_polygon<double>::point_t        Point_type;

--- a/contrib/brl/bseg/bmdl/pro/processes/bmdl_generate_mesh_process.cxx
+++ b/contrib/brl/bseg/bmdl/pro/processes/bmdl_generate_mesh_process.cxx
@@ -240,9 +240,7 @@ int zip_kmz(zipFile& zf, const char* filenameinzip)
   if (fin)
     vcl_fclose(fin);
 
-  if (err<0)
-    err=ZIP_ERRNO;
-  else {
+  if (err >= 0 ){
     err = zipCloseFileInZip(zf);
     if (err!=ZIP_OK)
       vcl_printf("error in closing %s in the zipfile\n", filenameinzip);

--- a/contrib/brl/bseg/boxm/boxm_scene_parser.cxx
+++ b/contrib/brl/bseg/boxm/boxm_scene_parser.cxx
@@ -28,19 +28,23 @@ bool boxm_scene_parser::lvcs(vpgl_lvcs& lvcs) {
   vpgl_lvcs::cs_names cs_name = vpgl_lvcs::str_to_enum(lvcs_cs_name_.data());
   vpgl_lvcs::LenUnits len_unit;
   vpgl_lvcs::AngUnits geo_unit;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0)
+   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0) {
      len_unit = vpgl_lvcs::FEET;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0)
+   }
+   else if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0) {
      len_unit = vpgl_lvcs::METERS;
+   }
    else {
      vcl_cout << "LVCS Length Unit " << lvcs_XYZ_unit_ << " is not valid\n";
      return false;
    }
 
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0)
+   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0) {
      geo_unit = vpgl_lvcs::RADIANS;
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0)
+   }
+   else if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0) {
      geo_unit = vpgl_lvcs::DEG;
+   }
    else {
      vcl_cout << "LVCS Geo Angle Unit " << lvcs_geo_angle_unit_ << " is not valid\n";
      return false;

--- a/contrib/brl/bseg/boxm2/boxm2_scene_parser.cxx
+++ b/contrib/brl/bseg/boxm2/boxm2_scene_parser.cxx
@@ -36,20 +36,24 @@ bool boxm2_scene_parser::lvcs(vpgl_lvcs& lvcs)
 {
   const vpgl_lvcs::cs_names cs_name = vpgl_lvcs::str_to_enum(lvcs_cs_name_.data());
   vpgl_lvcs::LenUnits len_unit = vpgl_lvcs::FEET;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0)
+   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0) {
      len_unit = vpgl_lvcs::FEET;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0)
+   }
+   else if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0) {
      len_unit = vpgl_lvcs::METERS;
+   }
    else {
      vcl_cout << "LVCS Length Unit " << lvcs_XYZ_unit_ << " is not valid\n";
      return false;
    }
 
   vpgl_lvcs::AngUnits geo_unit= vpgl_lvcs::RADIANS;
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0)
+   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0) {
      geo_unit = vpgl_lvcs::RADIANS;
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0)
+   }
+   else if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0) {
      geo_unit = vpgl_lvcs::DEG;
+   }
    else {
      vcl_cout << "LVCS Geo Angle Unit " << lvcs_geo_angle_unit_ << " is not valid\n";
      return false;

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_mog3_grey_processor.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_mog3_grey_processor.cxx
@@ -57,11 +57,9 @@ float  boxm2_mog3_grey_processor::prob_density(const vnl_vector_fixed<unsigned c
   if (w0>0.0f && sigma0 >0.0f)
   {
     sum += w0*boxm2_mog3_grey_processor::gauss_prob_density(x, mu0, sigma0);
-    sum_weights+=w0;
     if (w1>0.0f && sigma1 >0.0f)
     {
       sum += w1*gauss_prob_density(x, mu1, sigma1);
-      sum_weights+=w1;
       if (w2>0.0f && sigma2 >0.0f)
       {
         sum += w2*gauss_prob_density(x, mu2, sigma2);

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_online_color.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_online_color.cxx
@@ -372,6 +372,7 @@ bool boxm2_ocl_paint_online_color::paint_scene_with_weights(boxm2_scene_sptr    
       arg_status &= update_kern->set_arg( aux1 );
       arg_status &= update_kern->set_arg( aux2 );
       arg_status &= update_kern->set_arg( cl_output.ptr() );
+      check_val(arg_status, true, "AFTER UPDATE_KERN: set kernel args FAILED: "__FILE__ );
 
       vcl_cout << "local_threads = " << local_threads[0] << ", " << local_threads[1] << vcl_endl;
       vcl_cout << "global_threads = " << global_threads[0] << ", " << global_threads[1] << vcl_endl;

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_estimate_uncertain_viewpoints.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_estimate_uncertain_viewpoints.cxx
@@ -194,10 +194,12 @@ int main(int argc,  char** argv)
                 vcl_cout<<"Focal Length "<<mat.focal_length()<<vcl_endl;
                 //if scene has RGB data type, use color render process
                 bool good;
-                if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) )
+                if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) ) {
                   good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedColorProcess");
-                else
+                }
+                else {
                   good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedImageProcess");
+                }
                 //set process args
                 good = good
                     && bprb_batch_process_manager::instance()->set_input(0, brdb_device)        // device
@@ -208,8 +210,17 @@ int main(int argc,  char** argv)
                     && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)            // nj for rendered image
                     && bprb_batch_process_manager::instance()->set_input(6, brdb_ident)            // identifier for rendered image
                     && bprb_batch_process_manager::instance()->run_process();
+                if( !good ) {
+                  vcl_cout << "ERROR!!: process args not set: " << __FILE__ << __LINE__ << vcl_endl;
+                  return -1;
+                }
                 unsigned int img_id=0;
                 good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+                if( !good ) {
+                  vcl_cout << "ERROR!!: commit_output failed: " << __FILE__ << __LINE__ << vcl_endl;
+                  return -1;
+                }
+
                 brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
                 brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
                 if (S->size()!=1) {

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_export_scene.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_export_scene.cxx
@@ -250,9 +250,18 @@ int main(int argc,  char** argv)
                         && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
                         && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
                         && bprb_batch_process_manager::instance()->run_process();
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: process args input not set: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
 
                     unsigned int img_id=0;
                     good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+                    if( !good ) {
+                      vcl_cout << "ERROR!!:  commit output failed: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
+
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
                     brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
                     if (S->size()!=1) {
@@ -291,8 +300,18 @@ int main(int argc,  char** argv)
                         && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
                         && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
                         && bprb_batch_process_manager::instance()->run_process();
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: process args input not set: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
+
                     unsigned int img_id=0;
                     good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: commit output failed: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
+
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
                     brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
                     if (S->size()!=1) {
@@ -326,9 +345,18 @@ int main(int argc,  char** argv)
                         && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
                         && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
                         && bprb_batch_process_manager::instance()->run_process();
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: process args input not set: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
 
                     unsigned int img_id=0;
                     good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: commit output failed: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
+
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
                     brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
                     if (S->size()!=1) {
@@ -360,6 +388,11 @@ int main(int argc,  char** argv)
                         && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
                         && bprb_batch_process_manager::instance()->run_process()
                         && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+                    if( !good ) {
+                      vcl_cout << "ERROR!!: process args input not set: " << __FILE__ << __LINE__ << vcl_endl;
+                      return -1;
+                    }
+
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
                     brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
                     if (S->size()!=1) {

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_render_hemisphere.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_render_hemisphere.cxx
@@ -101,11 +101,16 @@ int main(int argc,  char** argv)
 
       //if scene has RGB data type, use color render process
       bool good;
-      if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) )
+      if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) ) {
         good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedColorProcess");
-      else
+      }
+      else {
         good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedImageProcess");
-
+      }
+      if ( !good ) {
+        vcl_cout << "ERROR: couldn't start color render process: " << __FILE__ << __LINE__ << vcl_endl;
+        return -1;
+      }
       //set process args and run process
       good = good
           && bprb_batch_process_manager::instance()->set_input(0, brdb_device) // device
@@ -115,9 +120,17 @@ int main(int argc,  char** argv)
           && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
           && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
           && bprb_batch_process_manager::instance()->run_process();
+      if ( !good ) {
+        vcl_cout << "ERROR: couldn't set process args: " << __FILE__ << __LINE__ << vcl_endl;
+        return -1;
+      }
 
       unsigned int img_id=0;
       good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+      if ( !good ) {
+        vcl_cout << "ERROR: couldn't commit output: " << __FILE__ << __LINE__ << vcl_endl;
+        return -1;
+      }
       brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
       brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
       if (S->size()!=1) {
@@ -205,10 +218,16 @@ int main(int argc,  char** argv)
 
         //if scene has RGB data type, use color render process
         bool good;
-        if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) )
+        if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) ) {
           good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedColorProcess");
-        else
+        }
+        else {
           good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedImageProcess");
+        }
+        if ( !good ) {
+          vcl_cout << "ERROR: couldn't start color render process: " << __FILE__ << __LINE__ << vcl_endl;
+          return -1;
+        }
 
         //set process args and run process
         good = good
@@ -219,9 +238,17 @@ int main(int argc,  char** argv)
             && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
             && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
             && bprb_batch_process_manager::instance()->run_process();
+        if ( !good ) {
+          vcl_cout << "ERROR: couldn't set process args: " << __FILE__ << __LINE__ << vcl_endl;
+          return -1;
+        }
 
         unsigned int img_id=0;
         good = good && bprb_batch_process_manager::instance()->commit_output(0, img_id);
+        if ( !good ) {
+          vcl_cout << "ERROR: couldn't commit output: " << __FILE__ << __LINE__ << vcl_endl;
+          return -1;
+        }
         brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
         brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
         if (S->size()!=1) {

--- a/contrib/brl/bseg/boxm2/ocl/pro/processes/boxm2_ocl_compute_expectation_per_view_process.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/pro/processes/boxm2_ocl_compute_expectation_per_view_process.cxx
@@ -373,7 +373,6 @@ bool boxm2_ocl_compute_expectation_per_view_process(bprb_func_process& pro)
       //grab an appropriately sized AUX data buffer
       int auxTypeSize  = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_AUX0>::prefix());
       bocl_mem *aux0   = opencl_cache->get_data(scene,*id, boxm2_data_traits<BOXM2_AUX0>::prefix(suffix),info_buffer->data_buffer_length*auxTypeSize,false);
-      auxTypeSize      = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_AUX2>::prefix());
 
       //also grab mog
       bocl_mem* mog       = opencl_cache->get_data(scene,*id,data_type,alpha->num_bytes()/alphaTypeSize*appTypeSize,false);

--- a/contrib/brl/bseg/boxm2/ocl/pro/processes/boxm2_ocl_uncertainty_per_image_process.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/pro/processes/boxm2_ocl_uncertainty_per_image_process.cxx
@@ -436,6 +436,7 @@ bool boxm2_ocl_uncertainty_per_image_process(bprb_func_process& pro)
                 aux2->read_to_buffer(queue);
                 aux3->read_to_buffer(queue);
                 status = clFinish(queue);
+                check_val(status, MEM_FAILURE, "UPDATE EXECUTE FAILED: " + error_to_string(status));
             }
         } // UPDATE POST DEPTH kernel
         else if (i==CONVERT_AUX_INT_FLOAT)

--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_lid_base.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_lid_base.cxx
@@ -220,9 +220,6 @@ double boxm2_vecf_lid_base::curve_distance(double t, double x, double y, double 
     double dx = xp-x, dy = y-gi(xp,t), dz = z-Z(xp, t);
     double d = vcl_sqrt(dx*dx + dy*dy + dz*dz);
     if(d<dmin){
-      xmin = xp;
-      ymin = gi(xp,t);
-      zmin = Z(xp,t);
       dmin = d;
     }
   }

--- a/contrib/brl/bseg/boxm2/vecf/exe/orbit_fitter.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/exe/orbit_fitter.cxx
@@ -186,6 +186,10 @@ int main(int argc, char ** argv)
     vcl_string right_marg_path = base_dir + patient_id +"_right_margin_fit.txt";
     vcl_ofstream rmstr(right_marg_path.c_str());
     good = right_fmargs.plot_orbit(rmstr);
+    if(!good){
+      vcl_cout << "ERROR: Invalid parameter to plot_orbit: " << __FILE__ << __LINE__ << vcl_endl;
+      return -1;
+    }
     rmstr.close();
   }
   // if image data set z values for margin and crease curve points
@@ -198,6 +202,10 @@ int main(int argc, char ** argv)
 
   vcl_ofstream rostr(right_vrml_path.c_str());
   good = fo.display_orbit_vrml(rostr, true, show_model);
+  if(!good){
+    vcl_cout << "ERROR: Invalid parameter to display_orbit: " << __FILE__ << __LINE__ << vcl_endl;
+    return -1;
+  }
   rostr.close();
 
   fo.fitting_error("right_eye_inferior_margin");
@@ -252,6 +260,10 @@ int main(int argc, char ** argv)
     vcl_string left_marg_path = base_dir + patient_id +"_left_margin_fit.txt";
     vcl_ofstream lmstr(left_marg_path.c_str());
     good = left_fmargs.plot_orbit(lmstr);
+    if(!good){
+      vcl_cout << "ERROR: Invalid parameter to plot_orbit: " << __FILE__ << __LINE__ << vcl_endl;
+      return -1;
+    }
     lmstr.close();
   }
   // if image data set z values for margin and crease curve points
@@ -262,6 +274,10 @@ int main(int argc, char ** argv)
   }
   vcl_ofstream lostr(left_vrml_path.c_str());
   good = fo.display_orbit_vrml(lostr, false, show_model);
+  if(!good){
+    vcl_cout << "ERROR: Invalid parameter to display_orbit: " << __FILE__ << __LINE__ << vcl_endl;
+    return -1;
+  }
   lostr.close();
 
   // find canthus angles
@@ -285,6 +301,10 @@ int main(int argc, char ** argv)
 
   vcl_ofstream lrmstr(left_right_merge_path.c_str());
   good = fo.display_left_right_orbit_model_vrml(lrmstr);
+  if(!good){
+    vcl_cout << "ERROR: Invalid parameter to display_orbit: " << __FILE__ << __LINE__ << vcl_endl;
+    return -1;
+  }
   lrmstr.close();
 
 

--- a/contrib/brl/bseg/boxm2/vecf/exe/skull_fitter.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/exe/skull_fitter.cxx
@@ -61,9 +61,19 @@ int main(int argc, char ** argv)
   vcl_string source_path = base_dir + "skull/skull-top-2x-r-zeroaxis-samp-1.0-r35-norm.txt";
   vcl_string target_path = base_dir + id + "/" + id + "_trans_skull.txt";
   good = fs.transform_skull(source_path, target_path);
+  if(!good){
+    vcl_cout << "ERROR: invalid path given to transform_skull: " << __FILE__ << __LINE__ << vcl_endl;
+    return -1;
+  }
+
   source_path = base_dir + "skull/mandible-2x-zero-samp-1.0-r35-norm.txt";
   target_path = base_dir + id + "/" + id + "_trans_mandible.txt";
   good = fs.transform_skull(source_path, target_path);
+  if(!good){
+    vcl_cout << "ERROR: invalid path given to transform_skull: " << __FILE__ << __LINE__ << vcl_endl;
+    return -1;
+  }
+
   return 0;
 }
 

--- a/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_composite_head_model.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_composite_head_model.cxx
@@ -60,13 +60,11 @@ void boxm2_vecf_ocl_composite_head_model::map_to_target(boxm2_scene_sptr target)
 {
   //  vcl_cout << "@@@@@@@@@@@@@@@  clearing and re-mapping head model " << vcl_endl;
   // clear target
-  bool need_to_clear_cache  = false;
 
   if (boxm2_vecf_ocl_head_model::intrinsic_change_){
     this->clear_target(target);
   // head model
     boxm2_vecf_ocl_head_model::map_to_target(target);
-    need_to_clear_cache = true;
   }
   //orbit model
   right_orbit_.map_to_target(target);

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
@@ -472,10 +472,12 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
 
     // block everything to ensure the reading score
     status = clFinish(queue_);
+    check_val(status, MEM_FAILURE, " release N_INDEX failed on device " + gpu_->device_identifier() + error_to_string(status));
     // read score
     score_cl_mem_->read_to_buffer(queue_);
     //mu_cl_mem_->read_to_buffer(queue_);
     status = clFinish(queue_);
+    check_val(status, MEM_FAILURE, " release N_INDEX failed on device " + gpu_->device_identifier() + error_to_string(status));
     // count time
     if (is_grd_reg_ && is_sky_reg_)
       gpu_matcher_time += kernels_[identifier][0]->exec_time();

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_pass0_compile_results.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_pass0_compile_results.cxx
@@ -80,7 +80,6 @@ int main(int argc,  char** argv)
   if ( candidate_list().compare("") != 0) {
     vcl_cout << " candidate list = " <<  candidate_list() << vcl_endl;
     if ( vul_file::extension(candidate_list()).compare(".txt") == 0) {
-      is_candidate = true;
       volm_io::read_polygons(candidate_list(), cand_poly);
     }
     else {

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_post_process_p1_integration.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_post_process_p1_integration.cxx
@@ -136,12 +136,6 @@ int main(int argc, char** argv)
   // search for the top 30 scores
   for (unsigned i = 0; i < tiles.size(); i++) {
     unsigned zone_id;
-    if (i < 8 && i != 5) {
-      zone_id = 17;
-    }
-    else {
-      zone_id = 18;
-    }
     vcl_stringstream score_file;
     score_file << out() << "/ps_1_scores_tile_" << i << ".bin";
     if (!vul_file::exists(score_file.str()))
@@ -174,7 +168,7 @@ int main(int argc, char** argv)
       geo_hypo_folder = geo_hypo_folder_a();
     }
     else {
-      zone_id = 18;  geo_hypo_folder = geo_hypo_folder_b();
+      geo_hypo_folder = geo_hypo_folder_b();
     }
     // load associate geo_hypo
     vcl_stringstream file_name_pre;

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_change_scene_res_by_geo_cover_process.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_change_scene_res_by_geo_cover_process.cxx
@@ -161,7 +161,7 @@ bool boxm2_change_scene_res_by_geo_cover_process(bprb_func_process& pro)
           }
           else if ( (*img)(i,j) == volm_osm_category_io::GEO_AGRICULTURE_GENERAL || (*img)(i,j) == volm_osm_category_io::GEO_AGRICULTURE_GENERAL) {
             if (land_cover != volm_osm_category_io::GEO_URBAN) {
-              land_cover = volm_osm_category_io::GEO_AGRICULTURE_GENERAL;  ii = i;  jj = j;
+              land_cover = volm_osm_category_io::GEO_AGRICULTURE_GENERAL;
             }
           }
         }

--- a/contrib/brl/bseg/boxm2_multi/exe/boxm2_multi_render.cxx
+++ b/contrib/brl/bseg/boxm2_multi/exe/boxm2_multi_render.cxx
@@ -64,10 +64,15 @@ void test_render_expected_images(boxm2_scene_sptr scene,
 
     //if scene has RGB data type, use color render process
     bool good = true;
-    if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) )
+    if (scene->has_data_type(boxm2_data_traits<BOXM2_GAUSS_RGB>::prefix()) ) {
       good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedColorProcess");
-    else
+    }
+    else {
       good = bprb_batch_process_manager::instance()->init_process("boxm2OclRenderExpectedImageProcess");
+    }
+    if ( !good ) {
+      vcl_cout << "ERROR: couldn't start color render process: " << __FILE__ << __LINE__ << vcl_endl;
+    }
 
     //set process args
     good = good && bprb_batch_process_manager::instance()->set_input(0, brdb_device) // device
@@ -77,10 +82,17 @@ void test_render_expected_images(boxm2_scene_sptr scene,
                 && bprb_batch_process_manager::instance()->set_input(4, brdb_ni)     // ni for rendered image
                 && bprb_batch_process_manager::instance()->set_input(5, brdb_nj)     // nj for rendered image
                 && bprb_batch_process_manager::instance()->run_process();
+    if ( !good ) {
+      vcl_cout << "ERROR: couldn't set process args: " << __FILE__ << __LINE__ << vcl_endl;
+    }
 
     //grab vil_image_view_base_sptr from process
     unsigned int out_img = 0;
     good = good && bprb_batch_process_manager::instance()->commit_output(0, out_img);
+    if ( !good ) {
+      vcl_cout << "ERROR: couldn't commit output: " << __FILE__ << __LINE__ << vcl_endl;
+    }
+
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, out_img);
     brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
     if (S->size()!=1) {
@@ -122,7 +134,6 @@ int main(int argc,  char** argv)
 
   if (numGPU() > mgr.gpus_.size()) {
     vcl_cout<<"-numGPU ("<<numGPU()<<") is too big, only "<<mgr.gpus_.size()<<" available"<<vcl_endl;
-    return -1;
   }
   //make a multicache
   vcl_vector<bocl_device_sptr> gpus;

--- a/contrib/brl/bseg/bstm/bstm_block.cxx
+++ b/contrib/brl/bseg/bstm/bstm_block.cxx
@@ -83,7 +83,6 @@ bool bstm_block::init_empty_block(bstm_block_metadata data)
                                         sub_block_num_.y(),
                                         sub_block_num_.z(),
                                         treesBuff);
-  bytes_read += sizeof(uchar16)*sub_block_num_.x()*sub_block_num_.y()*sub_block_num_.z();
 
   //--- Now initialize blocks and their pointers --------- ---------------------
   //6. initialize blocks in order

--- a/contrib/brl/bseg/bstm/bstm_scene_parser.cxx
+++ b/contrib/brl/bseg/bstm/bstm_scene_parser.cxx
@@ -29,19 +29,23 @@ bool bstm_scene_parser::lvcs(vpgl_lvcs& lvcs)
   vpgl_lvcs::cs_names cs_name = vpgl_lvcs::str_to_enum(lvcs_cs_name_.data());
   vpgl_lvcs::LenUnits len_unit;
   vpgl_lvcs::AngUnits geo_unit;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0)
+   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "feet")==0) {
      len_unit = vpgl_lvcs::FEET;
-   if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0)
+   }
+   else if (vcl_strcmp(lvcs_XYZ_unit_.data(), "meters")==0) {
      len_unit = vpgl_lvcs::METERS;
+   }
    else {
      vcl_cout << "LVCS Length Unit " << lvcs_XYZ_unit_ << " is not valid\n";
      return false;
    }
 
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0)
+   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "radians")==0) {
      geo_unit = vpgl_lvcs::RADIANS;
-   if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0)
+   }
+   else if (vcl_strcmp(lvcs_geo_angle_unit_.data(), "degrees")==0) {
      geo_unit = vpgl_lvcs::DEG;
+   }
    else {
      vcl_cout << "LVCS Geo Angle Unit " << lvcs_geo_angle_unit_ << " is not valid\n";
      return false;

--- a/contrib/brl/bseg/bstm/bstm_util.cxx
+++ b/contrib/brl/bseg/bstm/bstm_util.cxx
@@ -60,7 +60,6 @@ bool bstm_util::query_point_color(bstm_scene_sptr& scene,
       {
           data_type = apps[i];
           foundDataType = true;
-          appTypeSize = (int)bstm_data_info::datasize(bstm_data_traits<BSTM_GAUSS_RGB>::prefix());
       }
   }
 

--- a/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_particle_filter.cxx
+++ b/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_particle_filter.cxx
@@ -632,7 +632,6 @@ vcl_vector<double> bstm_ocl_particle_filter::eval_mi(unsigned prev_time, unsigne
     bocl_mem* alpha = opencl_cache_->get_data(relevant_blk_id, bstm_data_traits<BSTM_ALPHA>::prefix());
     bocl_mem* app = opencl_cache_->get_data(relevant_blk_id, bstm_data_traits<BSTM_MOG6_VIEW_COMPACT>::prefix());
     blk_info = opencl_cache_->loaded_block_info();
-    info_buffer = (bstm_scene_info*) blk_info->cpu_buffer();
 
     //opencl mem operations are done. begin kernel launches...
 

--- a/contrib/brl/bseg/bstm/util/bstm_cams_and_box_to_scene.cxx
+++ b/contrib/brl/bseg/bstm/util/bstm_cams_and_box_to_scene.cxx
@@ -104,6 +104,9 @@ void bstm_util_cams_and_box_to_scene (vcl_vector<CamType>& cams,
         good = good && vgl_intersection(ur, zp, urp);
         good = good && vgl_intersection(bl, zp, blp);
         good = good && vgl_intersection(br, zp, brp);
+        if (!good) {
+            vcl_cout << "ERROR: lines do not intersect" << __FILE__ << __LINE__ << vcl_endl;
+        }
 
         //convert the four corners into image coordinates
         typedef vgl_polygon<double>::point_t        Point_type;

--- a/contrib/brl/bseg/bvxm/bvxm_edge_ray_processor.cxx
+++ b/contrib/brl/bseg/bvxm/bvxm_edge_ray_processor.cxx
@@ -897,11 +897,11 @@ update_von_mises_edge_tangents(bvxm_image_metadata const& metadata,
             vgl_plane_3d<double> pl = cam->backproject(img_l);
             double pa = pl.a(), pb = pl.b(), pc = pl.c(), pd = pl.d();
             double nm = vcl_sqrt(pa*pa + pb*pb + pc*pc);
+#if 0
             pa/=nm;
             pb/=nm;
             pc/=nm;
             pd/=nm;
-#if 0
             dos << pa << ' ' << pb << ' ' << pc << ' ' << pd
                 << '\n' << vcl_flush;
 #endif

--- a/contrib/brl/bseg/sdet/sdet_sel_base.cxx
+++ b/contrib/brl/bseg/sdet/sdet_sel_base.cxx
@@ -3181,7 +3181,6 @@ void sdet_sel_base::Construct_Hypothesis_Tree()
                     curve_frag_graph_.CFTG.insert_fragment(new_chain6a);
                     }
                   p2=0;
-                  p16=0;
                   p3=0;
                   }
               }

--- a/core/vil/file_formats/vil_png.cxx
+++ b/core/vil/file_formats/vil_png.cxx
@@ -386,11 +386,6 @@ bool vil_png_image::read_header()
 
   png_color_8p sig_bit;
   if (png_get_valid(p_->png_ptr, p_->info_ptr, PNG_INFO_sBIT) && png_get_sBIT(p_->png_ptr, p_->info_ptr, &sig_bit)) {
-    png_byte max_bits = sig_bit->red;
-    max_bits = vcl_max( max_bits, sig_bit->green );
-    max_bits = vcl_max( max_bits, sig_bit->blue );
-    max_bits = vcl_max( max_bits, sig_bit->gray );
-    max_bits = vcl_max( max_bits, sig_bit->alpha );
     png_set_shift(p_->png_ptr, sig_bit);
   }
 


### PR DESCRIPTION
The clang static analyser produces many useful diagnostic warnings,
including "Value stored is never read". Most of the time these warnings
are a result of  messy code, or previous debugging statements, and have no
effect on the functionality of the code. However, sometimes these
warnings illusrate faulty logic, and appear when branches in the code
are mistakinly never taken. Ex:

vxl/contrib/brl/bseg/boxm/boxm_scene_parser.cxx|32 col 6|
warning: Value stored to 'len_unit' is never read
||      len_unit = vpgl_lvcs::FEET;