### PR TITLE
ENH: Make size_type uniform accross vxl

### DIFF
--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -105,7 +105,7 @@ class vnl_matrix_fixed
 
  public:
   typedef vnl_matrix_fixed<T,num_rows,num_cols> self;
-  typedef unsigned int size_type;
+  typedef size_t size_type;
 
   //: Construct an empty num_rows*num_cols matrix
   vnl_matrix_fixed() {}

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -257,7 +257,7 @@ class vnl_vector
 
   //: Type defs for iterators
   typedef T element_type;
-  typedef unsigned  size_type;
+  typedef size_t  size_type;
 
   //: Type defs for iterators
   typedef T       *iterator;

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -90,7 +90,7 @@ class vnl_vector_fixed
 
  public:
   typedef vnl_vector_fixed<T,n> self;
-  typedef unsigned int size_type;
+  typedef size_t size_type;
   // Compile-time accessible attribute to get the dimensionality of the vector.
   enum { SIZE = n };
 

--- a/core/vnl/vnl_vector_fixed_ref.h
+++ b/core/vnl/vnl_vector_fixed_ref.h
@@ -32,7 +32,7 @@ class vnl_vector_fixed_ref_const
   const T* data_;
 
  public:
-  typedef unsigned int size_type;
+  typedef size_t size_type;
 
   vnl_vector_fixed_ref_const(vnl_vector_fixed<T,n> const& rhs) : data_(rhs.data_block()) {}
 


### PR DESCRIPTION
The value type for size_type was different in
different parts of vxl.  In all cases using
an alias to size_t seems to work well.

This has the advantage of being consistent
in all parts of vxl.