### PR TITLE
optimizer for position, orientation, and focal length  + better test coverage

### DIFF
--- a/core/vpgl/algo/tests/test_optimize_camera.cxx
+++ b/core/vpgl/algo/tests/test_optimize_camera.cxx
@@ -5,44 +5,19 @@
 #include <vgl/vgl_vector_3d.h>
 #include <vgl/vgl_homg_point_2d.h>
 #include <vgl/vgl_homg_point_3d.h>
+#include <vgl/vgl_distance.h>
 #include <vgl/algo/vgl_rotation_3d.h>
 #include <vpgl/algo/vpgl_optimize_camera.h>
 #include <vnl/vnl_double_3.h>
 #include <vnl/vnl_random.h>
 #include <vnl/vnl_math.h> // for pi
 
-static void test_optimize_camera()
-{
-  const double max_t_err = 100.0; // maximum translation error to introduce
-  const double max_r_err = vnl_math::pi/2; // maximum rotation error to introduce (radians)
-  const double max_p_err = 0.5; // maximum image error to introduce (pixels)
-
-  vcl_vector<vgl_homg_point_3d<double> > world;
-  world.push_back(vgl_homg_point_3d<double>(1.0, 0.0, 0.0));
-  world.push_back(vgl_homg_point_3d<double>(0.0, 1.0, 0.0));
-  world.push_back(vgl_homg_point_3d<double>(0.0, 0.0, 1.0));
-  world.push_back(vgl_homg_point_3d<double>(1.0, 1.0, 0.0));
-  world.push_back(vgl_homg_point_3d<double>(0.0, 1.0, 1.0));
-  world.push_back(vgl_homg_point_3d<double>(1.0, 0.0, 1.0));
-
-  vpgl_calibration_matrix<double> K(2000.0,vgl_homg_point_2d<double>(512,384));
-  vgl_homg_point_3d<double> c(10.0,10.0,10.0);
-  vnl_double_3 w = (vnl_math::pi - vcl_asin(vcl_sqrt(2.0/3.0)))/vcl_sqrt(2.0)*vnl_double_3(-1.0,1.0,0.0);
-  vgl_rotation_3d<double> R(w);
-  vpgl_perspective_camera<double> cam(K,c,R);
-
-  vcl_vector<vgl_point_2d<double> > image;
-  vnl_random rnd;
-  // project each point adding uniform noise in a [-max_p_err, max_p_err] pixel window
-  for (unsigned int i=0; i<world.size(); ++i){
-    vgl_homg_point_2d<double> hpt = cam(world[i]);
-    vgl_vector_2d<double> err(rnd.drand32()-0.5, rnd.drand32()-0.5);
-    err *= max_p_err;
-    image.push_back(vgl_point_2d<double>(hpt.x()/hpt.w(), hpt.y()/hpt.w())+err);
-    vcl_cout <<  err << '\t'
-             <<  vgl_point_2d<double>(hpt.x()/hpt.w(), hpt.y()/hpt.w()) << vcl_endl;
-  }
-  vcl_cout << cam << vcl_endl;
+void test_opt_orient_pos(vpgl_perspective_camera<double> const& cam,
+                         vcl_vector<vgl_homg_point_3d<double> > const& world,
+                         vcl_vector<vgl_point_2d<double> > const& image,
+                         vnl_random &rnd) {
+  const double max_t_err = 10.0; // maximum translation error to introduce
+  const double max_r_err = vnl_math::pi/4; // maximum rotation error to introduce (radians)
 
   // select a random rotation axis
   vnl_double_3 dw = (vnl_double_3(rnd.drand32(), rnd.drand32(), rnd.drand32())-0.5).normalize();
@@ -55,6 +30,12 @@ static void test_optimize_camera()
   vcl_cout << "Initial position:" << cam.get_camera_center() << vcl_endl
            << "Initial principal ray:" << cam.principal_axis() << vcl_endl;
 
+  vgl_point_3d<double> c = cam.get_camera_center();
+  vpgl_calibration_matrix<double> K = cam.get_calibration();
+  vgl_rotation_3d<double> R = cam.get_rotation();
+
+  vgl_point_3d<double> new_center = c + max_t_err*dc;
+  std::cout << "new center = " << new_center << std::endl;
   vpgl_perspective_camera<double> err_cam(K,c+max_t_err*dc,dR*R);
   vcl_cout << "Perturbed position:" << err_cam.get_camera_center() << vcl_endl
            << "Perturbed principal ray:" << err_cam.principal_axis() << vcl_endl;
@@ -63,6 +44,104 @@ static void test_optimize_camera()
 
   vcl_cout << "Estimated position:" << opt_cam.get_camera_center() << vcl_endl
            << "Estimated principal ray:" << opt_cam.principal_axis() << vcl_endl;
+
+  double dist = vgl_distance(opt_cam.get_camera_center(), cam.get_camera_center());
+  TEST_NEAR("opt_orient_pos: position", dist, 0, 0.25);
+
+  double cos_angle = dot_product( opt_cam.principal_axis(), cam.principal_axis() );
+  if (cos_angle > 1) { cos_angle = 1; }
+  double angle = std::acos( cos_angle );
+  TEST_NEAR("opt_orient_pos: principal_axis", angle, 0, 0.1);
+}
+
+void test_opt_orient_pos_f(vpgl_perspective_camera<double> const& cam,
+                           vcl_vector<vgl_homg_point_3d<double> > const& world,
+                           vcl_vector<vgl_point_2d<double> > const& image,
+                           vnl_random &rnd) {
+
+  const double max_t_err = 0;//10.0; // maximum translation error to introduce
+  const double max_r_err = 0;//vnl_math::pi/4; // maximum rotation error to introduce (radians)
+  const double max_f_err = 100.0;
+
+  // select a random rotation axis
+  vnl_double_3 dw = (vnl_double_3(rnd.drand32(), rnd.drand32(), rnd.drand32())-0.5).normalize();
+  // select a random rotation angle
+  dw *= max_r_err * rnd.drand32();
+  vgl_rotation_3d<double> dR(dw);
+
+  vgl_vector_3d<double> dc(rnd.drand32()-0.5, rnd.drand32()-0.5, rnd.drand32()-0.5);
+
+  vcl_cout << "Initial position:" << cam.get_camera_center() << vcl_endl
+           << "Initial principal ray:" << cam.principal_axis() << vcl_endl
+           << "Initial focal length:" << cam.get_calibration().focal_length() << vcl_endl;
+
+  vgl_point_3d<double> c = cam.get_camera_center();
+  vpgl_calibration_matrix<double> K = cam.get_calibration();
+  vgl_rotation_3d<double> R = cam.get_rotation();
+
+  vgl_point_3d<double> new_center = c + max_t_err*dc;
+  std::cout << "new center = " << new_center << std::endl;
+  vpgl_perspective_camera<double> err_cam(K,c+max_t_err*dc,dR*R);
+  vcl_cout << "Perturbed position:" << err_cam.get_camera_center() << vcl_endl
+           << "Perturbed principal ray:" << err_cam.principal_axis() << vcl_endl
+           << "Perturbed focal length:" << err_cam.get_calibration().focal_length() << vcl_endl;
+
+  vpgl_perspective_camera<double> opt_cam = vpgl_optimize_camera::opt_orient_pos_f(err_cam,world,image);
+
+  vcl_cout << "Estimated position:" << opt_cam.get_camera_center() << vcl_endl
+           << "Estimated principal ray:" << opt_cam.principal_axis() << vcl_endl
+           << "Estimated focal length:" << opt_cam.get_calibration().focal_length() << vcl_endl;
+
+  double dist = vgl_distance(opt_cam.get_camera_center(), cam.get_camera_center());
+  TEST_NEAR("opt_orient_pos_f: position", dist, 0, 0.25);
+
+  double cos_angle = dot_product( opt_cam.principal_axis(), cam.principal_axis() );
+  if (cos_angle > 1) { cos_angle = 1; }
+  double angle = std::acos( cos_angle );
+  TEST_NEAR("opt_orient_pos_f: principal_axis", angle, 0, 0.1);
+
+  double f_opt = opt_cam.get_calibration().focal_length();
+  double f_cam = cam.get_calibration().focal_length();
+  TEST_NEAR_REL("opt_orient_pos_f: focal_len", f_opt, f_cam, 0.1);
+}
+
+static void test_optimize_camera()
+{
+  const double max_p_err = 0.25; // maximum image error to introduce (pixels)
+
+  vcl_vector<vgl_homg_point_3d<double> > world;
+  double side_len = 1.0;
+  world.push_back(vgl_homg_point_3d<double>(0.0,0.0,0.0));
+  world.push_back(vgl_homg_point_3d<double>(0.0, 0.0, side_len));
+  world.push_back(vgl_homg_point_3d<double>(0.0, side_len, 0.0));
+  world.push_back(vgl_homg_point_3d<double>(0.0, side_len, side_len));
+  world.push_back(vgl_homg_point_3d<double>(side_len, 0.0, 0.0));
+  world.push_back(vgl_homg_point_3d<double>(side_len, 0.0, side_len));
+  world.push_back(vgl_homg_point_3d<double>(side_len, side_len, 0.0));
+  world.push_back(vgl_homg_point_3d<double>(side_len, side_len, side_len));
+
+  vpgl_calibration_matrix<double> K(2000.0,vgl_homg_point_2d<double>(512,384));
+  vgl_homg_point_3d<double> c(4.0,4.0,4.0);
+  vpgl_perspective_camera<double> cam(K,c,vgl_rotation_3d<double>());
+  // look at the center of the cube
+  cam.look_at(vgl_homg_point_3d<double>(side_len/2, side_len/2, side_len/2));
+
+  vcl_vector<vgl_point_2d<double> > image;
+  // seed with fixed number for repeatable results
+  vnl_random rnd(1234);
+  // project each point adding uniform noise in a [-max_p_err, max_p_err] pixel window
+  for (unsigned int i=0; i<world.size(); ++i){
+    vgl_homg_point_2d<double> hpt = cam(world[i]);
+    vgl_vector_2d<double> err(rnd.drand32()-0.5, rnd.drand32()-0.5);
+    err *= max_p_err;
+    image.push_back(vgl_point_2d<double>(hpt.x()/hpt.w(), hpt.y()/hpt.w())+err);
+    vcl_cout <<  err << '\t'
+             <<  vgl_point_2d<double>(hpt.x()/hpt.w(), hpt.y()/hpt.w()) << vcl_endl;
+  }
+  vcl_cout << cam << vcl_endl;
+
+  test_opt_orient_pos(cam, world, image, rnd);
+  test_opt_orient_pos_f(cam, world, image, rnd);
 }
 
 TESTMAIN(test_optimize_camera);

--- a/core/vpgl/algo/vpgl_optimize_camera.cxx
+++ b/core/vpgl/algo/vpgl_optimize_camera.cxx
@@ -150,6 +150,45 @@ vpgl_orientation_position_calibration_lsqr::f(vnl_vector<double> const& x, vnl_v
   }
 }
 
