### PR TITLE
ENH: Apply across rows and columns of matrix_fixed

### DIFF
--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -33,6 +33,10 @@ int malloc_count = 0;
 # define check_count TEST("mallocs",malloc_count<=1,true)
 #endif
 
+// This function is used in testing later.
+template< typename T, unsigned int n >
+T sum_vector(const vnl_vector_fixed<T,n> &v) { return v.sum(); }
+
 static
 void
 test_size()
@@ -452,6 +456,16 @@ void test_double()
   vnl_double_2x2 d8(d8values);
   d8 = d8.apply(vcl_sqrt);
   TEST("apply(sqrt)", d8[0][0]==0 && d8[0][1]==1 && d8[1][0]==3 && d8[1][1]==4, true);
+
+  {
+  vnl_matrix_fixed<double,4,20> m(1.);
+  vnl_vector_fixed<double,4> vr = m.apply_rowwise(sum_vector);
+  for (unsigned int i = 0; i < vr.size(); ++i)
+    TEST("vr.apply_rowwise(sum_vector)", vr.get(i), 20.);
+  vnl_vector_fixed<double,20> vc = m.apply_columnwise(sum_vector);
+  for (unsigned int i = 0; i < vc.size(); ++i)
+    TEST("vc.apply_columnwise(sum_vector)", vc.get(i), 4.);
+  }
 
   // normalizations
   d8.normalize_rows();

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -405,6 +405,12 @@ class vnl_matrix_fixed
   //: Make a new matrix by applying function to each element.
   vnl_matrix_fixed apply(T (*f)(T const&)) const;
 
+  //: Make a vector by applying a function across rows.
+  vnl_vector_fixed<T,num_rows> apply_rowwise(T (*f)(vnl_vector_fixed<T,num_cols> const&)) const;
+
+  //: Make a vector by applying a function across columns.
+  vnl_vector_fixed<T,num_cols> apply_columnwise(T (*f)(vnl_vector_fixed<T,num_rows> const&)) const;
+
   //: Return transpose
   vnl_matrix_fixed<T,num_cols,num_rows> transpose() const;
 

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -160,7 +160,8 @@ vnl_matrix_fixed<T,nrows,ncols>::print(vcl_ostream& os) const
 
 template <class T, unsigned nrows, unsigned ncols>
 vnl_matrix_fixed<T,nrows,ncols>
-vnl_matrix_fixed<T,nrows,ncols>::apply(T (*f)(T const&)) const
+vnl_matrix_fixed<T,nrows,ncols>
+::apply(T (*f)(T const&)) const
 {
   vnl_matrix_fixed<T,nrows,ncols> ret;
   vnl_c_vector<T>::apply(this->data_[0], rows()*cols(), f, ret.data_block());
@@ -169,11 +170,36 @@ vnl_matrix_fixed<T,nrows,ncols>::apply(T (*f)(T const&)) const
 
 template <class T, unsigned nrows, unsigned ncols>
 vnl_matrix_fixed<T,nrows,ncols>
-vnl_matrix_fixed<T,nrows,ncols>::apply(T (*f)(T)) const
+vnl_matrix_fixed<T,nrows,ncols>
+::apply(T (*f)(T)) const
 {
   vnl_matrix_fixed<T,nrows,ncols> ret;
   vnl_c_vector<T>::apply(this->data_[0], rows()*cols(), f, ret.data_block());
   return ret;
+}
+
+//: Make a vector by applying a function across rows.
+template <class T, unsigned nrows, unsigned ncols>
+vnl_vector_fixed<T,nrows>
+vnl_matrix_fixed<T,nrows,ncols>
+::apply_rowwise(T (*f)(vnl_vector_fixed<T,ncols> const&)) const
+{
+  vnl_vector_fixed<T,nrows> v;
+  for (unsigned int i = 0; i < nrows; ++i)
+    v.put(i,f(this->get_row(i)));
+  return v;
+}
+
+//: Make a vector by applying a function across columns.
+template <class T, unsigned nrows, unsigned ncols>
+vnl_vector_fixed<T,ncols>
+vnl_matrix_fixed<T,nrows,ncols>
+::apply_columnwise(T (*f)(vnl_vector_fixed<T,nrows> const&)) const
+{
+  vnl_vector_fixed<T,ncols> v;
+  for (unsigned int i = 0; i < ncols; ++i)
+    v.put(i,f(this->get_column(i)));
+  return v;
 }
 
 ////--------------------------- Additions------------------------------------


### PR DESCRIPTION
`apply_rowwise` and `apply_columnwise` methods were recently added to `vnl_matrix`.  This patch extends this functionality to `vnl_matrix_fixed`.