### PR TITLE
STYLE: VC9 compatibility does not seem necessary

### DIFF
--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -188,11 +188,6 @@ set( vcl_sources
   iso/vcl_typeinfo.h
   iso/vcl_valarray.h
 
-  win32-vc9/vcl_cmath.h
-  win32-vc9/vcl_complex.h
-  win32-vc9/vcl_cstdlib.h
-  win32-vc9/vcl_valarray.h
-
   # The following shall not be used other than as reference count for smart pointers
   vcl_atomic_count.h
   internal/vcl_atomic_count_gcc.h

--- a/vcl/vcl_cmath.h
+++ b/vcl/vcl_cmath.h
@@ -38,12 +38,7 @@
 // \endcode
 
 #include "vcl_compiler.h"
-
-#if defined(VCL_VC_9)     // C++ .NET earlier than 2003 is not iso compliant
-# include "win32-vc9/vcl_cmath.h"
-#else
-# include "iso/vcl_cmath.h"
-#endif
+#include "iso/vcl_cmath.h"
 
 
 #if !VCL_COMPLEX_POW_WORKS && !defined VCL_CMATH_POW_DECLARED

--- a/vcl/vcl_complex.h
+++ b/vcl/vcl_complex.h
@@ -18,13 +18,7 @@
 // complex over other number types.
 
 
-// ---------- Visual Studio 9
-#if defined(VCL_VC_9)
-# include "win32-vc9/vcl_complex.h"
-// ---------- ISO
-#else
-# include "iso/vcl_complex.h"
-#endif
+#include "iso/vcl_complex.h"
 
 
 # if !VCL_COMPLEX_POW_WORKS

--- a/vcl/vcl_cstdlib.h
+++ b/vcl/vcl_cstdlib.h
@@ -12,11 +12,6 @@
 // NB: size_t is declared in <cstddef>, not <cstdlib>
 
 #include "vcl_compiler.h"
-
-#if defined(VCL_VC_9) // need to handle abs(__int64) correctly
-# include "win32-vc9/vcl_cstdlib.h"
-#else
-# include "iso/vcl_cstdlib.h"
-#endif
+#include "iso/vcl_cstdlib.h"
 
 #endif // vcl_cstdlib_h_

--- a/vcl/vcl_valarray.h
+++ b/vcl/vcl_valarray.h
@@ -6,12 +6,7 @@
 
 #include "vcl_compiler.h"
 
-#if defined(VCL_VC_9)
-# include "win32-vc9/vcl_valarray.h"
-
-#else
-# include "iso/vcl_valarray.h"
-#endif
+#include "iso/vcl_valarray.h"
 
 #if !VCL_COMPLEX_POW_WORKS
 // deal with corrections to pow(complex...)

--- a/vcl/win32-vc9/vcl_cmath.h
+++ b/vcl/win32-vc9/vcl_cmath.h
@@ -3,17 +3,7 @@
 
 #include <cmath>
 
-// VC8 does not declare abs(__int 64) - so need to rewrite all vcl_abs
-
-#ifndef vcl_abs
-# define vcl_abs vcl_abs
-#endif
-
 #define vcl_generic_cmath_STD std
 #include "../generic/vcl_cmath.h"
-
-inline float  vcl_abs(float x) { return x >= 0.0f ? x : -x; }
-inline double vcl_abs(double  x) { return x >= 0.0 ? x : -x; }
-inline long double vcl_abs(long double  x) { return x >= 0.0 ? x : -x; }
 
 #endif // vcl_win32_vc_9_cmath_h_

--- a/vcl/win32-vc9/vcl_complex.h
+++ b/vcl/win32-vc9/vcl_complex.h
@@ -3,20 +3,7 @@
 
 #include <complex>
 
-// It used to necessary to bring the complex abs functions from the
-// std namespace into the global namespace to avoid conflicts with the
-// (incorrect) cstdlib headers.  Then these headers were
-// updated to define the functions with a vcl_ prefix.  We must do the
-// same here.
-
-#ifndef vcl_abs
-# define vcl_abs vcl_abs
-#endif
-
-
 #define vcl_generic_complex_STD std
 #include "../generic/vcl_complex.h"
-
-template <class T> inline T vcl_abs(const vcl_complex<T>& x) { return std::abs(x); }
 
 #endif // vcl_win32_vc_9_complex_h_

--- a/vcl/win32-vc9/vcl_cstdlib.h
+++ b/vcl/win32-vc9/vcl_cstdlib.h
@@ -3,16 +3,7 @@
 
 #include <cstdlib>
 
-#ifndef vcl_abs
-# define vcl_abs vcl_abs
-#endif
-
 #define vcl_generic_cstdlib_STD std
 #include "../generic/vcl_cstdlib.h"
 
-// Use compiler intrinsics
-// see http://msdn.microsoft.com/en-us/library/5704bbxw(VS.80).aspx
-inline int vcl_abs(int x) { return abs(x); }
-inline long vcl_abs(long x) { return labs(x); }
-inline long long vcl_abs(long long x) { return _abs64(x); }
 #endif // vcl_win32_vc_9_cstdlib_h_

--- a/vcl/win32-vc9/vcl_valarray.h
+++ b/vcl/win32-vc9/vcl_valarray.h
@@ -1,19 +1,7 @@
 #ifndef vcl_win32_vc_9_valarray_h_
 #define vcl_win32_vc_9_valarray_h_
 
-// VC7 does not define abs functions correctly in  cstdlib.
-// The vcl versions of these headers declare the functions with vcl_
-// prefixes, so we must do the same here.
-
-#include <valarray>
-
-#ifndef vcl_abs
-# define vcl_abs vcl_abs
-#endif
-
 #define vcl_generic_valarray_STD std
 #include "../generic/vcl_valarray.h"
-
-template <class T> inline vcl_valarray<T> vcl_abs(const vcl_valarray<T>& x) { return std::abs(x); }
 
 #endif // vcl_win32_vc_9_valarray_h_


### PR DESCRIPTION
The code comments in the VC9 alternate files
were comments referencing VC8 and VC7 that are
no longer supported.  Once the VC8 and VC7
specific comments were removed, there was
no longer any specialization for VC9, so
the alternate files for VC9 were no longer
relevant and indicate that VC9 will work
even without these files.