### PR TITLE
BUG: Match new/delete signatures for memory

### DIFF
--- a/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
+++ b/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
@@ -699,8 +699,8 @@ vil_image_view<float> bil_detect_compass_edges(vil_image_view<vxl_byte>& image,
 
   // garbage collection
   delete mask;
-  delete masksum;
-  delete wHist;
+  delete [] masksum;
+  delete [] wHist;
   delete dist;
   vil_image_view<float> magimg=NMS.mag();
 

--- a/contrib/brl/bbas/bmsh3d/algo/bmsh3d_mesh_tri.cxx
+++ b/contrib/brl/bbas/bmsh3d/algo/bmsh3d_mesh_tri.cxx
@@ -136,7 +136,7 @@ bool Triangulate::Process(const Vector2dVector &contour,Vector2dVector &result)
     }
   }
 
-  delete V;
+  delete [] V;
 
   return true;
 }

--- a/contrib/brl/bseg/brip/brip_vil_float_ops.cxx
+++ b/contrib/brl/bseg/brip/brip_vil_float_ops.cxx
@@ -361,7 +361,7 @@ brip_vil_float_ops::gaussian(vil_image_view<float> const& input, float sigma,
       for (unsigned i = 0; i<ni; ++i)
         dest(i,j,p) = plane(i,j);
   }
-  delete ker;
+  delete [] ker;
   return dest;
 }
 

--- a/core/vgui/tests/test_image_tableau.cxx
+++ b/core/vgui/tests/test_image_tableau.cxx
@@ -46,7 +46,7 @@ static void test_image_tableau(int argc, char* argv[])
     }
     TEST( "Contents are correct", okay, true);
 
-    delete img1_buf;
+    delete [] img1_buf;
     delete img2_buf;
   }
 }

--- a/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
@@ -145,7 +145,7 @@ static int geostr_to_double(const char* in_string, double* val, vpgl_nitf_ration
     vcl_strncpy(temp,in_string-length,length);
     if ( (fsec = (float)vcl_atof(temp)) >= 60.0f || fsec<0.0f)
       return 0;
-    delete temp;
+    delete [] temp;
 
     //go past '"' and any spaces to the direction
     ++in_string;
@@ -189,7 +189,7 @@ static int geostr_to_double(const char* in_string, double* val, vpgl_nitf_ration
     vcl_strncpy(temp,in_string-length,length);
     *val = vcl_atof(temp);
     if (vcl_fabs(*val)>float(maxval)) return 0;
-    delete temp;
+    delete [] temp;
 
     ++in_string;
 


### PR DESCRIPTION
warning: Memory allocated by 'new[]' should be deallocated by
'delete[]', not 'delete' [clang-analyzer-unix.MismatchedDeallocator]

for i in $(cat /tmp/xx ); do
  clang-tidy -p ~/src/vxl-bld/ $i \
        -checks=-*,clang-analyzer-unix.MismatchedDeallocator -fix;
done |tee ../warning_list.txt 2>&1