### PR TITLE
COMP: Suppress valgrind long double false positives

### DIFF
--- a/contrib/brl/bbas/bgui/tests/test_histogram.cxx
+++ b/contrib/brl/bbas/bgui/tests/test_histogram.cxx
@@ -63,9 +63,11 @@ static void test_histogram(int argc, char* argv[])
 
              << "double [" << -std::numeric_limits< double>::max()
              << ' ' << std::numeric_limits< double>::max()  << "]\n"
-
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
              << "long double [" << -std::numeric_limits< long double>::max()
-             << ' ' << std::numeric_limits< long double>::max()  << "]\n";
+             << ' ' << std::numeric_limits< long double>::max()  << "]\n"
+#endif
+             << "\n";
 }
 
 TESTMAIN_ARGS(test_histogram);

--- a/core/vgui/tests/test_range_map.cxx
+++ b/core/vgui/tests/test_range_map.cxx
@@ -4,6 +4,7 @@
 #include <vgui/vgui_range_map.h>
 #include <vbl/vbl_array_1d.h>
 
+#define INCLUDE_LONG_DOUBLE_TESTS
 static void test_range_map()
 {
   //Test the range map parameter class
@@ -176,5 +177,8 @@ static void test_range_map()
 
   TEST("RGB vxl_byte values", Rval==127&&Gval==127&&Bval==127&&!RGBrmuc.offset()&&map_good, true);
 }
+#else
+static void test_range_map() { return; } // Can not test with valgrind
+#endif
 
 TESTMAIN(test_range_map);

