### PR TITLE
BUG: Fix cmake errors related to INTERFACE_INCLUDE_DIRECTORY

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -105,7 +105,7 @@ macro( vxl_add_library )
     target_include_directories(${lib_name}
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:${relative_install_path}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${relative_install_path}>
     )
     INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${lib_srcs})
   endif()


### PR DESCRIPTION
property not containing full path in cmake 2.8.11.

@hjmjohnson @andyneff This should fix the cmake errors...
 