+//: Constructor
+vpgl_orientation_position_focal_lsqr::
+vpgl_orientation_position_focal_lsqr(const vpgl_calibration_matrix<double>& K_init,
+                                     const vcl_vector<vgl_homg_point_3d<double> >& world_points,
+                                     const vcl_vector<vgl_point_2d<double> >& image_points )
+ : vnl_least_squares_function(7,2*world_points.size(),no_gradient),
+   K_init_(K_init),
+   world_points_(world_points),
+   image_points_(image_points)
+{
+  assert(world_points_.size() == image_points_.size());
+}
+
+
+//: The main function.
+//  Given the parameter vector x, compute the vector of residuals fx.
+//  Fx has been sized appropriately before the call.
+//  The parameters in x are really two three component vectors {wx, wy, wz, tx, ty, tz}
+//  where w is the Rodrigues vector of the rotation and t is the translation.
+void
+vpgl_orientation_position_focal_lsqr::f(vnl_vector<double> const& x, vnl_vector<double>& fx)
+{
+  assert(x.size() == 7);
+  vnl_double_3 w(x[0], x[1], x[2]);
+  vgl_rotation_3d<double> R(w);
+  vgl_homg_point_3d<double> t(x[3], x[4], x[5]);
+
+  vpgl_calibration_matrix<double> K(K_init_);
+  K.set_focal_length(x[6]);
+  vpgl_perspective_camera<double> cam(K, t, R);
+  for (unsigned int i=0; i<world_points_.size(); ++i)
+  {
+    vgl_homg_point_2d<double> proj = cam(world_points_[i]);
+    fx[2*i]   = image_points_[i].x() - proj.x()/proj.w();
+    fx[2*i+1] = image_points_[i].y() - proj.y()/proj.w();
+  }
+}
+
+
 //===============================================================
 // Static functions for vpgl_optimize_camera
 //===============================================================
