### PR TITLE
STYLE: Remove files that can no longer be accessed

### DIFF
--- a/vcl/win32-vc9/vcl_cmath.h
+++ b/vcl/win32-vc9/vcl_cmath.h
@@ -1,9 +1,0 @@
-#ifndef vcl_win32_vc_9_cmath_h_
-#define vcl_win32_vc_9_cmath_h_
-
-#include <cmath>
-
-#define vcl_generic_cmath_STD std
-#include "../generic/vcl_cmath.h"
-
-#endif // vcl_win32_vc_9_cmath_h_

--- a/vcl/win32-vc9/vcl_complex.h
+++ b/vcl/win32-vc9/vcl_complex.h
@@ -1,9 +1,0 @@
-#ifndef vcl_win32_vc_9_complex_h_
-#define vcl_win32_vc_9_complex_h_
-
-#include <complex>
-
-#define vcl_generic_complex_STD std
-#include "../generic/vcl_complex.h"
-
-#endif // vcl_win32_vc_9_complex_h_

--- a/vcl/win32-vc9/vcl_cstdlib.h
+++ b/vcl/win32-vc9/vcl_cstdlib.h
@@ -1,9 +1,0 @@
-#ifndef vcl_win32_vc_9_cstdlib_h_
-#define vcl_win32_vc_9_cstdlib_h_
-
-#include <cstdlib>
-
-#define vcl_generic_cstdlib_STD std
-#include "../generic/vcl_cstdlib.h"
-
-#endif // vcl_win32_vc_9_cstdlib_h_

--- a/vcl/win32-vc9/vcl_valarray.h
+++ b/vcl/win32-vc9/vcl_valarray.h
@@ -1,7 +1,0 @@
-#ifndef vcl_win32_vc_9_valarray_h_
-#define vcl_win32_vc_9_valarray_h_
-
-#define vcl_generic_valarray_STD std
-#include "../generic/vcl_valarray.h"
-
-#endif // vcl_win32_vc_9_valarray_h_


### PR DESCRIPTION
The win32-vc9 directory was tested and determined to be
unnecessary.  Previous patch (35893e482edc5feea54623b571c9041c5de57e1c)
set had removed compiling this code, but neglected to remove these
files.