### PR TITLE
ENH: Add vxl_add_library for contrib/mul

### DIFF
--- a/contrib/mul/clsfy/CMakeLists.txt
+++ b/contrib/mul/clsfy/CMakeLists.txt
@@ -52,9 +52,7 @@ set(clsfy_sources
 
 aux_source_directory(Templates clsfy_sources)
 
-add_library(clsfy ${clsfy_sources})
-install_targets(/lib clsfy)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/clsfy ${clsfy_sources})
+vxl_add_library( LIBNAME clsfy LIBSRCS ${clsfy_sources})
 target_link_libraries(clsfy vpdfl mbl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vul)
 
 if(BUILD_TESTING)

--- a/contrib/mul/fhs/CMakeLists.txt
+++ b/contrib/mul/fhs/CMakeLists.txt
@@ -12,7 +12,7 @@ set(fhs_sources
 )
 aux_source_directory(Templates fhs_sources)
 
-add_library(fhs ${fhs_sources})
+vxl_add_library( LIBNAME fhs LIBSRCS ${fhs_sources})
 target_link_libraries(fhs vimt ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vsl)
 
 if(BUILD_TESTING)

--- a/contrib/mul/ipts/CMakeLists.txt
+++ b/contrib/mul/ipts/CMakeLists.txt
@@ -15,9 +15,7 @@ set(ipts_sources
     ipts_orientation_pyramid.cxx ipts_orientation_pyramid.h
 )
 
-add_library(ipts ${ipts_sources})
-install_targets(/lib ipts)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/ipts ${ipts_sources})
+vxl_add_library( LIBNAME ipts LIBSRCS ${ipts_sources})
 target_link_libraries(ipts vimt_algo vimt ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil)
 
 if(BUILD_MUL_TOOLS)

--- a/contrib/mul/m23d/CMakeLists.txt
+++ b/contrib/mul/m23d/CMakeLists.txt
@@ -20,7 +20,7 @@ set(m23d_sources
 )
 aux_source_directory(Templates m23d_sources)
 
-add_library(m23d ${m23d_sources})
+vxl_add_library( LIBNAME m23d LIBSRCS ${m23d_sources})
 target_link_libraries(m23d mbl)
 
 if(BUILD_TESTING)

--- a/contrib/mul/mbl/CMakeLists.txt
+++ b/contrib/mul/mbl/CMakeLists.txt
@@ -120,11 +120,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set_source_files_properties(Templates/mbl_data_wrapper_mixer+vnl_vector+double--.cxx PROPERTIES COMPILE_FLAGS -O0)
 endif()
 
-add_library(mbl ${mbl_sources})
+vxl_add_library( LIBNAME mbl LIBSRCS ${mbl_sources})
 target_link_libraries(mbl ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vbl)
-
-install_targets(/lib mbl)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/mbl ${mbl_sources})
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/contrib/mul/mcal/CMakeLists.txt
+++ b/contrib/mul/mcal/CMakeLists.txt
@@ -21,7 +21,7 @@ set(mcal_sources
 )
 aux_source_directory(Templates mcal_sources)
 
-add_library(mcal ${mcal_sources})
+vxl_add_library( LIBNAME mcal LIBSRCS ${mcal_sources})
 target_link_libraries(mcal mbl)
 
 if(BUILD_TESTING)

--- a/contrib/mul/mfpf/CMakeLists.txt
+++ b/contrib/mul/mfpf/CMakeLists.txt
@@ -69,7 +69,7 @@ set(mfpf_sources
 )
 
 aux_source_directory(Templates mfpf_sources)
-add_library(mfpf ${mfpf_sources} )
+vxl_add_library( LIBNAME mfpf LIBSRCS ${mfpf_sources} )
 target_link_libraries(mfpf clsfy mipa)
 
 if(BUILD_MUL_TOOLS)

--- a/contrib/mul/mipa/CMakeLists.txt
+++ b/contrib/mul/mipa/CMakeLists.txt
@@ -22,7 +22,7 @@ set(mipa_sources
 )
 
 aux_source_directory(Templates mipa_sources)
