### PR TITLE
ENH: Adds CMake macro combining  PERFORM_CMAKE_TEST and SET_INVERT

### DIFF
--- a/config/cmake/config/VXLIntrospectionConfig.cmake
+++ b/config/cmake/config/VXLIntrospectionConfig.cmake
@@ -90,6 +90,21 @@ macro(PERFORM_CMAKE_TEST PLFM_TEST_FILE TEST)
 endmacro()
 
 #
+# Get the inverse result of calling PERFORM_CMAKE_TEST
+#
+# Sets the TEST to 0 if the corresponding program could be compiled
+# and linked
+#
+macro(PERFORM_CMAKE_INVERTTEST PLFM_TEST_FILE TEST)
+  if(NOT DEFINED "${TEST}" )
+    PERFORM_CMAKE_TEST( ${PLFM_TEST_FILE} ${TEST} )
+    SET_INVERT( ${TEST} "${${TEST}}")
+  else()
+    message( "Not performing test becaue ${TEST} already defined as ${${TEST}}" )
+  endif()
+endmacro()
+
+#
 # Perform a custom VXL try compile test with status output
 #
 # DIR is the directory containing the test project


### PR DESCRIPTION
The two macros, PERFORM_CMAKE_TEST and SET_INVERT are often used
together when a false result is expected. This macro combines both
of these together. NOTE: this does not replace the exact function of
the two old macros with the new one. Because PERFORM_CMAKE_TEST skips
its test if the TEST variable is defined, calling the two functions
in succession might have resulted in flipping the desired result, as
SET_INVERT did not know that PERFORM_CMAKE_TEST had decided not to
test. This was assumed to be a bug, and is addressed in the new macro
that combines the two functions.