### PR TITLE
Do not override CMake output variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,9 @@ endif()
 
 
 #-----------------------------------------------------------------------------
-set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib CACHE PATH
-     "Output directory for the vxl module libraries" )
-set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib CACHE PATH
-     "Output directory for the vxl static libraries" )
-set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin CACHE PATH
-     "Output directory for the vxl executables" )
+SETIFEMPTY(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+SETIFEMPTY(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+SETIFEMPTY(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 #-----------------------------------------------------------------------------
 SETIFEMPTY(CMAKE_INSTALL_LIBRARY_DESTINATION lib)


### PR DESCRIPTION
Project that use VXL internally, like ITK, will have these variables
overridden -- they are not usually cached.

Also, this prevents the variables from being non-advanced variables exposed
someone configuring VXL. They usually are not changed and should not be
considered advanced.