### PR TITLE
fix std compile error under Visual Studio 2012

### DIFF
--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_fit_fat_pocket.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_fit_fat_pocket.cxx
@@ -14,6 +14,7 @@
 #include <vnl/vnl_least_squares_function.h>
 #include <vnl/vnl_cost_function.h>
 #include <vgl/vgl_pointset_3d.h>
+#include <functional>   // std::greater
 
 class neutral_residual_function : public vnl_least_squares_function{
  public:

--- a/core/vil/file_formats/vil_j2k_image.cxx
+++ b/core/vil/file_formats/vil_j2k_image.cxx
@@ -372,7 +372,7 @@ vil_j2k_image::get_copy_view_decimated_by_size(unsigned sample0,
   //We don't want infinite hangs or application crashes.
   unsigned int maxDim = mRemoteFile ? mMaxRemoteDimension : mMaxLocalDimension;
   if ( output_width > maxDim || output_height > maxDim ) {
-    unsigned int biggestDim = std::max( output_width, output_height );
+    unsigned int biggestDim = (std::max)( output_width, output_height );
     double zoomFactor = ((double)maxDim) / ((double)biggestDim);
     output_width  = (unsigned int) ( ((double)output_width)  * zoomFactor );
     output_height = (unsigned int) ( ((double)output_height) * zoomFactor );

--- a/core/vil/file_formats/vil_nitf2_image.cxx
+++ b/core/vil/file_formats/vil_nitf2_image.cxx
@@ -646,10 +646,10 @@ vil_image_view_base_sptr vil_nitf2_image::get_block_j2k( unsigned int blockIndex
   //if this is a bug in the file or if we need to handle it.  Anyway,
   //we handle it by using std::min.  test file named p0_11xa,ntf exhibits
   //this issue
-  unsigned int i0 = std::min( blockIndexX * size_block_i(), ni() );
-  unsigned int num_i = std::min( size_block_i(), ni() - i0 );
-  unsigned int j0 = std::min( blockIndexY * size_block_j(), nj() );
-  unsigned int num_j = std::min( size_block_j(), nj() - j0 );
+  unsigned int i0 = (std::min)( blockIndexX * size_block_i(), ni() );
+  unsigned int num_i = (std::min)( size_block_i(), ni() - i0 );
+  unsigned int j0 = (std::min)( blockIndexY * size_block_j(), nj() );
+  unsigned int num_j = (std::min)( size_block_j(), nj() - j0 );
   return get_copy_view( i0, num_i, j0, num_j );
 }
 


### PR DESCRIPTION
Under Visual Studio 2012, std::less and std::greater are defined in <functional>.  Adding this header to avoid compiler error

second std type of compiler error was occurred in windows when v3p/j2k is used.  This error is fixed by avoiding the confliction between max/min in windows.h and std::max/std::min