--- a/core/vnl/algo/tests/test_util.cxx
+++ b/core/vnl/algo/tests/test_util.cxx
@@ -18,5 +18,7 @@ void test_util_fill_random(std::complex<T> *b, std::complex<T> *e, vnl_random &r
 
 macro(float);
 macro(double);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
 macro(long double);
+#endif
 #undef macro

--- a/core/vnl/algo/tests/test_util.h
+++ b/core/vnl/algo/tests/test_util.h
@@ -6,11 +6,13 @@ class vnl_random;
 #include <complex>
 #define macro(T) void test_util_fill_random(T *begin, T *end, vnl_random &rng)
 macro(float);
-macro(double);
-macro(long double);
 macro(std::complex<float>);
+macro(double);
 macro(std::complex<double>);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
+macro(long double);
 macro(std::complex<long double>);
+#endif
 #undef macro
 
 #endif

--- a/core/vnl/tests/test_bignum.cxx
+++ b/core/vnl/tests/test_bignum.cxx
@@ -69,6 +69,7 @@ static void run_constructor_tests()
   {vnl_bignum b(-1234567e3); TEST("vnl_bignum b(-1234567e3);", (double)b, -1234567e3);}
   {vnl_bignum b(double(0xf00000)); TEST("vnl_bignum b(double(0xf00000));", b, 0xf00000);}
 
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   std::cout << "long double constructor:\n";
   {vnl_bignum b(0.0L); TEST("vnl_bignum b(0.0L);", (long double)b, 0.0L);}
   {vnl_bignum b(1.0L); TEST("vnl_bignum b(1.0L);", (long double)b, 1.0L);}
@@ -78,6 +79,7 @@ static void run_constructor_tests()
   {vnl_bignum b(1234567e3L); TEST("vnl_bignum b(1234567e3L);", (long double)b, 1234567e3L);}
   {vnl_bignum b(-1234567e3L); TEST("vnl_bignum b(-1234567e3L);", (long double)b, -1234567e3L);}
   {vnl_bignum b((long double)(0xf00000)); TEST("vnl_bignum b((long double)(0xf00000));", (long double)b, (long double)0xf00000);}
+#endif
 
   std::cout << "char* constructor:\n";
   {vnl_bignum b("-1"); TEST("vnl_bignum b(\"-1\");", b, -1L);}

--- a/core/vnl/tests/test_math.cxx
+++ b/core/vnl/tests/test_math.cxx
@@ -286,7 +286,9 @@ static void test_math()
 
   TEST("std::numeric_limits<float>::has_infinity==true assumption",std::numeric_limits<float>::has_infinity, true);
   TEST("std::numeric_limits<double>::has_infinity==true assumption",std::numeric_limits<double>::has_infinity, true);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   TEST("std::numeric_limits<ldouble>::has_infinity==true assumption",std::numeric_limits<long double>::has_infinity, true);
+#endif
   if (! std::numeric_limits<float>::has_infinity && ! std::numeric_limits<double>::has_infinity)
   {
     std::cout << "Your platform doesn't appear to have an infinity. VXL is in places relatively\n"
@@ -297,7 +299,9 @@ static void test_math()
   }
   TEST("std::numeric_limits<float>::has_quiet_NaN==true assumption",std::numeric_limits<float>::has_quiet_NaN, true);
   TEST("std::numeric_limits<double>::has_quiet_NaN==true assumption",std::numeric_limits<double>::has_quiet_NaN, true);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   TEST("std::numeric_limits<ldouble>::has_quiet_NaN==true assumption",std::numeric_limits<long double>::has_quiet_NaN, true);
+#endif
   if (! std::numeric_limits<float>::has_quiet_NaN && ! std::numeric_limits<double>::has_quiet_NaN)
   {
     std::cout << "Your platform doesn't appear to have a quiet NaN. VXL is in places relatively\n"
@@ -311,23 +315,26 @@ static void test_math()
   const float ninf_f = - std::numeric_limits<float>::infinity();
   const double pinf_d =   std::numeric_limits<double>::infinity();
   const double ninf_d = - std::numeric_limits<double>::infinity();
-  const long double pinf_q =  std::numeric_limits<long double>::infinity();
-  const long double ninf_q = -std::numeric_limits<long double>::infinity();
-
   // Create NaN
   const float qnan_f = std::numeric_limits<float>::quiet_NaN();
   const double qnan_d = std::numeric_limits<double>::quiet_NaN();
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
+  const long double pinf_q =  std::numeric_limits<long double>::infinity();
+  const long double ninf_q = -std::numeric_limits<long double>::infinity();
   const long double qnan_q = std::numeric_limits<long double>::quiet_NaN();
+#endif
 
   std::cout << "pinf_f = " << pinf_f << " =  "<< print_hex(pinf_f) << "    sizeof " << sizeof(pinf_f) << '\n'
            << "ninf_f = " << ninf_f << " = " << print_hex(ninf_f) << "    sizeof " << sizeof(ninf_f) << '\n'
            << "pinf_d = " << pinf_d << " =  "<< print_hex(pinf_d) << "    sizeof " << sizeof(pinf_d) << '\n'
            << "ninf_d = " << ninf_d << " = " << print_hex(ninf_d) << "    sizeof " << sizeof(ninf_d) << '\n'
-           << "pinf_q = " << pinf_q << " =  "<< print_hex(pinf_q) << "    sizeof " << sizeof(pinf_q) << '\n'
-           << "ninf_q = " << ninf_q << " = " << print_hex(ninf_q) << "    sizeof " << sizeof(ninf_q) << '\n'
            << "qnan_f = " << qnan_f << " =  "<< print_hex(qnan_f) << "    sizeof " << sizeof(qnan_f) << '\n'
            << "qnan_d = " << qnan_d << " =  "<< print_hex(qnan_d) << "    sizeof " << sizeof(qnan_d) << '\n'
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
+           << "pinf_q = " << pinf_q << " =  "<< print_hex(pinf_q) << "    sizeof " << sizeof(pinf_q) << '\n'
+           << "ninf_q = " << ninf_q << " = " << print_hex(ninf_q) << "    sizeof " << sizeof(ninf_q) << '\n'
            << "qnan_q = " << qnan_q << " =  "<< print_hex(qnan_q) << "    sizeof " << sizeof(qnan_q) << '\n'
+#endif
            << std::endl;
 
   TEST("!isfinite(pinf_f)", vnl_math::isfinite(pinf_f), false);
@@ -350,6 +357,7 @@ static void test_math()
   TEST("!isinf(qnan_d)   ", vnl_math::isinf(qnan_d), false);
   TEST(" isnan(qnan_d)   ",  vnl_math::isnan(qnan_d), true);
 
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
 #ifndef __ICC // "long double" has no standard internal representation on different platforms/compilers
   TEST("!isfinite(pinf_q)", vnl_math::isfinite(pinf_q), false);
   TEST("!isfinite(ninf_q)", vnl_math::isfinite(ninf_q), false);
@@ -360,6 +368,7 @@ static void test_math()
   TEST("!isfinite(qnan_q)", vnl_math::isfinite(qnan_q), false);
   TEST("!isinf(qnan_q)   ", vnl_math::isinf(qnan_q), false);
 #endif // __ICC
+#endif
 
   TEST("!isfinite(huge_val(double))", vnl_math::isfinite(vnl_huge_val(double())), false);
   TEST("!isfinite(huge_val(float))",  vnl_math::isfinite(vnl_huge_val(float())),  false);
@@ -437,8 +446,10 @@ static void test_math()
     float          y_float       = 2;
     double         x_double      = 7;
     double         y_double      = 2;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     long double    x_long_double = 7;
     long double    y_long_double = 2;
+#endif
 
     TEST("vnl_math::remainder_truncated(x_short_u    ,y_short_u    )",vnl_math::remainder_truncated(x_short_u    ,y_short_u    ),+1);
     TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),+1);
