### PR TITLE
Do not use target_include_directories with CMake 2.8.11.

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -113,7 +113,7 @@ macro( vxl_add_library )
       ## Identify the relative path for installing the header files and txx files
       string(REPLACE ${VXL_ROOT_SOURCE_DIR} "${VXL_INSTALL_INCLUDE_DIR}" relative_install_path ${CMAKE_CURRENT_SOURCE_DIR})
       ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
-      if(${CMAKE_VERSION} VERSION_GREATER 2.8.10)
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11)
         target_include_directories(${lib_name}
           PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -126,7 +126,7 @@ macro( vxl_add_library )
         set(relative_install_path "${relative_install_path}/${header_install_dir}")
       endif()
       ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
-      if(${CMAKE_VERSION} VERSION_GREATER 2.8.10)
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11)
         target_include_directories(${lib_name}
           PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
This addresses warnings like:

CMake Error in contrib/prip/vdtop/CMakeLists.txt:
  Target "vdtop" INTERFACE_INCLUDE_DIRECTORIES property contains relative
  path:

    "include/vxl/contrib/prip/vdtop"

CMake Error in contrib/prip/vpyr/CMakeLists.txt:
  Target "vpyr" INTERFACE_INCLUDE_DIRECTORIES property contains relative
  path:

    "include/vxl/contrib/prip/vpyr"

Although current target_include_directories documentation recommends using a
relative path for the install interface.  The warning is not present with
CMake 2.8.12.

@bradking please review.

CC: @hjmjohnson @blowekamp