-add_library(mipa ${mipa_sources} )
+vxl_add_library( LIBNAME mipa LIBSRCS ${mipa_sources} )
 target_link_libraries(mipa vimt vpdfl)
 
 if(BUILD_MUL_TOOLS)

--- a/contrib/mul/mmn/CMakeLists.txt
+++ b/contrib/mul/mmn/CMakeLists.txt
@@ -27,7 +27,7 @@ set(mmn_sources
 )
 aux_source_directory(Templates mmn_sources)
 
-add_library(mmn ${mmn_sources})
+vxl_add_library( LIBNAME mmn LIBSRCS ${mmn_sources})
 target_link_libraries(mmn mbl)
 
 if(BUILD_TESTING)

--- a/contrib/mul/msdi/CMakeLists.txt
+++ b/contrib/mul/msdi/CMakeLists.txt
@@ -16,7 +16,7 @@ set(msdi_sources
 
 #aux_source_directory(Templates msdi_sources)
 
-add_library(msdi ${msdi_sources})
+vxl_add_library( LIBNAME msdi LIBSRCS ${msdi_sources})
 target_link_libraries(msdi msm)
 
 if(BUILD_TESTING)

--- a/contrib/mul/msm/CMakeLists.txt
+++ b/contrib/mul/msm/CMakeLists.txt
@@ -40,7 +40,7 @@ set(msm_sources
 )
 
 aux_source_directory(Templates msm_sources)
-add_library(msm ${msm_sources} )
+vxl_add_library( LIBNAME msm LIBSRCS ${msm_sources} )
 target_link_libraries(msm mcal vimt)
 
 add_subdirectory(utils)

--- a/contrib/mul/msm/utils/CMakeLists.txt
+++ b/contrib/mul/msm/utils/CMakeLists.txt
@@ -15,7 +15,7 @@ set(msm_utils_sources
 )
 
 # aux_source_directory(Templates msm_utils_sources)
-add_library(msm_utils ${msm_utils_sources} )
+vxl_add_library( LIBNAME msm_utils LIBSRCS ${msm_utils_sources} )
 target_link_libraries(msm_utils msm ${VXL_LIB_PREFIX}vgl)
 
 if( BUILD_TESTING)

--- a/contrib/mul/mvl2/CMakeLists.txt
+++ b/contrib/mul/mvl2/CMakeLists.txt
@@ -51,9 +51,7 @@ else()
   set(AVIFILE_LIBRARIES "")
 endif()
 
-add_library(mvl2 ${mvl2_sources})
-install_targets(/lib mvl2)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/mvl2 ${mvl2_sources})
+vxl_add_library( LIBNAME mvl2 LIBSRCS ${mvl2_sources})
 target_link_libraries( mvl2 ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${AVIFILE_LIBRARIES} )
 
 if(AVIFILE_FOUND)

--- a/contrib/mul/pdf1d/CMakeLists.txt
+++ b/contrib/mul/pdf1d/CMakeLists.txt
@@ -48,9 +48,7 @@ set(pdf1d_sources
 
 aux_source_directory(Templates pdf1d_sources)
 
-add_library(pdf1d ${pdf1d_sources})
-install_targets(/lib pdf1d)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/pdf1d ${pdf1d_sources})
+vxl_add_library( LIBNAME pdf1d LIBSRCS ${pdf1d_sources})
 target_link_libraries( pdf1d mbl ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vsl )
 
 if(BUILD_MUL_TOOLS)

--- a/contrib/mul/vil3d/CMakeLists.txt
+++ b/contrib/mul/vil3d/CMakeLists.txt
@@ -48,11 +48,8 @@ set(vil3d_sources
 )
 aux_source_directory(Templates vil3d_sources)
 
-add_library(vil3d ${vil3d_sources})
+vxl_add_library( LIBNAME vil3d LIBSRCS ${vil3d_sources})
 target_link_libraries( vil3d ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vcl ${VXL_LIB_PREFIX}vnl )
-
-install_targets(/lib vil3d)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vil3d ${vil3d_sources})
 
 add_subdirectory(algo)
 add_subdirectory(io)