@@ -448,7 +459,9 @@ static void test_math()
     TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),+1);
     TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),+1);
     TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),+1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),+1);
+#endif
 
     std::cout << "+ -" << std::endl;
 
@@ -457,14 +470,18 @@ static void test_math()
     y_long_s      *= -1;
     y_float       *= -1;
     y_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     y_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),+1);
     TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),+1);
     TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),+1);
     TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),+1);
     TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),+1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),+1);
+#endif
 
     std::cout << "- -" << std::endl;
 
@@ -473,14 +490,18 @@ static void test_math()
     x_long_s      *= -1;
     x_float       *= -1;
     x_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     x_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),-1);
     TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),-1);
     TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),-1);
     TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),-1);
     TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),-1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),-1);
+#endif
 
     std::cout << "- +" << std::endl;
 
@@ -489,14 +510,18 @@ static void test_math()
     y_long_s      *= -1;
     y_float       *= -1;
     y_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     y_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_truncated(x_short_s    ,y_short_s    )",vnl_math::remainder_truncated(x_short_s    ,y_short_s    ),-1);
     TEST("vnl_math::remainder_truncated(x_int_s      ,y_int_s      )",vnl_math::remainder_truncated(x_int_s      ,y_int_s      ),-1);
     TEST("vnl_math::remainder_truncated(x_long_s     ,y_long_s     )",vnl_math::remainder_truncated(x_long_s     ,y_long_s     ),-1);
     TEST("vnl_math::remainder_truncated(x_float      ,y_float      )",vnl_math::remainder_truncated(x_float      ,y_float      ),-1);
     TEST("vnl_math::remainder_truncated(x_double     ,y_double     )",vnl_math::remainder_truncated(x_double     ,y_double     ),-1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_truncated(x_long_double,y_long_double)",vnl_math::remainder_truncated(x_long_double,y_long_double),-1);
+#endif
     }
 
   /////////////
@@ -527,8 +552,10 @@ static void test_math()
     float          y_float       = 2;
     double         x_double      = 7;
     double         y_double      = 2;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     long double    x_long_double = 7;
     long double    y_long_double = 2;
+#endif
 
     TEST("vnl_math::remainder_floored(x_short_u    ,y_short_u    )",vnl_math::remainder_floored(x_short_u    ,y_short_u    ),+1);
     TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),+1);
@@ -538,7 +565,9 @@ static void test_math()
     TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),+1);
     TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),+1);
     TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),+1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),+1);
+#endif
 
     std::cout << "+ -" << std::endl;
 
@@ -547,14 +576,18 @@ static void test_math()
     y_long_s      *= -1;
     y_float       *= -1;
     y_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     y_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),-1);
     TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),-1);
     TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),-1);
     TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),-1);
     TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),-1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),-1);
+#endif
 
     std::cout << "- -" << std::endl;
 
