### PR TITLE
Apply Rowwise and Columnwise

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -6,6 +6,10 @@
 #include <testlib/testlib_test.h>
 #include <vcl_cmath.h> // sqrt()
 
+// This function is used in testing later.
+template< typename T >
+T sum_vector(const vnl_vector<T> &v) { return v.sum(); }
+
 static
 void test_int()
 {
@@ -223,6 +227,17 @@ void test_int()
     TEST("zero-size after clear()", m2.rows(), 0);
     TEST("zero-size after clear()", m2.columns(), 0);
   }
+
+  {
+  vnl_matrix<int> m(5,10,1);
+  vnl_vector<int> vr = m.apply_rowwise(sum_vector);
+  for (unsigned int i = 0; i < vr.size(); ++i)
+    TEST("vr.apply_rowwise(sum_vector)", vr.get(i), 10);
+  vnl_vector<int> vc = m.apply_columnwise(sum_vector);
+  for (unsigned int i = 0; i < vc.size(); ++i)
+    TEST("vc.apply_columnwise(sum_vector)", vc.get(i), 5);
+  }
+
 }
 
 
@@ -344,6 +359,17 @@ void test_float()
   v.clear();
   TEST("zero-size after clear()", v.rows(), 0);
   TEST("zero-size after clear()", v.columns(), 0);
+
+  {
+  vnl_matrix<float> m(5,10,1);
+  vnl_vector<float> vr = m.apply_rowwise(sum_vector);
+  for (unsigned int i = 0; i < vr.size(); ++i)
+    TEST("vr.apply_rowwise(sum_vector)", vr.get(i), 10);
+  vnl_vector<float> vc = m.apply_columnwise(sum_vector);
+  for (unsigned int i = 0; i < vc.size(); ++i)
+    TEST("vc.apply_columnwise(sum_vector)", vc.get(i), 5);
+  }
+
 }
 
 void test_double()
@@ -444,6 +470,17 @@ void test_double()
   d9.fill(-15.0);
   vnl_copy(d10, d9);
   TEST("vnl_copy(T, S)", d9==d2, true);
+
+  {
+  vnl_matrix<double> m(5,10,1);
+  vnl_vector<double> vr = m.apply_rowwise(sum_vector);
+  for (unsigned int i = 0; i < vr.size(); ++i)
+    TEST("vr.apply_rowwise(sum_vector)", vr.get(i), 10);
+  vnl_vector<double> vc = m.apply_columnwise(sum_vector);
+  for (unsigned int i = 0; i < vc.size(); ++i)
+    TEST("vc.apply_columnwise(sum_vector)", vc.get(i), 5);
+  }
+
 }
 
 #ifdef LEAK

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -343,6 +343,12 @@ class vnl_matrix
   //: Make a new matrix by applying function to each element.
   vnl_matrix<T> apply(T (*f)(T const&)) const;
 
+  //: Make a vector by applying a function across rows.
+  vnl_vector<T> apply_rowwise(T (*f)(vnl_vector<T> const&)) const;
+
+  //: Make a vector by applying a function across columns.
+  vnl_vector<T> apply_columnwise(T (*f)(vnl_vector<T> const&)) const;
+
   //: Return transpose
   vnl_matrix<T> transpose() const;
 

--- a/core/vnl/vnl_matrix.txx
+++ b/core/vnl/vnl_matrix.txx
@@ -638,6 +638,31 @@ vnl_matrix<T> vnl_matrix<T>::apply(T (*f)(T)) const
   return ret;
 }
 
+//: Make a vector by applying a function across rows.
+template <class T>
+vnl_vector<T>
+vnl_matrix<T>
+::apply_rowwise(T (*f)(vnl_vector<T> const&)) const
+{
+  vnl_vector<T> v(this->num_rows);
+  for (unsigned int i = 0; i < this->num_rows; ++i)
+    v.put(i,f(this->get_row(i)));
+  return v;
+}
+
+//: Make a vector by applying a function across columns.
+template <class T>
+vnl_vector<T>
+vnl_matrix<T>
+::apply_columnwise(T (*f)(vnl_vector<T> const&)) const
+{
+  vnl_vector<T> v(this->num_cols);
+  for (unsigned int i = 0; i < this->num_cols; ++i)
+    v.put(i,f(this->get_column(i)));
+  return v;
+}
+
+
 ////--------------------------- Additions------------------------------------
 
 //: Returns new matrix with rows and columns transposed.


### PR DESCRIPTION
This patch allows the user to apply a function which takes a vector and returns a scalar rowwise or columnwise across a matrix.  This is meant to mimic the functionality of the `apply` functions present in R and in Python.