### PR TITLE
BUG: Fixed VNL_CONFIG_CHECK_BOUNDS bug

### DIFF
--- a/core/vnl/tests/test_diag_matrix.cxx
+++ b/core/vnl/tests/test_diag_matrix.cxx
@@ -105,7 +105,7 @@ void test_diag_matrix()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   // Get

--- a/core/vnl/tests/test_diag_matrix_fixed.cxx
+++ b/core/vnl/tests/test_diag_matrix_fixed.cxx
@@ -105,7 +105,7 @@ void test_diag_matrix_fixed()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   // Get

--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -53,7 +53,7 @@ void test_int()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   // Get

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -115,7 +115,7 @@ void test_int()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   // Get

--- a/core/vnl/tests/test_sym_matrix.cxx
+++ b/core/vnl/tests/test_sym_matrix.cxx
@@ -74,7 +74,7 @@ void test_int()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   // Get

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -51,7 +51,7 @@ void vnl_vector_test_int()
   // ACCESSORS //
   ///////////////
 
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
 
   {
   bool exceptionThrownAndCaught = false;

--- a/core/vnl/vnl_diag_matrix.h
+++ b/core/vnl/vnl_diag_matrix.h
@@ -130,7 +130,7 @@ class vnl_diag_matrix
   inline void put (unsigned r, unsigned c, T const& v) {
     assert(r == c);
     (void)c;
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->size())                  // If invalid size specified
       vnl_error_matrix_row_index("get", r); // Raise exception
 #endif
@@ -141,7 +141,7 @@ class vnl_diag_matrix
   inline T get (unsigned r, unsigned c) const {
     assert(r == c);
     (void)c;
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
   if (r >= this->size())                  // If invalid size specified
     vnl_error_matrix_row_index("get", r); // Raise exception
 #endif

--- a/core/vnl/vnl_diag_matrix_fixed.h
+++ b/core/vnl/vnl_diag_matrix_fixed.h
@@ -130,7 +130,7 @@ class vnl_diag_matrix_fixed
   {
     assert(r == c);
     (void)c;
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->size())                  // If invalid size specified
       vnl_error_matrix_row_index("put", r); // Raise exception
 #endif
@@ -142,7 +142,7 @@ class vnl_diag_matrix_fixed
   {
     assert(r == c);
     (void)c;
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->size())                  // If invalid size specified
       vnl_error_matrix_row_index("get", r); // Raise exception
 #endif

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -715,7 +715,7 @@ template<class T>
 inline T vnl_matrix<T>
 ::get(unsigned r, unsigned c) const
 {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
   if (r >= this->num_rows)                // If invalid size specified
     vnl_error_matrix_row_index("get", r); // Raise exception
   if (c >= this->num_cols)                // If invalid size specified
@@ -731,7 +731,7 @@ template<class T>
 inline void vnl_matrix<T>
 ::put(unsigned r, unsigned c, T const& v)
 {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
   if (r >= this->num_rows)                // If invalid size specified
     vnl_error_matrix_row_index("put", r); // Raise exception
   if (c >= this->num_cols)                // If invalid size specified

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -197,7 +197,7 @@ class vnl_matrix_fixed
   //: set element
   inline void put (unsigned r, unsigned c, T const& v)
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= num_rows)                // If invalid size specified
       vnl_error_matrix_row_index("put", r); // Raise exception
     if (c >= num_cols)                // If invalid size specified
@@ -209,7 +209,7 @@ class vnl_matrix_fixed
   //: get element
   inline T get (unsigned r, unsigned c) const
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= num_rows)                // If invalid size specified
       vnl_error_matrix_row_index("get", r); // Raise exception
     if (c >= num_cols)                // If invalid size specified

--- a/core/vnl/vnl_sym_matrix.h
+++ b/core/vnl/vnl_sym_matrix.h
@@ -121,7 +121,7 @@ class vnl_sym_matrix
   //: set element
   inline void put (unsigned r, unsigned c, T const& v)
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->nn_)                // If invalid size specified
       vnl_error_matrix_row_index("put", r); // Raise exception
     if (c >= this->nn_)                // If invalid size specified
@@ -133,7 +133,7 @@ class vnl_sym_matrix
   //: get element
   inline T get (unsigned r, unsigned c) const
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (r >= this->nn_)                // If invalid size specified
       vnl_error_matrix_row_index("get", r); // Raise exception
     if (c >= this->nn_)                // If invalid size specified

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -16,6 +16,7 @@
 //   Mar.2009 - Peter Vanroose - added arg_min() and arg_max()
 //   Oct.2010 - Peter Vanroose - mutators and setters now return *this
 // \endverbatim
+# include <vnl/vnl_error.h>
 
 #include <vcl_iosfwd.h>
 #include <vnl/vnl_tag.h>
@@ -492,7 +493,7 @@ template <class T>
 inline T vnl_vector<T>
 ::get(unsigned int i) const
 {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
   if (i >= this->size())     // If invalid index specified
     vnl_error_vector_index("get", i);  // Raise exception
 #endif
@@ -506,7 +507,7 @@ template <class T>
 inline void vnl_vector<T>
 ::put(unsigned int i, T const& v)
 {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
   if (i >= this->size())     // If invalid index specified
     vnl_error_vector_index("put", i); // Raise exception
 #endif

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -191,7 +191,7 @@ class vnl_vector_fixed
   //: Put value at given position in vector.
   inline void put (unsigned int i, T const& v)
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (i >= this->size())           // If invalid index specified
       vnl_error_vector_index("put", i); // Raise exception
 #endif
@@ -201,7 +201,7 @@ class vnl_vector_fixed
   //: Get value at element i
   inline T get (unsigned int i) const
   {
-#ifdef VNL_CONFIG_CHECK_BOUNDS
+#if VNL_CONFIG_CHECK_BOUNDS
     if (i >= this->size())            // If invalid index specified
       vnl_error_vector_index("get", i);  // Raise exception
 #endif


### PR DESCRIPTION
A bunch of #ifdefs were added when it should have been #ifs. This caused
building in Release to fail, because code that should not have been active, was

Bugs were introduced in 0dd5124a823be67f7779613fbc5d06a1af5d4508 and PR #207 

This bug was missed by travis-ci because it only manifested in Non-Debug modes (Release, RelWithDebInfo, etc...) It showed up [here](https://open.cdash.org/viewBuildError.php?buildid=4257489 ) because this cdash was configured for Release mode.

@DVigneault Does this patch look alright?