@@ -563,14 +596,18 @@ static void test_math()
     x_long_s      *= -1;
     x_float       *= -1;
     x_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     x_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),-1);
     TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),-1);
     TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),-1);
     TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),-1);
     TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),-1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),-1);
+#endif
 
     std::cout << "- +" << std::endl;
 
@@ -579,14 +616,18 @@ static void test_math()
     y_long_s      *= -1;
     y_float       *= -1;
     y_double      *= -1;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     y_long_double *= -1;
+#endif
 
     TEST("vnl_math::remainder_floored(x_short_s    ,y_short_s    )",vnl_math::remainder_floored(x_short_s    ,y_short_s    ),+1);
     TEST("vnl_math::remainder_floored(x_int_s      ,y_int_s      )",vnl_math::remainder_floored(x_int_s      ,y_int_s      ),+1);
     TEST("vnl_math::remainder_floored(x_long_s     ,y_long_s     )",vnl_math::remainder_floored(x_long_s     ,y_long_s     ),+1);
     TEST("vnl_math::remainder_floored(x_float      ,y_float      )",vnl_math::remainder_floored(x_float      ,y_float      ),+1);
     TEST("vnl_math::remainder_floored(x_double     ,y_double     )",vnl_math::remainder_floored(x_double     ,y_double     ),+1);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     TEST("vnl_math::remainder_floored(x_long_double,y_long_double)",vnl_math::remainder_floored(x_long_double,y_long_double),+1);
+#endif
     }
 
 }

--- a/core/vnl/tests/test_numeric_traits.cxx
+++ b/core/vnl/tests/test_numeric_traits.cxx
@@ -40,16 +40,22 @@ void test_static_const_definition()
   ALL(unsigned long);
   ALL(float);
   ALL(double);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   ALL(long double);
+#endif
   ONE_ZERO( std::complex<float> );
   ONE_ZERO( std::complex<double> );
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   ONE_ZERO( std::complex<long double> );
+#endif
 
 #undef ONE_ZERO
 #undef ALL
 }
 
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
 extern "C" { long double increment(long double x) { return x+1; } }
+#endif
 
 void test_numeric_traits()
 {
@@ -86,8 +92,10 @@ void test_numeric_traits()
   TEST("vnl_numeric_traits<float>::one", vnl_numeric_traits<float>::one, 1.0f);
   TEST("vnl_numeric_traits<double>::zero", vnl_numeric_traits<double>::zero, 0.0);
   TEST("vnl_numeric_traits<double>::one", vnl_numeric_traits<double>::one, 1.0);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   TEST("vnl_numeric_traits<long double>::zero", vnl_numeric_traits<long double>::zero, 0.0);
   TEST("vnl_numeric_traits<long double>::one", vnl_numeric_traits<long double>::one, 1.0);
+#endif
   TEST("vnl_numeric_traits<std::complex<float> >::zero",
        vnl_numeric_traits<std::complex<float> >::zero, std::complex<float>(0.0f));
   TEST("vnl_numeric_traits<std::complex<float> >::one",
@@ -96,11 +104,12 @@ void test_numeric_traits()
        vnl_numeric_traits<std::complex<double> >::zero, std::complex<double>(0.0));
   TEST("vnl_numeric_traits<std::complex<double> >::one",
        vnl_numeric_traits<std::complex<double> >::one, std::complex<double>(1.0));
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   TEST("vnl_numeric_traits<std::complex<long double> >::zero",
        vnl_numeric_traits<std::complex<long double> >::zero, std::complex<long double>(0.0));
   TEST("vnl_numeric_traits<std::complex<long double> >::one",
        vnl_numeric_traits<std::complex<long double> >::one, std::complex<long double>(1.0));
-
+#endif
   // Testing maxval values
 
   char cm = vnl_numeric_traits<char>::maxval;
@@ -114,7 +123,9 @@ void test_numeric_traits()
   unsigned long ulm = vnl_numeric_traits<unsigned long>::maxval;
   float fm = vnl_numeric_traits<float>::maxval;
   double dm = vnl_numeric_traits<double>::maxval;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   long double ldm = vnl_numeric_traits<long double>::maxval;
+#endif
 
   std::cout << " vnl_numeric_traits<bool>::maxval = " << vnl_numeric_traits<bool>::maxval << '\n'
            << " vnl_numeric_traits<char>::maxval = " << (int)cm << '\n'
@@ -128,7 +139,10 @@ void test_numeric_traits()
            << " vnl_numeric_traits<unsigned long>::maxval = " << ulm << '\n'
            << " vnl_numeric_traits<float>::maxval = " << fm << '\n'
            << " vnl_numeric_traits<double>::maxval = " << dm << '\n'
-           << " vnl_numeric_traits<long double>::maxval = " << ldm << '\n';
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
+           << " vnl_numeric_traits<long double>::maxval = " << ldm << '\n'
+#endif
+           << '\n';
 
   // Verify that these values are positive and satisfy certain constraints:
   TEST("vnl_numeric_traits<char>::maxval must be at least 127", cm >= 127, true);
@@ -142,7 +156,9 @@ void test_numeric_traits()
   TEST("vnl_numeric_traits<unsigned long>::maxval must be larger than that", ulm>(unsigned long)lm, true);
   TEST("vnl_numeric_traits<float>::maxval must be at least 1e33", fm>1e33, true);
   TEST("vnl_numeric_traits<double>::maxval must be larger than that", dm>fm, true);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   TEST("vnl_numeric_traits<long double>::maxval must be at least as large", ldm>=dm, true);
+#endif
 
   // Verify that there is nothing larger than these maxval values:
   // unsigned cases:
@@ -202,6 +218,7 @@ void test_numeric_traits()
   // there should only be 2 zeros in the representation: the sign bits of mantissa and of exponent:
   TEST("vnl_numeric_traits<double>::maxval must be the largest possible", nr_of_ones, 8*sizeof(double)-2);
 
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   x = (unsigned char*)(&ldm);
   std::cout << "vnl_numeric_traits<long double>::maxval has internal representation ";
 #if VXL_BIG_ENDIAN
@@ -214,6 +231,7 @@ void test_numeric_traits()
       std::cout << n;
     }
   std::cout << '\n';
