### PR TITLE
ENH: Unifying out-of-bounds behavior for vnl containers.

### DIFF
--- a/core/vnl/tests/test_diag_matrix.cxx
+++ b/core/vnl/tests/test_diag_matrix.cxx
@@ -9,6 +9,7 @@
 #include <vnl/vnl_diag_matrix.h>
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_vector_fixed.h>
+#include <vcl_exception.h>
 
 void test_diag_matrix()
 {
@@ -99,6 +100,29 @@ void test_diag_matrix()
   TEST("matrix product", p2(0,0) ==  0.0  && p2(0,1) == 0.0 && p2(0,2) == -0.75
                       && p2(1,0) == -1.5  && p2(1,1) == 0.0 && p2(1,2) == -0.5
                       && p2(2,0) == -0.75 && p2(2,1) == 0.0 && p2(2,2) ==  0.0, true);
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  // Get
+  bool exceptionThrownAndCaught = false;
+  vcl_try { m1.get(25,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,25)", exceptionThrownAndCaught, true);
+
+  // Put
+  exceptionThrownAndCaught = false;
+  vcl_try { m1.put(25,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,25,0)", exceptionThrownAndCaught, true);
+  }
+
+#endif
+
 }
 
 TESTMAIN(test_diag_matrix);

--- a/core/vnl/tests/test_diag_matrix_fixed.cxx
+++ b/core/vnl/tests/test_diag_matrix_fixed.cxx
@@ -9,6 +9,7 @@
 #include <vnl/vnl_diag_matrix_fixed.h>
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_vector_fixed.h>
+#include <vcl_exception.h>
 
 void test_diag_matrix_fixed()
 {
@@ -99,6 +100,29 @@ void test_diag_matrix_fixed()
   TEST("matrix product", p2(0,0) ==  0.0  && p2(0,1) == 0.0 && p2(0,2) == -0.75
                       && p2(1,0) == -1.5  && p2(1,1) == 0.0 && p2(1,2) == -0.5
                       && p2(2,0) == -0.75 && p2(2,1) == 0.0 && p2(2,2) ==  0.0, true);
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  // Get
+  bool exceptionThrownAndCaught = false;
+  vcl_try { m1.get(25,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,25)", exceptionThrownAndCaught, true);
+
+  // Put
+  exceptionThrownAndCaught = false;
+  vcl_try { m1.put(25,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,25,0)", exceptionThrownAndCaught, true);
+  }
+
+#endif
+
 }
 
 TESTMAIN(test_diag_matrix_fixed);

--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -5,6 +5,7 @@
 #include <vnl/vnl_copy.h>
 #include <testlib/testlib_test.h>
 #include <vcl_cmath.h> // sqrt()
+#include <vcl_exception.h>
 
 // This function is used in testing later.
 template< typename T >
@@ -16,6 +17,11 @@ void test_int()
   vcl_cout << "***********************\n"
            << "Testing vnl_matrix<int>\n"
            << "***********************" << vcl_endl;
+
+  //////////////////
+  // CONSTRUCTORS //
+  //////////////////
+
   vnl_matrix<int> m0(2,2);
   TEST("vnl_matrix<int> m0(2,2)", (m0.rows()==2 && m0.columns()==2), true);
   vnl_matrix<int> m1(3,4);
@@ -42,6 +48,50 @@ void test_int()
         (m0.get(0,0)==2 && m0.get(0,1)==2 && m0.get(1,0)==2 && m0.get(1,1)==2)), true);
   TEST("m0 == m2", (m0 == m2), true);
   TEST("(m0 == m2)", (m0 == m2), true);
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  // Get
+  bool exceptionThrownAndCaught = false;
+  vcl_try { m0.get(0,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(0,25)", exceptionThrownAndCaught, true);
+  
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.get(25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.get(25,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,25)", exceptionThrownAndCaught, true);
+
+  // Put
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(0,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(0,25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(25,0,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,0,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(25,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,25,0)", exceptionThrownAndCaught, true);
+
+  }
+
+#endif
+
   TEST("m2.put(1,1,3)", (m2.put(1,1,3),m2.get(1,1)), 3);
   TEST("m2.get(1,1)", m2.get(1,1), 3);
   int v2_data[] = {2,3};

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -16,6 +16,7 @@
 #include <vnl/vnl_int_2x2.h>
 
 #include <testlib/testlib_test.h>
+#include <vcl_exception.h>
 
 #undef printf // to work around a bug in libintl.h
 #include <vcl_cstdio.h> // do not use iostream within operator new - it causes infinite recursion
@@ -78,6 +79,11 @@ void test_int()
   vcl_cout << "*********************************\n"
            << "Testing vnl_matrix_fixed<int,x,x>\n"
            << "*********************************" << vcl_endl;
+
+  //////////////////
+  // CONSTRUCTORS //
+  //////////////////
+
   vnl_matrix_fixed<int,2,2> m0;
   TEST("vnl_matrix_fixed<int,2,2> m0", (m0.rows()==2 && m0.columns()==2), true);
   vnl_matrix_fixed<int,3,4> m1;
@@ -104,6 +110,50 @@ void test_int()
         (m0.get(0,0)==2 && m0.get(0,1)==2 && m0.get(1,0)==2 && m0.get(1,1)==2)), true);
   TEST("m0 == m2", (m0 == m2), true);
   TEST("(m0 == m2)", (m0 == m2), true);
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  // Get
+  bool exceptionThrownAndCaught = false;
+  vcl_try { m0.get(0,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(0,25)", exceptionThrownAndCaught, true);
+  
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.get(25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.get(25,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,25)", exceptionThrownAndCaught, true);
+
+  // Put
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(0,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(0,25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(25,0,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,0,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { m0.put(25,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,25,0)", exceptionThrownAndCaught, true);
+
+  }
+
+#endif
+
   TEST("m2.put(1,1,3)", (m2.put(1,1,3),m2.get(1,1)), 3);
   TEST("m2.get(1,1)", m2.get(1,1), 3);
   int v2_data[] = {2,3};

--- a/core/vnl/tests/test_sym_matrix.cxx
+++ b/core/vnl/tests/test_sym_matrix.cxx
@@ -2,6 +2,7 @@
 #include <vcl_iostream.h>
 #include <vnl/vnl_sym_matrix.h>
 #include <testlib/testlib_test.h>
+#include <vcl_exception.h>
 
 static
 void test_int()
@@ -9,6 +10,11 @@ void test_int()
   vcl_cout << "*****************************\n"
            << "Testing Symmetric Matrix<int>\n"
            << "*****************************\n";
+
+  //////////////////
+  // CONSTRUCTORS //
+  //////////////////
+
   vnl_sym_matrix<int> sm1(2);
   TEST("\n\nvnl_sym_matrix<int> m1(2)", (sm1.rows()==2 && sm1.columns()==2), true);
   vnl_sym_matrix<int> sm2(2,2);
@@ -63,6 +69,49 @@ void test_int()
         sm5(1,0)==5 && sm5(1,1)==5 && sm5(1,2)==2 &&
         sm5(2,0)==0 && sm5(2,1)==2 && sm5(2,2)==3), true);
   vcl_cout << "sm5\n" << sm5 << vcl_endl << vcl_endl;
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  // Get
+  bool exceptionThrownAndCaught = false;
+  vcl_try { sm1.get(0,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(0,25)", exceptionThrownAndCaught, true);
+  
+  exceptionThrownAndCaught = false;
+  vcl_try { sm1.get(25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { sm1.get(25,25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get(25,25)", exceptionThrownAndCaught, true);
+
+  // Put
+  exceptionThrownAndCaught = false;
+  vcl_try { sm1.put(0,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(0,25,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { sm1.put(25,0,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,0,0)", exceptionThrownAndCaught, true);
+
+  exceptionThrownAndCaught = false;
+  vcl_try { sm1.put(25,25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put(25,25,0)", exceptionThrownAndCaught, true);
+
+  }
+
+#endif
 }
 
 

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -9,23 +9,66 @@
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_cross.h>
 #include <testlib/testlib_test.h>
+#include <vcl_exception.h>
 
 void vnl_vector_test_int()
 {
+
   vcl_cout << "***********************\n"
            << "Testing vnl_vector<int>\n"
            << "***********************\n";
-  //// test constructors, accessors
+
+  //////////////////
+  // CONSTRUCTORS //
+  //////////////////
+
+  //  vnl_vector();
   vnl_vector<int> v0;
   TEST("vnl_vector<int> v0()", v0.size(), 0);
+
+  //  vnl_vector(unsigned int len);
   vnl_vector<int> v1(2);
   TEST("vnl_vector<int> v1(2)", v1.size(), 2);
+
+  //  vnl_vector(unsigned int len, T const& v0);
   vnl_vector<int> v2(2,2);
   TEST("vnl_vector<int> v2(2,2)", (v2.get(0)==2 && v2.get(1)==2), true);
-//   TEST("v0.set_compare", (v0.set_compare(int_equal), true), true);
+
+  //  vnl_vector(unsigned int len, int n, T const values[]);
   int vcvalues[] = {1,0};
   vnl_vector<int> vc(2,2,vcvalues);
   TEST("vnl_vector<int> vc(2,2,int[])", (vc(0)==1 && vc(1)==0), true);
+
+  //  vnl_vector(T const* data_block,unsigned int n);
+  vnl_vector<int> vb(vcvalues,2);
+  TEST("vnl_vector<int> vb(int[],2)", (vb(0)==1 && vb(1)==0), true);
+
+  //  vnl_vector(vnl_vector<T> const&);
+  vnl_vector<int> v_copy(vb);
+  TEST("vnl_vector<int> v_copy(vb)", (v_copy(0)==1 && v_copy(1)==0), true);
+
+  ///////////////
+  // ACCESSORS //
+  ///////////////
+
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+
+  {
+  bool exceptionThrownAndCaught = false;
+  vcl_try { v0.get(25); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds get()", exceptionThrownAndCaught, true);
+  
+  exceptionThrownAndCaught = false;
+  vcl_try { v0.put(25,0); }  // Raise out of bounds exception.
+  vcl_catch_all { exceptionThrownAndCaught = true; }
+  TEST("Out of bounds put()", exceptionThrownAndCaught, true);
+  }
+
+#endif
+
+  //// test constructors, accessors
+//   TEST("v0.set_compare", (v0.set_compare(int_equal), true), true);
   TEST("v1=2", (v1=2, (v1.get(0)==2 && v1.get(1)==2)), true);
   TEST("v1 == v2", (v1 == v2), true);
   TEST("v0 = v2", ((v0 = v2), (v0 == v2)), true);
@@ -251,7 +294,6 @@ void vnl_vector_test_int()
        (1 == v[0] && 2 == v[1] && 3 == v[2] && 0 == v[3]), true);
   }
 }
-
 
 bool float_equal(const float& f1, const float& f2)
 {

--- a/core/vnl/vnl_diag_matrix.h
+++ b/core/vnl/vnl_diag_matrix.h
@@ -89,18 +89,6 @@ class vnl_diag_matrix
   inline T& operator[] (unsigned i) { return diagonal_[i]; }
   inline T const& operator[] (unsigned i) const { return diagonal_[i]; }
 
-  //: set element with boundary checks.
-  inline void put (unsigned r, unsigned c, T const& v) {
-    assert(r == c); (void)c;
-    assert (r<size()); diagonal_[r] = v;
-  }
-
-  //: get element with boundary checks.
-  inline T get (unsigned r, unsigned c) const {
-    assert(r == c); (void)c;
-    assert (r<size()); return diagonal_[r];
-  }
-
   //: Return a vector (copy) with the content of the (main) diagonal
   inline vnl_vector<T> get_diagonal() const { return diagonal_; }
 
@@ -122,10 +110,43 @@ class vnl_diag_matrix
   inline const_iterator begin() const { return diagonal_.begin(); }
   inline const_iterator end() const { return diagonal_.end(); }
 
-  inline unsigned size() const { return diagonal_.size(); }
-  inline unsigned rows() const { return diagonal_.size(); }
-  inline unsigned cols() const { return diagonal_.size(); }
-  inline unsigned columns() const { return diagonal_.size(); }
+  //: Return the total number of elements stored by the matrix.
+  // Since vnl_diag_matrix only stores values on the diagonal
+  // and must be square, size() == rows() == cols().
+  inline unsigned int size() const { return diagonal_.size(); }
+
+  //: Return the number of rows.
+  inline unsigned int rows() const { return diagonal_.size(); }
+
+  //: Return the number of columns.
+  // A synonym for columns().
+  inline unsigned int cols() const { return diagonal_.size(); }
+
+  //: Return the number of columns.
+  // A synonym for cols().
+  inline unsigned int columns() const { return diagonal_.size(); }
+
+  //: set element with boundary checks.
+  inline void put (unsigned r, unsigned c, T const& v) {
+    assert(r == c);
+    (void)c;
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= this->size())                  // If invalid size specified
+      vnl_error_matrix_row_index("get", r); // Raise exception
+#endif
+    diagonal_[r] = v;
+  }
+
+  //: get element with boundary checks.
+  inline T get (unsigned r, unsigned c) const {
+    assert(r == c);
+    (void)c;
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+  if (r >= this->size())                  // If invalid size specified
+    vnl_error_matrix_row_index("get", r); // Raise exception
+#endif
+    return diagonal_[r];
+  }
 
   // Need this until we add a vnl_diag_matrix ctor to vnl_matrix;
   inline vnl_matrix<T> asMatrix() const;

--- a/core/vnl/vnl_diag_matrix_fixed.h
+++ b/core/vnl/vnl_diag_matrix_fixed.h
@@ -88,18 +88,6 @@ class vnl_diag_matrix_fixed
   inline T& operator[] (unsigned i) { return diagonal_[i]; }
   inline T const& operator[] (unsigned i) const { return diagonal_[i]; }
 
-  //: set element with boundary checks.
-  inline void put (unsigned r, unsigned c, T const& v) {
-    assert(r == c); (void)c;
-    assert (r<size()); diagonal_[r] = v;
-  }
-
-  //: get element with boundary checks.
-  inline T get (unsigned r, unsigned c) const {
-    assert(r == c); (void)c;
-    assert (r<size()); return diagonal_[r];
-  }
-
   //: Return a vector (copy) with the content of the (main) diagonal
   inline vnl_vector_fixed<T,N> get_diagonal() const { return diagonal_; }
 
@@ -121,10 +109,45 @@ class vnl_diag_matrix_fixed
   inline const_iterator begin() const { return diagonal_.begin(); }
   inline const_iterator end() const { return diagonal_.end(); }
 
-  inline unsigned size() const { return diagonal_.size(); }
-  inline unsigned rows() const { return diagonal_.size(); }
-  inline unsigned cols() const { return diagonal_.size(); }
-  inline unsigned columns() const { return diagonal_.size(); }
+  //: Return the total number of elements stored by the matrix.
+  // Since vnl_diag_matrix_fixed only stores values on the diagonal
+  // and must be square, size() == rows() == cols().
+  inline unsigned int size() const { return diagonal_.size(); }
+
+  //: Return the number of rows.
+  inline unsigned int rows() const { return diagonal_.size(); }
+
+  //: Return the number of columns.
+  // A synonym for columns().
+  inline unsigned int cols() const { return diagonal_.size(); }
+
+  //: Return the number of columns.
+  // A synonym for cols().
+  inline unsigned int columns() const { return diagonal_.size(); }
+
+  //: set element with boundary checks.
+  inline void put (unsigned r, unsigned c, T const& v)
+  {
+    assert(r == c);
+    (void)c;
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= this->size())                  // If invalid size specified
+      vnl_error_matrix_row_index("put", r); // Raise exception
+#endif
+    diagonal_[r] = v;
+  }
+
+  //: get element with boundary checks.
+  inline T get (unsigned r, unsigned c) const
+  {
+    assert(r == c);
+    (void)c;
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= this->size())                  // If invalid size specified
+      vnl_error_matrix_row_index("get", r); // Raise exception
+#endif
+    return diagonal_[r];
+  }
 
   // Need this until we add a vnl_diag_matrix_fixed ctor to vnl_matrix;
   inline vnl_matrix_fixed<T,N,N> as_matrix_fixed() const;

--- a/core/vnl/vnl_error.cxx
+++ b/core/vnl/vnl_error.cxx
@@ -18,44 +18,45 @@
 
 #include "vnl_error.h"
 #include <vcl_iostream.h>
-#include <vcl_cstdlib.h> // for vcl_abort()
+#include <vcl_exception.h> // for vcl_throw
 
-//: Raise exception for invalid index
+//: Raise exception for invalid index.
 void vnl_error_vector_index (char const* fcn, int index)
 {
   //RAISE Error, SYM(vnl_error_vector), SYM(Invalid_Index),
   vcl_cerr << "vnl_error_vector_index:" << fcn
            << ": Invalid value " << index << " specified for index.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
-//: Raise exception for invalid dimensions
+//: Raise exception for invalid dimension.
 void vnl_error_vector_dimension (char const* fcn, int l1, int l2)
 {
   //RAISE Error, SYM(vnl_error_vector), SYM(Invalid_Dim),
   vcl_cerr << "vnl_error_vector_dimension:" << fcn << ": Dimensions ["
            << l1 << "] and [" << l2 << "] do not match.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
 
-//: Raise exception for using class objects, or chars in (...)
+//: Raise exception for using class objects, or chars in (...).
 void vnl_error_vector_va_arg (int n)
 {
   //RAISE Error, SYM(vnl_error_vector), SYM(Invalid_Va_Arg),
   vcl_cerr << "vnl_error_vector_va_arg: Invalid type in ..."
            << " or wrong alignment with " << n << " bytes.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
 //--------------------------------------------------------------------------------
 
+//: Raise exception for invalid row index.
 void vnl_error_matrix_row_index (char const* fcn, int r)
 {
   //RAISE Error, SYM(vnl_error_matrix), SYM(Invalid_Row),
   vcl_cerr << "vnl_error_matrix_row_index:" << fcn
            << ": Invalid value " << r << " specified for row.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
 
@@ -65,33 +66,33 @@ void vnl_error_matrix_col_index (char const* fcn, int c)
   //RAISE Error, SYM(vnl_error_matrix), SYM(Invalid_Col),
   vcl_cerr << "vnl_error_matrix_col_index:" << fcn << ": Invalid value "
            << c << " specified for column.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
-//: Raise exception for invalid dimensions
+//: Raise exception for invalid dimensions.
 void vnl_error_matrix_dimension (char const* fcn, int r1, int c1, int r2, int c2)
 {
   //RAISE Error, SYM(vnl_error_matrix), SYM(Invalid_Dim),
   vcl_cerr << "vnl_error_matrix_dimension:" << fcn << ": Dimensions [" << r1
            << ',' << c1 << "] and [" << r2 << ',' << c2 << "] do not match.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
 
-//: Raise exception for invalid dimensions
+//: Raise exception for a nonsquare matrix.
 void vnl_error_matrix_nonsquare (char const* fcn)
 {
   //RAISE Error, SYM(vnl_error_matrix), SYM(Invalid_Dim),
   vcl_cerr << "vnl_error_matrix_nonsquare:" << fcn
            << ": Matrix must be square.\n";
-  vcl_abort();
+  vcl_throw 0;
 }
 
-//: Raise exception for using class objects, or chars in (...)
+//: Raise exception for using class objects, or chars in (...).
 void vnl_error_matrix_va_arg (int n)
 {
   //RAISE Error, SYM(vnl_error_matrix), SYM(Invalid_Va_Arg),
   vcl_cerr << "vnl_error_matrix_va_arg: Invalid type in ..."
            << " or wrong alignment with " << n << " bytes.\n";
-  vcl_abort();
+  vcl_throw 0;
 }

--- a/core/vnl/vnl_error.h
+++ b/core/vnl/vnl_error.h
@@ -8,16 +8,28 @@
 //  \file
 //  \author fsm
 
-//
+//: Raise exception for invalid index.
 extern void vnl_error_vector_index (const char* fcn, int index);
+
+//: Raise exception for invalid dimension.
 extern void vnl_error_vector_dimension (const char* fcn, int l1, int l2);
+
+//: Raise exception for using class objects, or chars in (...).
 extern void vnl_error_vector_va_arg (int n);
 
-//
+//: Raise exception for invalid row index.
 extern void vnl_error_matrix_row_index (char const* fcn, int r);
+
+//: Raise exception for invalid col index.
 extern void vnl_error_matrix_col_index (char const* fcn, int c);
+
+//: Raise exception for invalid dimensions.
 extern void vnl_error_matrix_dimension (char const* fcn, int r1, int c1, int r2, int c2);
+
+//: Raise exception for a nonsquare matrix.
 extern void vnl_error_matrix_nonsquare (char const* fcn);
+
+//: Raise exception for using class objects, or chars in (...).
 extern void vnl_error_matrix_va_arg (int n);
 
 #endif // vnl_error_h_

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -169,26 +169,26 @@ class vnl_matrix
 
 // Basic 2D-Array functionality-------------------------------------------
 
-  //: Return number of rows
-  unsigned rows()    const { return num_rows; }
-
-  //: Return number of columns
-  // A synonym for cols()
-  unsigned columns()  const { return num_cols; }
-
-  //: Return number of columns
-  // A synonym for columns()
-  unsigned cols()    const { return num_cols; }
-
-  //: Return number of elements
+  //: Return the total number of elements stored by the matrix.
   // This equals rows() * cols()
-  unsigned size()    const { return rows()*cols(); }
+  inline unsigned int size() const { return this->num_rows*this->num_cols; }
+
+  //: Return the number of rows.
+  inline unsigned int rows() const { return this->num_rows; }
+
+  //: Return the number of columns.
+  // A synonym for columns().
+  inline unsigned int cols() const { return this->num_cols; }
+
+  //: Return the number of columns.
+  // A synonym for cols().
+  inline unsigned int columns() const { return this->num_cols; }
 
   //: set element with boundary checks if error checking is on.
-  void put(unsigned r, unsigned c, T const&);
+  inline void put(unsigned r, unsigned c, T const&);
 
   //: get element with boundary checks if error checking is on.
-  T    get(unsigned r, unsigned c) const;
+  inline T get(unsigned r, unsigned c) const;
 
   //: return pointer to given row
   // No boundary checking here.
@@ -712,30 +712,32 @@ class vnl_matrix
 // Checks for valid range of indices.
 
 template<class T>
-inline T vnl_matrix<T>::get(unsigned row, unsigned column) const
+inline T vnl_matrix<T>
+::get(unsigned r, unsigned c) const
 {
-#ifdef ERROR_CHECKING
-  if (row >= this->num_rows)                   // If invalid size specified
-    vnl_error_matrix_row_index("get", row);    // Raise exception
-  if (column >= this->num_cols)                // If invalid size specified
-    vnl_error_matrix_col_index("get", column); // Raise exception
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+  if (r >= this->num_rows)                // If invalid size specified
+    vnl_error_matrix_row_index("get", r); // Raise exception
+  if (c >= this->num_cols)                // If invalid size specified
+    vnl_error_matrix_col_index("get", c); // Raise exception
 #endif
-  return this->data[row][column];
+  return this->data[r][c];
 }
 
 //: Puts value into element at specified row and column. O(1).
 // Checks for valid range of indices.
 
 template<class T>
-inline void vnl_matrix<T>::put(unsigned row, unsigned column, T const& value)
+inline void vnl_matrix<T>
+::put(unsigned r, unsigned c, T const& v)
 {
-#ifdef ERROR_CHECKING
-  if (row >= this->num_rows)                   // If invalid size specified
-    vnl_error_matrix_row_index("put", row);    // Raise exception
-  if (column >= this->num_cols)                // If invalid size specified
-    vnl_error_matrix_col_index("put", column); // Raise exception
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+  if (r >= this->num_rows)                // If invalid size specified
+    vnl_error_matrix_row_index("put", r); // Raise exception
+  if (c >= this->num_cols)                // If invalid size specified
+    vnl_error_matrix_col_index("put", c); // Raise exception
 #endif
-  this->data[row][column] = value;             // Assign data value
+  this->data[r][c] = v;             // Assign data value
 }
 
 

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -179,29 +179,47 @@ class vnl_matrix_fixed
 
 // Basic 2D-Array functionality-------------------------------------------
 
-  //: Return number of rows
-  unsigned rows()    const { return num_rows; }
-
-  //: Return number of columns
-  // A synonym for cols()
-  unsigned columns()  const { return num_cols; }
-
-  //: Return number of columns
-  // A synonym for columns()
-  unsigned cols()    const { return num_cols; }
-
-  //: Return number of elements
+  //: Return the total number of elements stored by the matrix.
   // This equals rows() * cols()
-  unsigned size()    const { return num_rows*num_cols; }
+  inline unsigned int size() const { return num_rows*num_cols; }
+
+  //: Return the number of rows.
+  inline unsigned int rows() const { return num_rows; }
+
+  //: Return the number of columns.
+  // A synonym for columns().
+  inline unsigned int cols() const { return num_cols; }
+
+  //: Return the number of columns.
+  // A synonym for cols().
+  inline unsigned int columns() const { return num_cols; }
 
   //: set element
-  void put (unsigned r, unsigned c, T const& v) { (*this)(r,c) = v; }
+  inline void put (unsigned r, unsigned c, T const& v)
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= num_rows)                // If invalid size specified
+      vnl_error_matrix_row_index("put", r); // Raise exception
+    if (c >= num_cols)                // If invalid size specified
+      vnl_error_matrix_col_index("put", c); // Raise exception
+#endif
+    this->data_[r][c] = v;
+  }
+
+  //: get element
+  inline T get (unsigned r, unsigned c) const
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= num_rows)                // If invalid size specified
+      vnl_error_matrix_row_index("get", r); // Raise exception
+    if (c >= num_cols)                // If invalid size specified
+      vnl_error_matrix_col_index("get", c); // Raise exception
+#endif
+    return this->data_[r][c];
+  }
 
   //: set element, and return *this
   vnl_matrix_fixed& set (unsigned r, unsigned c, T const& v) { (*this)(r,c) = v; return *this; }
-
-  //: get element
-  T    get (unsigned r, unsigned c) const { return (*this)(r,c); }
 
   //: return pointer to given row
   // No boundary checking here.

--- a/core/vnl/vnl_sym_matrix.h
+++ b/core/vnl/vnl_sym_matrix.h
@@ -101,10 +101,46 @@ class vnl_sym_matrix
   inline const_iterator begin() const { return data_; }
   inline const_iterator end() const { return data_ + size(); }
 
-  unsigned long size() const { return nn_ * (nn_ + 1) / 2; }
-  unsigned rows() const { return nn_; }
-  unsigned cols() const { return nn_; }
-  unsigned columns() const { return nn_; }
+  //: Return the total number of elements stored by the matrix.
+  // Since vnl_sym_matrix only stores the diagonal and lower
+  // triangular elements and must be square, this returns
+  // n*(n+1)/2, where n == rows() == cols().
+  inline unsigned int size() const { return nn_ * (nn_ + 1) / 2; }
+
+  //: Return the number of rows.
+  inline unsigned int rows() const { return nn_; }
+
+  //: Return the number of columns.
+  // A synonym for columns().
+  inline unsigned int cols() const { return nn_; }
+
+  //: Return the number of columns.
+  // A synonym for cols().
+  inline unsigned int columns() const { return nn_; }
+
+  //: set element
+  inline void put (unsigned r, unsigned c, T const& v)
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= this->nn_)                // If invalid size specified
+      vnl_error_matrix_row_index("put", r); // Raise exception
+    if (c >= this->nn_)                // If invalid size specified
+      vnl_error_matrix_col_index("put", c); // Raise exception
+#endif
+    (r > c) ? index_[r][c] = v : index_[c][r] = v;
+  }
+
+  //: get element
+  inline T get (unsigned r, unsigned c) const
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (r >= this->nn_)                // If invalid size specified
+      vnl_error_matrix_row_index("get", r); // Raise exception
+    if (c >= this->nn_)                // If invalid size specified
+      vnl_error_matrix_col_index("get", c); // Raise exception
+#endif
+    return (r > c) ? index_[r][c] : index_[c][r];
+  }
 
   // Need this until we add a vnl_sym_matrix ctor to vnl_matrix;
   inline vnl_matrix<T> as_matrix() const;

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -80,15 +80,22 @@ class vnl_vector
   //: Creates an empty vector. O(1).
   vnl_vector() : num_elmts(0) , data(VXL_NULLPTR) {}
 
-  //: Creates vector containing n elements.
-  // Elements are not initialized.
-  explicit vnl_vector(unsigned len);
+  //: Creates a vector containing n uninitialized elements.
+  explicit vnl_vector(unsigned int len);
 
-  //: Creates vector of len elements, all set to v0
-  vnl_vector(unsigned len, T const& v0);
+  //: Creates a vector containing n elements, all set to v0.
+  vnl_vector(unsigned int len, T const& v0);
 
-  //: Creates a vector of specified length and initialize first n elements with values. O(n).
-  vnl_vector(unsigned len, int n, T const values[]);
+  //: Creates a vector containing len elements, with the first n
+  // elements taken from the array values[]. O(n).
+  vnl_vector(unsigned int len, int n, T const values[]);
+
+  //: Creates a vector containing len elements, initialized with values from
+  // a data block.
+  vnl_vector(T const* data_block,unsigned int n);
+
+  //: Copy constructor.
+  vnl_vector(vnl_vector<T> const&);
 
 #if VNL_CONFIG_LEGACY_METHODS // these constructors are deprecated and should not be used
   //: Creates a vector of length 2 and initializes with the arguments, px,py.
@@ -109,12 +116,6 @@ class vnl_vector
   // \deprecated
   vnl_vector(unsigned len, T const& px, T const& py, T const& pz, T const& pw);
 #endif
-
-  //: Create n element vector and copy data from data_block
-  vnl_vector(T const* data_block,unsigned int n);
-
-  //: Copy constructor
-  vnl_vector(vnl_vector<T> const&);
 
 #ifndef VXL_DOXYGEN_SHOULD_SKIP_THIS
 // <internal>
@@ -143,10 +144,10 @@ class vnl_vector
   ~vnl_vector();
 
   //: Return the length, number of elements, dimension of this vector.
-  unsigned size() const { return num_elmts; }
+  unsigned int size() const { return this->num_elmts; }
 
   //: Put value at given position in vector.
-  inline void put(unsigned int i, T const&);
+  inline void put(unsigned int i, T const& v);
 
   //: Get value at element i
   inline T get(unsigned int i) const;
@@ -488,26 +489,28 @@ class vnl_vector
 // Range check is performed.
 
 template <class T>
-inline T vnl_vector<T>::get(unsigned int index) const
+inline T vnl_vector<T>
+::get(unsigned int i) const
 {
-#ifdef ERROR_CHECKING
-  if (index >= this->num_elmts)     // If invalid index specified
-    vnl_error_vector_index("get", index);  // Raise exception
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+  if (i >= this->size())     // If invalid index specified
+    vnl_error_vector_index("get", i);  // Raise exception
 #endif
-  return this->data[index];
+  return this->data[i];
 }
 
 //: Puts the value at specified index. O(1).
 // Range check is performed.
 
 template <class T>
-inline void vnl_vector<T>::put(unsigned int index, T const& value)
+inline void vnl_vector<T>
+::put(unsigned int i, T const& v)
 {
-#ifdef ERROR_CHECKING
-  if (index >= this->num_elmts)     // If invalid index specified
-    vnl_error_vector_index("put", index); // Raise exception
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+  if (i >= this->size())     // If invalid index specified
+    vnl_error_vector_index("put", i); // Raise exception
 #endif
-  this->data[index] = value;    // Assign data value
+  this->data[i] = v;    // Assign data value
 }
 
 //: multiply matrix and (column) vector. O(m*n).

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -186,19 +186,33 @@ class vnl_vector_fixed
 
   //: Length of the vector.
   // This is always \a n.
-  unsigned size() const { return n; }
+  unsigned int size() const { return n; }
 
   //: Put value at given position in vector.
-  void put (unsigned int i, T const& v) { data_[i] = v; }
+  inline void put (unsigned int i, T const& v)
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (i >= this->size())           // If invalid index specified
+      vnl_error_vector_index("put", i); // Raise exception
+#endif
+    this->data_[i] = v;
+  }
 
   //: Get value at element i
-  T get (unsigned int i) const { return data_[i]; }
+  inline T get (unsigned int i) const
+  {
+#ifdef VNL_CONFIG_CHECK_BOUNDS
+    if (i >= this->size())            // If invalid index specified
+      vnl_error_vector_index("get", i);  // Raise exception
+#endif
+    return this->data_[i];
+  }
 
   //: Set all values to v
   vnl_vector_fixed& fill( T const& v )
   {
     for ( size_type i = 0; i < n; ++i )
-      data_[i] = v;
+      this->data_[i] = v;
     return *this;
   }
 


### PR DESCRIPTION
Currently, the behavior when accessing elements in vnl containers
using the get() and put() functions is inconsistent.  This patch
attempts to unify the behavior somewhat, such that exceptions
are raised when an out-of-bounds index is requested from `get()` or
`put()` and  `VNL_CONFIG_CHECK_BOUNDS` is enabled.

Importantly, the behavior of the functions in `vnl_error.h` has been
modified such that exceptions are raised, rather than simply
aborting.  This makes the behavior of the functions consistent
with their current documentation.

This patch addresses an issue (https://github.com/vxl/vxl/issues/206) raised here.