@@ -202,6 +241,39 @@ vpgl_optimize_camera::opt_orient_pos(const vpgl_perspective_camera<double>& came
 
   return vpgl_perspective_camera<double>(K, c_min, vgl_rotation_3d<double>(w_min) );
 }
+
+// optimize orientation, position, and focal length
+vpgl_perspective_camera<double>
+vpgl_optimize_camera::opt_orient_pos_f(const vpgl_perspective_camera<double>& camera,
+                                       const vcl_vector<vgl_homg_point_3d<double> >& world_points,
+                                       const vcl_vector<vgl_point_2d<double> >& image_points,
+                                       const double xtol, const unsigned nevals)
+{
+  const vpgl_calibration_matrix<double>& K = camera.get_calibration();
+  vgl_point_3d<double> c = camera.get_camera_center();
+  const vgl_rotation_3d<double>& R = camera.get_rotation();
+  vnl_double_3 w = R.as_rodrigues();
+
+  vpgl_orientation_position_focal_lsqr lsqr_func(K, world_points,image_points);
+  vnl_levenberg_marquardt lm(lsqr_func);
+
+  vnl_vector<double> params(7);
+  params[0]=w[0];  params[1]=w[1];  params[2]=w[2];
+  params[3]=c.x();  params[4]=c.y();  params[5]=c.z();
+  params[6]=K.focal_length();
+
+  //  lm.set_trace(true);
+  lm.set_x_tolerance(xtol);
+  lm.set_max_function_evals(nevals);
+  lm.minimize(params);
+  vnl_double_3 w_min(params[0],params[1],params[2]);
+  vgl_homg_point_3d<double> c_min(params[3], params[4], params[5]);
+  double f_min = params[6];
+  vpgl_calibration_matrix<double> K_min(K);
+  K_min.set_focal_length(f_min);
+  return vpgl_perspective_camera<double>(K_min, c_min, vgl_rotation_3d<double>(w_min));
+}
+
 // optimize all the parameters except internal skew
 vpgl_perspective_camera<double>
 vpgl_optimize_camera::opt_orient_pos_cal(const vpgl_perspective_camera<double>& camera,

--- a/core/vpgl/algo/vpgl_optimize_camera.h
+++ b/core/vpgl/algo/vpgl_optimize_camera.h
@@ -113,6 +113,40 @@ class vpgl_orientation_position_calibration_lsqr : public vnl_least_squares_func
   vcl_vector<vgl_point_2d<double> > image_points_;
 };
 