+#endif
 }
 
 TESTMAIN(test_numeric_traits);

--- a/vcl/tests/test_cmath.cxx
+++ b/vcl/tests/test_cmath.cxx
@@ -17,7 +17,9 @@ int test_cmath_main(int /*argc*/,char* /*argv*/[])
     long   xl = 314159265L;
     float  xf = 13.14159265358979323846f;
     double xd = 23.14159265358979323846;
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     long double ld = xd;
+#endif
     vcl_complex<double> xc(xd,0.0);
 
 #define macro(var, type) \
@@ -31,7 +33,9 @@ do { \
     macro(xl, long);
     macro(xf, float);
     macro(xd, double);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
     macro(ld, long double);
+#endif
     macro(xc, vcl_complex<double>);
 #undef macro
   }
@@ -61,7 +65,9 @@ do { \
   } while (false)
   macro(float, 1e-6);        // actually sqrtf()
   macro(double, 1e-14);
+#ifdef INCLUDE_LONG_DOUBLE_TESTS
   macro(long double, 1e-14); // actually sqrtl()
+#endif
 #undef macro
 
   return 0;

--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -227,6 +227,15 @@ typedef int saw_VCL_FOR_SCOPE_HACK;
 // Check if the compiler (claims to) support C++11.
 #if defined(NDEBUG)
 # define VXL_USED_IN_DEBUG(x)
+/* Valgrind does not support "long double" types and this results
+ * in numerous false positive memory errors being reported.
+ * Turn off tests involving "long double" types by default
+ * when compiling in "Debug" mode.
+ * You can override this behavior by including a compiler
+ * flag of -DINCLUDE_LONG_DOUBLE_TESTS when compiling
+ * in debug mode to enable these tests.
+ */
+# define INCLUDE_LONG_DOUBLE_TESTS
 #else
 # define VXL_USED_IN_DEBUG(x) x
 #endif


### PR DESCRIPTION
Valgrind does not support long double (see #161 for details)

This patch supressesses long double tests when built in debug mode
(i.e. them mode used for valgrind), but does provide a mechanism for
forcing these tests, even in debug mode.

This is needed to help clean up the nightly valgrind warnings.