### PR TITLE
vcl header install locations

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -112,19 +112,27 @@ macro( vxl_add_library )
     if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
       ## Identify the relative path for installing the header files and txx files
       string(REPLACE ${VXL_ROOT_SOURCE_DIR} "${VXL_INSTALL_INCLUDE_DIR}" relative_install_path ${CMAKE_CURRENT_SOURCE_DIR})
+      ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.10)
+        target_include_directories(${lib_name}
+          PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:${relative_install_path}>
+        )
+      endif()
     else()
       set(relative_install_path "${VXL_INSTALL_INCLUDE_DIR}")
       if(DEFINED header_install_dir)
         set(relative_install_path "${relative_install_path}/${header_install_dir}")
       endif()
-    endif()
-    ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
-    if(${CMAKE_VERSION} VERSION_GREATER 2.8.10)
-      target_include_directories(${lib_name}
-        PUBLIC
-          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${relative_install_path}>
-      )
+      ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.10)
+        target_include_directories(${lib_name}
+          PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:${VXL_INSTALL_INCLUDE_DIR}>
+        )
+      endif()
     endif()
     INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${lib_srcs})
   endif()

--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -103,7 +103,7 @@ set( vcl_sources
 #aux_source_directory(Templates vcl_sources)
 vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vcl
   LIBRARY_SOURCES ${vcl_sources}
-  HEADER_INSTALL_DIR vcl)
+  )
 if(UNIX)
   target_link_libraries(${VXL_LIB_PREFIX}vcl m)
 endif()


### PR DESCRIPTION
@hjmjohnson This fixes some of ITK's 'build against an install tree' issues.  For the others, we could maybe use the `snapshot_redact_cmd` of the `UpdateFromUpstream.sh` script.