### PR TITLE
COMP: VC9 Does not have HUGE_VAL or HUGE_VALL

### DIFF
--- a/contrib/brl/bbas/bsta/bsta_k_medoid.cxx
+++ b/contrib/brl/bbas/bsta/bsta_k_medoid.cxx
@@ -1,10 +1,11 @@
 #include "bsta_k_medoid.h"
 //:
 // \file
-#include <vcl_cmath.h> //for HUGE_VAL
+#include <vcl_cmath.h>
 #include <vcl_algorithm.h> //for find
 #include <vcl_iostream.h>
 #include <vcl_cassert.h>
+#include <vcl_limits.h>
 
 bsta_k_medoid::bsta_k_medoid(const unsigned n_elements, bool verbose)
 {
@@ -121,7 +122,7 @@ void bsta_k_medoid::form_clusters()
     else
     {
       //find closest medoid
-      double dmin = HUGE_VAL;
+      double dmin = vcl_numeric_limits<double>::max();
       unsigned jmin=0;
       for (unsigned j=0; j<this->k(); ++j)
         if (distance(i,this->medoid(j))<dmin)
@@ -157,7 +158,7 @@ bool bsta_k_medoid::test_medoid_swap(unsigned& mj, unsigned& mk)
   mj = n_elements_, mk = n_elements_;
 
   // for each j not a medoid
-  double Sdc_min = HUGE_VAL;
+  double Sdc_min = vcl_numeric_limits<double>::max();
   unsigned jmin=0, kmin=0;
   for ( unsigned j = 0; j<n_elements_; ++j)
     if (is_medoid(j))

--- a/core/bin/check_consistency
+++ b/core/bin/check_consistency
@@ -261,7 +261,7 @@ foreach $f (@FILES)
     elsif ($j eq 'vcl_cerrno.h') { $i='errno|EBUSY|EEXIST'; }
     elsif ($j eq 'vcl_cfloat.h') { $i='FLT_MAX|DBL_MAX|MAXFLOAT|MAXDOUBLE'; }
     elsif ($j eq 'vcl_climits.h') { $i='CHAR_BIT|CLK_TCK|[US]?(INT|CHAR)_(MIN|MAX)'; }
-    elsif ($j eq 'vcl_cmath.h') { $i='vcl_(abs|acos|asin|atan|atan2|ceil|cos|cosh|exp|fabs|floor|fmod|frexp|ldexp|log|log10|modf|pow|sin|sinh|sqrt|tan|tanh)|hypot|HUGE_VAL'; }
+    elsif ($j eq 'vcl_cmath.h') { $i='vcl_(abs|acos|asin|atan|atan2|ceil|cos|cosh|exp|fabs|floor|fmod|frexp|ldexp|log|log10|modf|pow|sin|sinh|sqrt|tan|tanh)|hypot'; }
     elsif ($j eq 'vcl_complex.h') { $i='vcl_(complex|real|imag|abs|arg|norm|conj|polar|cos|cosh|exp|log|log10|pow|sin|sinh|sqrt|tan|tanh)'; }
     elsif ($j eq 'vcl_complex.h' && $f =~ m!/tests/test_cmath\.cxx$!) { $i=''; }
     elsif ($j eq 'vcl_csetjmp.h') { $i='setjmp|vcl_(jmp_buf|longjmp)'; }

--- a/core/vnl/tests/test_math.cxx
+++ b/core/vnl/tests/test_math.cxx
@@ -310,8 +310,8 @@ static void test_math()
   const float ninf_f = - vcl_numeric_limits<float>::infinity();
   const double pinf_d =   vcl_numeric_limits<double>::infinity();
   const double ninf_d = - vcl_numeric_limits<double>::infinity();
-  const long double pinf_q =   HUGE_VALL; //vcl_numeric_limits<long double>::infinity();
-  const long double ninf_q = - HUGE_VALL; //vcl_numeric_limits<long double>::infinity();
+  const long double pinf_q =  vcl_numeric_limits<long double>::infinity();
+  const long double ninf_q = -vcl_numeric_limits<long double>::infinity();
 
   // Create NaN
   const float qnan_f = vcl_numeric_limits<float>::quiet_NaN();

--- a/core/vnl/vnl_math.cxx
+++ b/core/vnl/vnl_math.cxx
@@ -7,6 +7,7 @@
 
 #include "vnl_math.h"
 #include <vxl_config.h>
+#include <vcl_limits.h>
 
 #if defined(VCL_VC) || defined(__MINGW32__)
 // I don't think we need this, because <ieeefp.h> is available -- fsm
@@ -214,10 +215,7 @@ bool isnormal(long double x) { return vnl_math::isfinite(x) && (x != 0.0 ); }
 
 //: Type-accessible infinities for use in templates.
 template <class T> T vnl_huge_val(T);
-#ifndef VCL_ICC_81
-double vnl_huge_val(double) { return HUGE_VAL; }
-float  vnl_huge_val(float)  { return (float)HUGE_VAL; }
-#else
+#ifdef VCL_ICC_81
 // workaround ICC warning that 0x1.0p2047 cannot be represented exactly.
 double vnl_huge_val(double) { return // 2^2047
 16158503035655503650357438344334975980222051334857742016065172713762\
@@ -233,7 +231,12 @@ double vnl_huge_val(double) { return // 2^2047
 float  vnl_huge_val(float)  { return // 2^255
 57896044618658097711785492504343953926634992332820282019728792003956\
 564819968.0f; }
+#else
+float  vnl_huge_val(float)  { return vcl_numeric_limits<float>::infinity(); }
+double  vnl_huge_val(double)  { return vcl_numeric_limits<double>::infinity(); }
+long double vnl_huge_val(long double) { return vcl_numeric_limits<long double>::infinity(); }
 #endif
+
 #ifdef _INT_64BIT_
 long int vnl_huge_val(long int) { return 0x7fffffffffffffffL; }
 int    vnl_huge_val(int)    { return 0x7fffffffffffffffL; }

--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -77,12 +77,13 @@
 
 //: Type-accessible infinities for use in templates.
 template <class T> T vnl_huge_val(T);
-double   vnl_huge_val(double);
-float    vnl_huge_val(float);
-long int vnl_huge_val(long int);
-int      vnl_huge_val(int);
-short    vnl_huge_val(short);
-char     vnl_huge_val(char);
+extern long double   vnl_huge_val(long double);
+extern double   vnl_huge_val(double);
+extern float    vnl_huge_val(float);
+extern long int vnl_huge_val(long int);
+extern int      vnl_huge_val(int);
+extern short    vnl_huge_val(short);
+extern char     vnl_huge_val(char);
 
 //: real numerical constants
 // Strictly speaking, the static declaration of the constant variables is


### PR DESCRIPTION
VC9 compiler does not have macros for HUGE_VAL or HUGE_VALL so
remove the need for these.

http://en.cppreference.com/w/cpp/numeric/math/HUGE_VAL
"On implementations that support floating-point infinities, these macros
always expand to the positive infinities of float, double, and long
double, respectively."

We already have vcl_numeric_limits<>::infinity() defined, so use that
instead for consistent behavior.