### PR TITLE
ENH: Compose new matrix by row and column indices.

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -95,6 +95,51 @@ void test_int()
 
   TEST("m2.put(1,1,3)", (m2.put(1,1,3),m2.get(1,1)), 3);
   TEST("m2.get(1,1)", m2.get(1,1), 3);
+
+  ///////////////////////////////
+  // Row and Column Operations //
+  ///////////////////////////////
+
+  {
+    int some_data[2*3] = { 1, 2, 3,
+                           4, 5, 6 };
+    vnl_matrix<int> mrc(some_data, 2, 3);
+    vnl_vector<int> v;
+
+    TEST("v = mrc.get_row(0)",
+         (v = mrc.get_row(0),
+          (v.get(0)==1 && v.get(1)==2 && v.get(2)==3)), true);
+    TEST("v = mrc.get_row(1)",
+         (v = mrc.get_row(1),
+          (v.get(0)==4 && v.get(1)==5 && v.get(2)==6)), true);
+
+    TEST("v = mrc.get_column(0)",
+         (v = mrc.get_column(0),
+          (v.get(0)==1 && v.get(1)==4)), true);
+    TEST("v = mrc.get_column(1)",
+         (v = mrc.get_column(1),
+          (v.get(0)==2 && v.get(1)==5)), true);
+    TEST("v = mrc.get_column(2)",
+         (v = mrc.get_column(2),
+          (v.get(0)==3 && v.get(1)==6)), true);
+
+    // Indices: {1, 0, 1}
+    vnl_vector<unsigned int> indices(3, 1);
+    indices.put(1,0);
+    vnl_matrix<int> mi;
+
+    TEST("mi = mrc.get_rows(indices)",
+         (mi = mrc.get_rows(indices),
+         (mi.get_row(0)==mrc.get_row(1)
+       && mi.get_row(1)==mrc.get_row(0)
+       && mi.get_row(2)==mrc.get_row(1))), true);
+    TEST("mi = mrc.get_columns(indices)",
+         (mi = mrc.get_columns(indices),
+         (mi.get_column(0)==mrc.get_column(1)
+       && mi.get_column(1)==mrc.get_column(0)
+       && mi.get_column(2)==mrc.get_column(1))), true);
+  }
+
   int v2_data[] = {2,3};
   TEST("m2.get_diagonal()", m2.get_diagonal(), vnl_vector<int>(2,2,v2_data));
   TEST("m0 == m2", (m0 == m2), false);

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -400,6 +400,12 @@ class vnl_matrix
   //: Get a vector equal to the given column
   vnl_vector<T> get_column(unsigned c) const;
 
+  //: Get a matrix composed of rows from the indices specified in the supplied vector.
+  vnl_matrix<T> get_rows(vnl_vector<unsigned int> i) const;
+
+  //: Get a matrix composed of columns from the indices specified in the supplied vector.
+  vnl_matrix<T> get_columns(vnl_vector<unsigned int> i) const;
+
   //: Get n rows beginning at rowstart
   vnl_matrix<T> get_n_rows(unsigned rowstart, unsigned n) const;
 

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -978,6 +978,30 @@ vnl_vector<T> vnl_matrix<T>::get_column(unsigned column_index) const
   return v;
 }
 
+//: Create a vector out of row[row_index].
+template <class T>
+vnl_matrix<T>
+vnl_matrix<T>
+::get_rows(vnl_vector<unsigned int> i) const
+{
+  vnl_matrix<T> m(i.size(), this->num_cols);
+  for (unsigned int j = 0; j < i.size(); ++j)
+    m.set_row(j, this->get_row(i.get(j)));
+  return m;
+}
+
+//: Create a vector out of column[column_index].
+template <class T>
+vnl_matrix<T>
+vnl_matrix<T>
+::get_columns(vnl_vector<unsigned int> i) const
+{
+  vnl_matrix<T> m(this->num_rows, i.size());
+  for (unsigned int j = 0; j < i.size(); ++j)
+    m.set_column(j, this->get_column(i.get(j)));
+  return m;
+}
+
 //: Return a vector with the content of the (main) diagonal
 template <class T>
 vnl_vector<T> vnl_matrix<T>::get_diagonal() const


### PR DESCRIPTION
This patch adds methods allowing a matrix to be composed from the rows/columns of a given matrix by supplying a vector of row/column indices.  This is conceptually analogous to what can be done in other languages/packages, e.g., in R:

    m <- matrix(data = c(1, 2, 3, 4, 5, 6), nrow = 2, ncol = 3)
    m.from.rows <- m[c(2,1,1,2),]
    m.from.cols <- m[,c(3,2,1,1,2,3)]

One specific use case might be in sorting eigenvectors based on eigenvalues.

    vnl_real_eigensystem eig(SomeMatrix);
    const auto eigenvectors = vnl_real(eig.V);
    const auto eigenvalues = vnl_real(eig.D.get_diagonal());
    
    TSort sort;
    vnl_vector<TReal>  sortedEigenvalues;
    vnl_vector<TIndex> sortedEigenvalueIndices;
    sort.vector_sort(eigenvalues, sortedEigenvalues, sortedEigenvalueIndices);
    const auto sortedEigenvectors = eigenvectors.get_columns(sortedEigenvalueIndices);
