### PR TITLE
COMP: Fix advanced tr1 feature use and C++11

### DIFF
--- a/vcl/tests/test_memory.cxx
+++ b/vcl/tests/test_memory.cxx
@@ -73,7 +73,7 @@ int test_memory_main(int /*argc*/,char* /*argv*/[])
   ASSERT(instances == 0, "auto_ptr leaked an object");
 
   // Test parts of <memory> related to C++ 0x (if available)
-#if VCL_INCLUDE_CXX_0X
+#if ( VCL_INCLUDE_CXX_0X == 1) || ( __cplusplus >= 201103L )
   // reset instance count for shared pointer tests
   instances = 0;
   {

--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -888,6 +888,36 @@ typedef int saw_VCL_FOR_SCOPE_HACK;
 #define vcl_indirect_array std::indirect_array
 #define vcl_vector std::vector
 
+#if __cplusplus >= 201103L
+#define vcl_bad_weak_ptr std::bad_weak_ptr
+#define vcl_shared_ptr std::shared_ptr
+#define vcl_static_pointer_cast std::static_pointer_cast
+#define vcl_dynamic_pointer_cast std::dynamic_pointer_cast
+#define vcl_const_pointer_cast std::const_pointer_cast
+#define vcl_get_deleter std::get_deleter
+#define vcl_weak_ptr std::weak_ptr
+#define vcl_enable_shared_from_this std::enable_shared_from_this
 #endif
+#if VCL_INCLUDE_CXX_0X
+// [20.6] lib.memory (additions in 0x draft: 2006-11-06)
+#include <tr1/memory>
+/* The following includes are needed to preserve backwards
+   compatilibility for external applications.  Previously
+   definitions were defined in multiple headers with conditional
+   ifndef guards, but we now include a reference header
+   instead */
+//no dependancies remove comment above
+//vcl alias names to std names
+#define vcl_bad_weak_ptr std::tr1::bad_weak_ptr
+#define vcl_shared_ptr std::tr1::shared_ptr
+#define vcl_static_pointer_cast std::tr1::static_pointer_cast
+#define vcl_dynamic_pointer_cast std::tr1::dynamic_pointer_cast
+#define vcl_const_pointer_cast std::tr1::const_pointer_cast
+#define vcl_get_deleter std::tr1::get_deleter
+#define vcl_weak_ptr std::tr1::weak_ptr
+#define vcl_enable_shared_from_this std::tr1::enable_shared_from_this
+#endif //VCL_INCLUDE_CXX_0X
+
+#endif //VXL_LEGACY_FUTURE_REMOVE
 
 #endif // vcl_compiler_h_


### PR DESCRIPTION
Tests that are only built for the dashboard were failing.
These a bit of logic that was accidently removed during
recent cleanups.  Add ability to compile with both
tr1 and C++11 features.