### PR TITLE
ENH: Minimum supported cmake version configured

### DIFF
--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -7,8 +7,11 @@ export PATH=$INSTALL_DIR/bin:$PATH
 # check if directory is cached
 if [ ! -f "$INSTALL_DIR/bin/cmake" ]; then
   cd /tmp
-  wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.sh
-  bash cmake-3.4.0-Linux-x86_64.sh --skip-license --prefix="$INSTALL_DIR/"
+  ## NOTE: We are purposefully using the minimum supported cmake version
+  ##       for testing. When cmake_minimum_version is updated in top
+  ##       level CMakeLists.txt, this should also be updated.
+  wget --no-check-certificate https://cmake.org/files/v2.8/cmake-2.8.9-Linux-i386.sh
+  bash cmake-2.8.9-Linux-i386.sh --skip-license --prefix="$INSTALL_DIR/"
 else
   echo 'Using cached CMake directory.';
 fi


### PR DESCRIPTION
This provides better testing as exposed by issue #194

When building with cmake 3.4.0 there were no build failures,
but when using the minimum cmake version of 2.8.9 the default
search paths were insufficient to find necessary configuration
files.

The continuous integration testing environment should use
the minimum cmake version to induce errors early.