### PR TITLE
STYLE: Outdated IMMEDIATE flag to configure_file

### DIFF
--- a/config/cmake/Modules/CheckPrototypeExistsCXX.cmake
+++ b/config/cmake/Modules/CheckPrototypeExistsCXX.cmake
@@ -31,7 +31,7 @@ macro(CHECK_PROTOTYPE_EXISTS_CXX FUNC INCLUDE VARIABLE)
 
         file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log "Trying struct with ${FILE}\n" )
         configure_file( ${CHECK_PROTOTYPE_EXISTS_CXX_FILE_IN}
-                        ${CHECK_PROTOTYPE_EXISTS_CXX_FILE} IMMEDIATE @ONLY)
+                        ${CHECK_PROTOTYPE_EXISTS_CXX_FILE} @ONLY)
 
         try_compile( CHECK_PROTOTYPE_EXISTS_CXX_RESULT
           ${CMAKE_BINARY_DIR}

--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -35,7 +35,7 @@ endmacro()
 # A macro to setup configuration and installation of header files
 #
 macro(vxl_configure_file infile outfile installprefix)
-  configure_file(${infile}  ${outfile}  ESCAPE_QUOTES @ONLY IMMEDIATE)
+  configure_file(${infile}  ${outfile}  ESCAPE_QUOTES @ONLY)
   INSTALL_NOBASE_HEADER_FILES(${installprefix} ${outfile})
 endmacro()
 
@@ -44,7 +44,7 @@ endmacro()
 # A macro to setup configuration and installation of header files
 #
 macro(vxl_configure_file_copyonly infile outfile installprefix)
-  configure_file(${infile}  ${outfile} COPYONLY IMMEDIATE)
+  configure_file(${infile}  ${outfile} COPYONLY)
   INSTALL_NOBASE_HEADER_FILES(${installprefix} ${outfile})
 endmacro()
 
@@ -172,7 +172,7 @@ macro(GENERATE_TEST_INCLUDE LIB SOURCES PREFIX)
 
   configure_file("${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/test_include.cxx"
-                 @ONLY IMMEDIATE)
+                 @ONLY)
 
   add_executable(${LIB}_test_include ${CMAKE_CURRENT_BINARY_DIR}/test_include.cxx)
   target_link_libraries(${LIB}_test_include ${LIB})

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -7,7 +7,7 @@
 # and SITE from CMake
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/test_build_info.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/test_build_info.h
-                @ONLY IMMEDIATE)
+                @ONLY)
 
 # needed for generated test_build_info.h
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )


### PR DESCRIPTION
The IMMEDIATE keyworrd is not used any longer in the configure_file
function, in fact it is the default behavior.

See: http://www.itk.org/Bug/view.php?id=12434