### PR TITLE
avoid accessing element_ if array is empty

### DIFF
--- a/core/vbl/vbl_array_3d.h
+++ b/core/vbl/vbl_array_3d.h
@@ -84,6 +84,8 @@ class vbl_array_3d
   ~vbl_array_3d () { destruct(); }
   vbl_array_3d<T>& operator=(vbl_array_3d<T> const& that) {
     resize(that.row1_count_, that.row2_count_, that.row3_count_);
+        if(row1_count_*row2_count_*row3_count_==0)
+                return *this;
     set(that.data_block());
     return *this;
   }


### PR DESCRIPTION
fixes a crash caused by calling data_block() on an empty vbl_array_3d