+//: this class optimizes the rotation/translation/focal length of a perspective camera given an initial estimate
+class vpgl_orientation_position_focal_lsqr : public vnl_least_squares_function
+{
+ public:
+  //: Constructor
+  // \note image points are not homogeneous because require finite points to measure projection error
+  vpgl_orientation_position_focal_lsqr(const vpgl_calibration_matrix<double>& K_init,
+                                       const vcl_vector<vgl_homg_point_3d<double> >& world_points,
+                                       const vcl_vector<vgl_point_2d<double> >& image_points );
+  //: Destructor
+  virtual ~vpgl_orientation_position_focal_lsqr() {}
+
+  //: The main function.
+  //  Given the parameter vector x, compute the vector of residuals fx.
+  //  Fx has been sized appropriately before the call.
+  //  The parameters in x are really two three component vectors {wx, wy, wz, tx, ty, tz}
+  //  where w is the Rodrigues vector of the rotation and t is the translation.
+  virtual void f(vnl_vector<double> const& x, vnl_vector<double>& fx);
+
+#if 0
+  //: Called after each LM iteration to print debugging etc.
+  virtual void trace(int iteration, vnl_vector<double> const& x, vnl_vector<double> const& fx);
+#endif
+
+ protected:
+  //: The initial calibration matrix
+  vpgl_calibration_matrix<double> K_init_;
+  //: The known points in the world
+  vcl_vector<vgl_homg_point_3d<double> > world_points_;
+  //: The corresponding points in the image
+  vcl_vector<vgl_point_2d<double> > image_points_;
+};
+
+
 
 class vpgl_optimize_camera
 {
@@ -130,6 +164,13 @@ class vpgl_optimize_camera
     opt_orient_pos(const vpgl_perspective_camera<double>& camera,
                    const vcl_vector<vgl_homg_point_3d<double> >& world_points,
                    const vcl_vector<vgl_point_2d<double> >& image_points );
+
+  //: optimize orientation, position and focal length for a perspective camera
+  static vpgl_perspective_camera<double>
+    opt_orient_pos_f(const vpgl_perspective_camera<double>& camera,
+                     const vcl_vector<vgl_homg_point_3d<double> >& world_points,
+                     const vcl_vector<vgl_point_2d<double> >& image_points,
+                     const double xtol = 0.0001, const unsigned nevals=10000);
 
   //: optimize orientation, position and internal calibration(no skew)for a perspective camera
   static vpgl_perspective_camera<double>


### PR DESCRIPTION
Adds a function to optimize position, orientation and focal  length to vpgl_optimize_camera, as well as some test coverage.  Previously, no tests were actually computed in test_optimize_camera.