--- a/contrib/mul/vil3d/algo/CMakeLists.txt
+++ b/contrib/mul/vil3d/algo/CMakeLists.txt
@@ -36,9 +36,7 @@ set(vil3d_algo_sources
 
 aux_source_directory(Templates vil3d_algo_sources)
 
-add_library(vil3d_algo ${vil3d_algo_sources})
-install_targets(/lib vil3d_algo)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vil3d/algo ${vil3d_algo_sources})
+vxl_add_library( LIBNAME vil3d_algo LIBSRCS ${vil3d_algo_sources})
 target_link_libraries( vil3d_algo vil3d ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl )
 
 if( BUILD_TESTING )

--- a/contrib/mul/vil3d/io/CMakeLists.txt
+++ b/contrib/mul/vil3d/io/CMakeLists.txt
@@ -6,9 +6,7 @@ set(vil3d_io_sources
     vil3d_io_dummy.cxx
 )
 
-add_library(vil3d_io ${vil3d_io_sources})
-install_targets(/lib vil3d_io)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vil3d/io ${vil3d_io_sources})
+vxl_add_library( LIBNAME vil3d_io LIBSRCS ${vil3d_io_sources})
 target_link_libraries( vil3d_io vil3d ${VXL_LIB_PREFIX}vil_io )
 
 if( BUILD_TESTING)

--- a/contrib/mul/vimt/CMakeLists.txt
+++ b/contrib/mul/vimt/CMakeLists.txt
@@ -34,9 +34,7 @@ set(vimt_sources
 )
 aux_source_directory(Templates vimt_sources)
 
-add_library(vimt ${vimt_sources})
-install_targets(/lib vimt)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vimt ${vimt_sources})
+vxl_add_library( LIBNAME vimt LIBSRCS ${vimt_sources})
 target_link_libraries(vimt mbl ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil )
 
 add_subdirectory(algo)

--- a/contrib/mul/vimt/algo/CMakeLists.txt
+++ b/contrib/mul/vimt/algo/CMakeLists.txt
@@ -10,9 +10,7 @@ set( vimt_algo_sources
   vimt_dummy.cxx
 )
 
-add_library(vimt_algo ${vimt_algo_sources})
-install_targets(/lib vimt_algo)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vimt/algo ${vimt_algo_sources})
+vxl_add_library( LIBNAME vimt_algo LIBSRCS ${vimt_algo_sources})
 target_link_libraries( vimt_algo vimt ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vcl )
 
 if( BUILD_TESTING )

--- a/contrib/mul/vimt3d/CMakeLists.txt
+++ b/contrib/mul/vimt3d/CMakeLists.txt
@@ -33,9 +33,7 @@ set(vimt3d_sources
 
 aux_source_directory(Templates vimt3d_sources)
 
-add_library(vimt3d ${vimt3d_sources})
-install_targets(/lib vimt3d)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vimt3d ${vimt3d_sources})
+vxl_add_library( LIBNAME vimt3d LIBSRCS ${vimt3d_sources})
 target_link_libraries(vimt3d vil3d_algo vil3d_io vil3d vimt mbl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vul)
 
 if(BUILD_TESTING)

--- a/contrib/mul/vpdfl/CMakeLists.txt
+++ b/contrib/mul/vpdfl/CMakeLists.txt
@@ -36,9 +36,7 @@ set(vpdfl_sources
 
 aux_source_directory(Templates vpdfl_sources)
 
-add_library(vpdfl ${vpdfl_sources})
-install_targets(/lib vpdfl)
-INSTALL_NOBASE_HEADER_FILES(/include/vxl/contrib/mul/vpdfl ${vpdfl_sources})
+vxl_add_library( LIBNAME vpdfl LIBSRCS ${vpdfl_sources})
 target_link_libraries(vpdfl mbl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vul)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Extends previous work for core libraries
to the contrib/mul directories.

There was much redundant code needed to setup
the installation of libraries in a way compatible
for external applications.  This redundant code
was consolidated into a macro that can be consistently
applied.