### PR TITLE
BUG: Missed moving header for old MSVS compiler

### DIFF
--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -485,6 +485,7 @@ typedef int saw_VCL_FOR_SCOPE_HACK;
 // Microsoft has finally implemented snprintf in Visual Studio 2015. On earlier
 // versions you can simulate it as below.
 #if defined(_MSC_VER) && _MSC_VER < 1900
+#include <cstdarg>
 __inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
 {
     int count = -1;

--- a/vcl/vcl_cstdio.h
+++ b/vcl/vcl_cstdio.h
@@ -2,7 +2,6 @@
 #define vcl_cstdio_h_
 
 #include <cstdio>
-#include <cstdarg>
 #include "vcl_compiler.h"
 
 #endif // vcl_cstdio_h_


### PR DESCRIPTION
Old MSVS compilers also need cstdarg included
when overriding the snprintf functions.