### PR TITLE
COMP: Removes "Division by zero" Warnings

### DIFF
--- a/contrib/brl/bseg/bapl/bapl_keypoint_extractor.cxx
+++ b/contrib/brl/bseg/bapl/bapl_keypoint_extractor.cxx
@@ -372,6 +372,11 @@ bapl_lowe_orientation::orient_at( float x, float y, float scale,
   max *= 0.8f;
   for (unsigned int i=0; i<peaks.size(); ++i) {
     if (histogram[ peaks[i] ] > max) {
+      //check for zivide by zero condition
+      if (num_bins_ == 0) {
+        vcl_cerr << "ERROR: Division by 0" << vcl_endl;
+        throw 0;
+      }
       //parabolic interpolation
       float ypos = histogram[ (peaks[i]+1)%num_bins_ ];
       float yneg = histogram[ (peaks[i]-1)%num_bins_ ];
@@ -380,6 +385,7 @@ bapl_lowe_orientation::orient_at( float x, float y, float scale,
       float dx = 6.28319f/num_bins_;
       float angle = (float(peaks[i])+dy/d2y)*dx;
       orientations.push_back(angle);
+      
     }
   }
 }

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_export_oriented_point_cloud.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_export_oriented_point_cloud.cxx
@@ -60,6 +60,13 @@ export_oriented_point_cloud(boxm2_scene_sptr scene, boxm2_cache_sptr cache,
     vcl_size_t nobsTypeSize = boxm2_data_info::datasize(boxm2_data_traits<BOXM2_NUM_OBS_SINGLE_INT>::prefix());
     vcl_size_t raydirTypeSize = boxm2_data_info::datasize(boxm2_data_traits<BOXM2_RAY_DIR>::prefix());
 
+    // check for invalid parameters
+    if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     boxm2_data_base * alpha =        cache->get_data_base(scene, id,boxm2_data_traits<BOXM2_ALPHA>::prefix());
     int data_buff_length    = (int) (alpha->buffer_length()/alphaTypeSize);
 

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_export_oriented_point_cloud_function.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_export_oriented_point_cloud_function.cxx
@@ -28,6 +28,13 @@ void boxm2_export_oriented_point_cloud_function::exportPointCloudXYZ(const boxm2
 
   file << vcl_fixed;
   int pointTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_POINT>::prefix());
+  //check for invalid parameters
+  if( pointTypeSize == 0 ) //This should never happen, it will result in division by zero later
+  {
+    vcl_cerr << "ERROR: Division by zero in " << __FILE__ << __LINE__ << vcl_endl;
+    throw 0;
+  }
+
   for (unsigned currIdx=0; currIdx < (points->buffer_length()/pointTypeSize) ; currIdx++) {
     //check normal magnitude and vis score and that point data is valid
     if (normals_data[currIdx][3] >= nmag_t && vis_data[currIdx] >= vis_t && points_data[currIdx][3] != -1)
@@ -70,6 +77,13 @@ void boxm2_export_oriented_point_cloud_function::exportPointCloudPLY(const boxm2
 
   file << vcl_fixed;
   int pointTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_POINT>::prefix());
+  //check for invalid parameters
+  if( pointTypeSize == 0 ) //This should never happen, it will result in division by zero later
+  {
+    vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    throw 0;
+  }
+
   for (unsigned currIdx=0; currIdx < (points->buffer_length()/pointTypeSize) ; currIdx++) {
     //check normal magnitude and vis score and that point data is valid
     if (normals_data[currIdx][3] >= nmag_t && vis_data[currIdx] >= vis_t && points_data[currIdx][3] != -1)
@@ -108,6 +122,13 @@ void boxm2_export_oriented_point_cloud_function::exportPointCloudPLY(const boxm2
 
   file << vcl_fixed;
   int pointTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_POINT>::prefix());
+  //check for invalid parameters
+  if( pointTypeSize == 0 ) //This should never happen, it will result in division by zero later
+  {
+    vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    throw 0;
+  }
+
   for (unsigned currIdx=0; currIdx < (points->buffer_length()/pointTypeSize) ; currIdx++) {
     //check if the point data is valid
     //if (covs_data[currIdx][0] >= 0.0)
@@ -148,6 +169,12 @@ void boxm2_export_oriented_point_cloud_function::exportColorPointCloudPLY(const 
     boxm2_data_traits<BOXM2_ALPHA>::datatype     *   alpha_data   = (boxm2_data_traits<BOXM2_ALPHA>::datatype*) alpha->data_buffer();
     file << vcl_fixed;
     int pointTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_POINT>::prefix());
+    //check for invalid parameters
+    if( pointTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+        vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        throw 0;
+    }
     for (unsigned currIdx=0; currIdx < (points->buffer_length()/pointTypeSize) ; currIdx++) {
         float prob = 0.0f;
         if (!calculateProbOfPoint(scene, blk, points_data[currIdx], alpha_data[currIdx], prob))

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_extract_point_cloud.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_extract_point_cloud.cxx
@@ -25,6 +25,12 @@ bool boxm2_extract_point_cloud::extract_point_cloud(boxm2_scene_sptr scene, boxm
     vcl_size_t alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
     vcl_size_t pointTypeSize = boxm2_data_info::datasize(boxm2_data_traits<BOXM2_POINT>::prefix());
 
+    if( alphaTypeSize == 0 ) //this should never happen, it results in division by 0 in later calculations
+    {
+      vcl_cout << "ERROR alphaTypeSize == 0 " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     boxm2_data_base * points= cache->get_data_base(scene, id,boxm2_data_traits<BOXM2_POINT>::prefix(), (alpha->buffer_length() /alphaTypeSize) * pointTypeSize, false);
 
     //3d array of trees

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.cxx
@@ -23,6 +23,13 @@ bool boxm2_merge_block_function::init_data(boxm2_block* blk, vcl_vector<boxm2_da
 
     //Data length now is constant
     int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+    // check for invalid parameters
+    if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     data_len_ = (int) (alph->buffer_length()/alphaTypeSize);
     alpha_   = (float*)   alph->data_buffer();
     mog_     = (uchar8*)  mog->data_buffer();

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_update_functions.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_update_functions.cxx
@@ -61,6 +61,13 @@ bool boxm2_update_cone_image(boxm2_scene_sptr & scene,
             boxm2_data_base *  nobs = cache->get_data_base(scene,*id,num_obs_type,0,false);
             int alphaTypeSize       = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_GAMMA>::prefix());
             int auxTypeSize         = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_AUX>::prefix());
+            // check for invalid parameters
+            if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+            {
+                vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+                return false;
+            }
+
             boxm2_data_base *  aux  = cache->get_data_base(scene,*id,boxm2_data_traits<BOXM2_AUX>::prefix(),alph->buffer_length()/alphaTypeSize*auxTypeSize);
 
             vcl_vector<boxm2_data_base*> datas;

--- a/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_compute_synoptic_function_1d_process.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_compute_synoptic_function_1d_process.cxx
@@ -72,6 +72,13 @@ bool boxm2_cpp_batch_compute_synoptic_function_1d_process(bprb_func_process& pro
     boxm2_synoptic_fucntion_1d_functor data_functor;
     data_functor.init_data(str_cache,alpha,cubic_model_data);
     int phongs_model_TypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_FLOAT8>::prefix());
+    // check for invalid parameters
+    if( phongs_model_TypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cout << "ERROR: phongs_model_TypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     int data_buff_length = (int) (cubic_model_data->buffer_length()/phongs_model_TypeSize);
 
     boxm2_data_leaves_serial_iterator<boxm2_synoptic_fucntion_1d_functor>(blk,data_buff_length,data_functor);

--- a/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_update_nonsurface_model_process.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_update_nonsurface_model_process.cxx
@@ -72,6 +72,13 @@ bool boxm2_cpp_batch_update_nonsurface_model_process(bprb_func_process& pro)
     boxm2_compute_empty_model_gradient_functor data_functor;
     data_functor.init_data(entropy_histo_air, str_cache);
     int histo_entropy_airTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_AUX0>::prefix());
+    // check for invalid parameters
+    if( histo_entropy_airTypeSize == 0 ) {
+    //This should never happen, it will result in division by zero later
+        vcl_cout << "ERROR: histo_entropy_airTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        return false;
+    }
+
     int data_buff_length  = (int)(entropy_histo_air->buffer_length()/histo_entropy_airTypeSize);
     boxm2_data_serial_iterator<boxm2_compute_empty_model_gradient_functor>(data_buff_length,data_functor);
 

--- a/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_update_opt2_phongs_processes.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_batch_update_opt2_phongs_processes.cxx
@@ -320,6 +320,13 @@ bool boxm2_cpp_batch_update_nonray_process(bprb_func_process& pro)
 
     // assumes that the data of each image has been created in the data models previously
     int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+    // check for invalid parameters
+    //This should never happen, it will result in division by zero later
+    if( alphaTypeSize == 0 ) {
+        vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        return false;
+    }
+
     // iterate the scene block by block and write to output
     vcl_vector<boxm2_block_id> blk_ids = scene->get_block_ids();
     vcl_vector<boxm2_block_id>::iterator id;

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_aggregate_normal_from_filter_vector.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_aggregate_normal_from_filter_vector.cxx
@@ -121,11 +121,25 @@ bool boxm2_ocl_aggregate_normal_from_filter_vector::run(bool clear_cache)
     bocl_mem* alpha     = ocl_cache_->get_data<BOXM2_ALPHA>(scene_,blk_iter->first,0,true);
     boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
     int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+    // check for invalid parameters
+    if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
     blk_info->write_to_buffer((queue));
 
     //store normals locations
     vcl_size_t normalsTypeSize = boxm2_data_info::datasize(boxm2_data_traits<BOXM2_NORMAL>::prefix());
+    // check for invalid parameters
+    if( normalsTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cout << "ERROR: normalsTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      return false;
+    }
+
     bocl_mem * normals    = ocl_cache_->get_data(scene_,id,boxm2_data_traits<BOXM2_NORMAL>::prefix(), info_buffer->data_buffer_length*normalsTypeSize,false);
 
     vcl_cout<<"MBs in cache: "<< (ocl_cache_->bytes_in_cache()/(1024.0*1024.0)) << vcl_endl;

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_change_detection.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_change_detection.cxx
@@ -1280,6 +1280,13 @@ bool boxm2_ocl_aux_pass_change::change_detect(vil_image_view<float>&    change_i
         // aux buffers (determine length first)
         boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
         int alphaTypeSize = (int) boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
         blk_info->write_to_buffer(queue);
 

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_cone_update_function.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_cone_update_function.cxx
@@ -151,6 +151,13 @@ float boxm2_ocl_adaptive_cone_update( boxm2_scene_sptr & scene,
         bocl_mem* alpha     = opencl_cache->get_data<BOXM2_GAMMA>(scene, *id,0,false);
         boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_GAMMA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
         blk_info->write_to_buffer((queue));
 

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_filter_scene_data.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_filter_scene_data.cxx
@@ -103,6 +103,12 @@ bool boxm2_ocl_filter_scene_data::apply_filter(int index)
         bocl_mem* alpha     = opencl_cache_->get_data<BOXM2_ALPHA>(scene_,id,0,false);
 
         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
 
                 vcl_size_t data_size = alpha->num_bytes()/alphaTypeSize;
                 bocl_mem * blk_info  = opencl_cache_->loaded_block_info();

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.cxx
@@ -51,6 +51,12 @@ void boxm2_ocl_paint_batch::paint_block( boxm2_scene_sptr           scene,
   boxm2_cache_sptr cache  = opencl_cache->get_cpu_cache();
   boxm2_data_base* alph   = cache->get_data_base(scene, id,boxm2_data_traits<BOXM2_ALPHA>::prefix(),0,false);
   int alphaTypeSize       = (int) boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+  // check for invalid parameters
+  if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+  {
+    vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    throw 0;
+  }
   int data_buff_length    = (int) (alph->buffer_length()/alphaTypeSize);
 
   //debuggers--------

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_refine_scene_around_geometry.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_refine_scene_around_geometry.cxx
@@ -194,6 +194,13 @@ boxm2_ocl_refine_scene_around_geometry
 
 
                         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+                        // check for invalid parameters
+                        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+                        {
+                                vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+                                return false;
+                        }
+
                         vcl_size_t data_size = data_in->num_bytes()/alphaTypeSize;
                         data_in->write_to_buffer(queue);
                         vcl_size_t labelTypeSize =  boxm2_data_info::datasize(boxm2_data_traits<BOXM2_LABEL_SHORT>::prefix());;

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_auxQ.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_auxQ.cxx
@@ -645,6 +645,13 @@ bool boxm2_ocl_update_PusingQ::compute_probability(boxm2_scene_sptr         scen
       bocl_mem* alpha     = opencl_cache->get_data<BOXM2_ALPHA>(scene,*id,0,false);
       boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
       int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+      // check for invalid parameters
+      if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+      {
+          vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+          return false;
+      }
+
       info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
       blk_info->write_to_buffer((queue));
       //grab an appropriately sized AUX data buffer

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_sky.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_sky.cxx
@@ -471,6 +471,13 @@ bool boxm2_ocl_update_sky2::update_sky2( boxm2_scene_sptr         scene,
         bocl_mem* alpha     = opencl_cache->get_data<BOXM2_ALPHA>(scene,*id,0,false);
         boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
         int auxTypeSize = boxm2_data_info::datasize(boxm2_data_traits<BOXM2_AUX0>::prefix());
         bocl_mem *aux0   = opencl_cache->get_data<BOXM2_AUX0>(scene,*id, info_buffer->data_buffer_length*auxTypeSize,false,"cum");

--- a/contrib/brl/bseg/boxm2/reg/ocl/boxm2_ocl_reg_mutual_info.cxx
+++ b/contrib/brl/bseg/boxm2/reg/ocl/boxm2_ocl_reg_mutual_info.cxx
@@ -141,6 +141,13 @@ bool boxm2_ocl_reg_mutual_info::boxm2_ocl_register_world(vgl_rotation_3d<double>
         bocl_mem* alpha_A     = opencl_cache_->get_data<BOXM2_ALPHA>(sceneA_, *iter_blks_A,0,false);
         boxm2_scene_info* info_buffer = sceneA_->get_blk_metadata(*iter_blks_A);
         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         info_buffer->data_buffer_length = (int) (alpha_A->num_bytes()/alphaTypeSize);
         bocl_mem* blk_info_A  = new bocl_mem(device_->context(), info_buffer, sizeof(boxm2_scene_info), " Scene Info" );
         blk_info_A->create_buffer(CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
@@ -173,6 +180,13 @@ bool boxm2_ocl_reg_mutual_info::boxm2_ocl_register_world(vgl_rotation_3d<double>
                bocl_mem* blk_B       = opencl_cache_->get_block(sceneB_, *iter_blks_B);
                bocl_mem* alpha_B     = opencl_cache_->get_data<BOXM2_ALPHA>(sceneB_, *iter_blks_B,0,false);
                int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+               // check for invalid parameters
+               if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+               {
+                   vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+                   return false;
+               }
+
                info_buffer_B->data_buffer_length = (int) (alpha_B->num_bytes()/alphaTypeSize);
 
                bocl_mem* blk_info_B  = new bocl_mem(device_->context(), info_buffer_B, sizeof(boxm2_scene_info), " Scene Info" );

--- a/contrib/brl/bseg/boxm2/reg/ocl/boxm2_ocl_reg_points_to_volume_mutual_info.cxx
+++ b/contrib/brl/bseg/boxm2/reg/ocl/boxm2_ocl_reg_points_to_volume_mutual_info.cxx
@@ -150,6 +150,13 @@ bool boxm2_ocl_reg_points_to_volume_mutual_info::boxm2_ocl_register_world(vgl_ro
         bocl_mem* blk_B       = opencl_cache_->get_block(sceneB_, *iter_blks_B);
         bocl_mem* alpha_B     = opencl_cache_->get_data<BOXM2_ALPHA>(sceneB_, *iter_blks_B,0,false);
         int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         info_buffer_B->data_buffer_length = (int) (alpha_B->num_bytes()/alphaTypeSize);
 
         bocl_mem* blk_info_B  = new bocl_mem(device_->context(), info_buffer_B, sizeof(boxm2_scene_info), " Scene Info" );

--- a/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_transform_scene.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_transform_scene.cxx
@@ -424,6 +424,13 @@ bool boxm2_vecf_ocl_transform_scene::transform_1_blk_interp(vgl_rotation_3d<doub
    blk_source       = opencl_cache_->get_block(source_scene_, *iter_blk_source);
    alpha_source     = opencl_cache_->get_data<BOXM2_ALPHA>(source_scene_, *iter_blk_source,0,true);
    int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+   // check for invalid parameters
+   if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+   {
+     vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+     return false;
+   }
+
    info_buffer_source->data_buffer_length = (int) (alpha_source->num_bytes()/alphaTypeSize);
 
    blk_info_source  = new bocl_mem(device_->context(), info_buffer_source, sizeof(boxm2_scene_info), " Scene Info" );
@@ -552,6 +559,13 @@ transform_1_blk_interp_trilin(boxm2_vecf_ocl_vector_field &vec_field,
   blk_source       = opencl_cache_->get_block(source_scene_, *iter_blk_source);
   alpha_source     = opencl_cache_->get_data<BOXM2_ALPHA>(source_scene_, *iter_blk_source,0,true);
   int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+  // check for invalid parameters
+  if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+  {
+    vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    return false;
+  }
+
   info_buffer_source->data_buffer_length = (int) (alpha_source->num_bytes()/alphaTypeSize);
   data_size = info_buffer_source->data_buffer_length;
 
@@ -712,6 +726,13 @@ bool boxm2_vecf_ocl_transform_scene::transform_1_blk_interp_trilin(boxm2_scene_s
    alpha_source     = opencl_cache_->get_data<BOXM2_ALPHA>  (source_scene_, *iter_blk_source,0,true);
 
    int alphaTypeSize = (int) boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+   // check for invalid parameters
+   if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+   {
+    vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    return false;
+   }
+
    info_buffer_source->data_buffer_length = (int) (alpha_source->num_bytes()/alphaTypeSize);
    vcl_size_t data_size_target = static_cast<vcl_size_t>(info_buffer_->data_buffer_length);
 

--- a/contrib/brl/bseg/boxm2_multi/algo/boxm2_multi_render.cxx
+++ b/contrib/brl/bseg/boxm2_multi/algo/boxm2_multi_render.cxx
@@ -477,6 +477,13 @@ float boxm2_multi_render::render_block( boxm2_scene_sptr& scene,
     bocl_mem* alpha     = opencl_cache->get_data<BOXM2_ALPHA>(id);
     int alphaTypeSize   = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
     // data type string may contain an identifier so determine the buffer size
+    // check for invalid parameters
+    if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+        vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        return false;
+    }
+
     bocl_mem* mog       = opencl_cache->get_data(id,data_type,alpha->num_bytes()/alphaTypeSize*apptypesize,true);
     float transfer_time = (float) transfer.all();
 

--- a/contrib/brl/bseg/boxm2_multi/algo/boxm2_multi_update_cell.cxx
+++ b/contrib/brl/bseg/boxm2_multi/algo/boxm2_multi_update_cell.cxx
@@ -295,6 +295,13 @@ float boxm2_multi_update_cell::calc_beta_reduce( boxm2_multi_cache& mcache,
       boxm2_scene_info* info_buffer = (boxm2_scene_info*) blk_info->cpu_buffer();
 
       int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+      // check for invalid parameters
+      if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+      {
+        vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        throw 0;
+      }
+
       info_buffer->data_buffer_length = (int) (alpha->num_bytes()/alphaTypeSize);
       blk_info->write_to_buffer(queues[i]);
       //grab mog
@@ -374,6 +381,13 @@ float boxm2_multi_update_cell::calc_beta_reduce( boxm2_multi_cache& mcache,
       //write alpha, mog and num obs to disk
       bocl_mem* alpha     = ocl_cache->get_data<BOXM2_ALPHA>(id,0,false);
       int alphaTypeSize = (int)boxm2_data_info::datasize(boxm2_data_traits<BOXM2_ALPHA>::prefix());
+      // check for invalid parameters
+      if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+      {
+        vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+        throw 0;
+      }
+
       vcl_size_t dataLen = (vcl_size_t) (alpha->num_bytes()/alphaTypeSize);
       bocl_mem* mog       = ocl_cache->get_data(id,data_type,dataLen*apptypesize,false);
       //numobs

--- a/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_change_detection.cxx
+++ b/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_change_detection.cxx
@@ -583,6 +583,13 @@ bool bstm_ocl_aux_pass_change::change_detect(vil_image_view<float>&    change_im
 
         //figure out sizes
         int alphaTypeSize = (int)bstm_data_info::datasize(bstm_data_traits<BSTM_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         int data_buffer_length = alpha->num_bytes() / alphaTypeSize;
         int num_time_trees = info_buffer_t->tree_buffer_length;
 
@@ -647,6 +654,13 @@ bool bstm_ocl_aux_pass_change::change_detect(vil_image_view<float>&    change_im
 
         //figure out sizes
         int alphaTypeSize = (int)bstm_data_info::datasize(bstm_data_traits<BSTM_ALPHA>::prefix());
+        // check for invalid parameters
+        if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+        {
+            vcl_cout << "ERROR: alphaTypeSize == 0 in " << __FILE__ << __LINE__ << vcl_endl;
+            return false;
+        }
+
         int data_buffer_length = alpha->num_bytes() / alphaTypeSize;
         int num_time_trees = info_buffer_t->tree_buffer_length;
 

--- a/contrib/brl/bseg/bvxm_bridge/bvxm_to_boxm2.cxx
+++ b/contrib/brl/bseg/bvxm_bridge/bvxm_to_boxm2.cxx
@@ -80,6 +80,12 @@ void initialize_regular_world_scene(boxm2_scene_sptr new_scene, boxm2_cache_sptr
     const boxm2_array_3d<uchar16> trees = cache->get_block(new_scene, id)->trees();
 
     boxm2_data_traits<BOXM2_ALPHA>::datatype * alpha_data = (boxm2_data_traits<BOXM2_ALPHA>::datatype*) alpha->data_buffer();
+    // check for invalid parameters
+    if( alphaTypeSize == 0 ) //This should never happen, it will result in division by zero later
+    {
+      vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      throw 0;
+    }
 
     vcl_cout << " alpha array size: " << alpha->buffer_length() /alphaTypeSize << vcl_endl; vcl_cout.flush();
 

--- a/contrib/gel/gevd/gevd_edgel_regions.cxx
+++ b/contrib/gel/gevd/gevd_edgel_regions.cxx
@@ -711,8 +711,14 @@ int gevd_edgel_regions::bytes_per_pix()
 {
   int bypp = 1;
   if (image_source_)
+  {
+    if ( image_ ->bits_per_component() == 0 )
+    {
+      vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+      throw 0;
+    }
     bypp = (image_->components() / image_->bits_per_component());
-
+  }
   if (buf_source_)
     bypp = buf_->GetBytesPixel();
   return bypp;

--- a/contrib/gel/vmal/vmal_dense_matching.cxx
+++ b/contrib/gel/vmal/vmal_dense_matching.cxx
@@ -336,6 +336,11 @@ void vmal_dense_matching::disparity_map(vmal_multi_view_data_edge_sptr mvd_edge,
   {
     for (int j=0; j<w; j++)
     {
+      if(max_disparity == 0 )
+      {
+        vcl_cerr << "Error: Divide by zero in " << __FILE__ << __LINE__ << vcl_endl;
+        throw 0;
+      }
       int value=vmal_round_int((map(j,i)-min_disparity)*255/max_disparity);
       buf[i*w+j]=(unsigned char)value;
     }

--- a/core/vil/vil_decimate.h
+++ b/core/vil/vil_decimate.h
@@ -25,6 +25,11 @@ inline vil_image_view<T> vil_decimate(const vil_image_view<T> &im, unsigned i_fa
 {
   if (j_factor==0) j_factor=i_factor;
   // use (n+d-1)/n instead of ceil((double)n/d) to calcualte sizes
+  if ( i_factor == 0 ) //Silence compiler "Division by zero" warning
+  {
+    vcl_cerr << "ERROR: Division by 0 in " << __FILE__ << __LINE__ << vcl_endl;
+    throw 0;
+  }
   return vil_image_view<T>(im.memory_chunk(), im.top_left_ptr(),
                            (im.ni()+i_factor-1u)/i_factor, (im.nj()+j_factor-1u)/j_factor, im.nplanes(),
                            im.istep()*i_factor, im.jstep()*j_factor, im.planestep());

--- a/core/vul/vul_psfile.cxx
+++ b/core/vul/vul_psfile.cxx
@@ -287,6 +287,11 @@ void vul_psfile::print_greyscale_image(unsigned char* buffer, int sizex, int siz
               index += int(*(buffer + (pixel_number+m+n*width)));
               ++number_of_pixels_sampled;
             }
+        if(number_of_pixels_sampled == 0)
+        {
+          vcl_cerr << "ERROR: Division by 0! " << __FILE__ << __LINE__ << vcl_endl;
+          throw 0;
+        }
         index/=number_of_pixels_sampled; // Average the pixel intensity value.
       }
 
@@ -443,6 +448,11 @@ void vul_psfile::print_color_image(unsigned char* data, int sizex, int sizey)
                 index += int(*(data+(pixel_number+(m+n*sizex)*bytes_per_pixel)));
                 ++number_of_pixels_sampled;
               }
+          if(number_of_pixels_sampled == 0)
+          {
+              vcl_cerr << "ERROR: Division by 0! " << __FILE__ << __LINE__ << vcl_endl;
+              throw 0;
+          }
           index/=number_of_pixels_sampled;  // average the pixel intensity
         }
 


### PR DESCRIPTION
The clang static analyser produces many useful diagnostic warnings,
including "Division by zero". These warnings arise when
variables are not checked to see if they are zero before being used
as divisors. Most of these warnings would never actually result in
division by zero in real world usage.