### PR TITLE
Prevent integer overflow on Windows

### DIFF
--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
@@ -9,8 +9,8 @@
 boxm2_opencl_cache::boxm2_opencl_cache(bocl_device_sptr device)
 : bytesInCache_(0), block_info_(VXL_NULLPTR), device_(device)
 {
-  // store max bytes allowed in cache - use only 80 percent of the memory
-  maxBytesInCache_ = (size_t) (device->info().total_global_memory_ * 0.7);
+  // store max bytes allowed in cache - use only 70 percent of the memory
+  maxBytesInCache_ = (std::size_t) (device->info().total_global_memory_ * 0.7);
 
   // by default try to create an LRU cache
 

--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
@@ -9,7 +9,7 @@
 boxm2_opencl_cache::boxm2_opencl_cache(bocl_device_sptr device)
 : bytesInCache_(0), block_info_(VXL_NULLPTR), device_(device)
 {
-  // store max bytes allowed in cache - use only 70 percent of the memory
+  // store max bytes allowed in cache - use only 80 percent of the memory
   maxBytesInCache_ = (size_t) (device->info().total_global_memory_ * 0.7);
 
   // by default try to create an LRU cache

--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
@@ -10,7 +10,7 @@ boxm2_opencl_cache::boxm2_opencl_cache(bocl_device_sptr device)
 : bytesInCache_(0), block_info_(VXL_NULLPTR), device_(device)
 {
   // store max bytes allowed in cache - use only 80 percent of the memory
-  maxBytesInCache_ = (unsigned long) (device->info().total_global_memory_ * 0.7);
+  maxBytesInCache_ = (size_t) (device->info().total_global_memory_ * 0.7);
 
   // by default try to create an LRU cache
 

--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.cxx
@@ -9,7 +9,7 @@
 boxm2_opencl_cache::boxm2_opencl_cache(bocl_device_sptr device)
 : bytesInCache_(0), block_info_(VXL_NULLPTR), device_(device)
 {
-  // store max bytes allowed in cache - use only 80 percent of the memory
+  // store max bytes allowed in cache - use only 70 percent of the memory
   maxBytesInCache_ = (size_t) (device->info().total_global_memory_ * 0.7);
 
   // by default try to create an LRU cache

--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.h
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.h
@@ -106,8 +106,8 @@ class boxm2_opencl_cache: public vbl_ref_count
     bool lru_remove_last(std::pair<boxm2_scene_sptr, boxm2_block_id> & scene_id_pair); //removes all data and block with this ID. returns false if lru is empty
     std::list<std::pair<boxm2_scene_sptr,boxm2_block_id> > lru_order_;
     unsigned int maxBlocksInCache;
-    size_t bytesInCache_;
-    size_t maxBytesInCache_;
+    std::size_t bytesInCache_;
+    std::size_t maxBytesInCache_;
 
     ////////////////////////////////////////////////////////////////////////////
     // bocl_mem objects

--- a/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.h
+++ b/contrib/brl/bseg/boxm2/ocl/boxm2_opencl_cache.h
@@ -106,8 +106,8 @@ class boxm2_opencl_cache: public vbl_ref_count
     bool lru_remove_last(std::pair<boxm2_scene_sptr, boxm2_block_id> & scene_id_pair); //removes all data and block with this ID. returns false if lru is empty
     std::list<std::pair<boxm2_scene_sptr,boxm2_block_id> > lru_order_;
     unsigned int maxBlocksInCache;
-    unsigned long bytesInCache_;
-    unsigned long maxBytesInCache_;
+    size_t bytesInCache_;
+    size_t maxBytesInCache_;
 
     ////////////////////////////////////////////////////////////////////////////
     // bocl_mem objects


### PR DESCRIPTION
On windows, unsigned long is a 4 byte integer.  For a GPU with very large VRAM (e.g. 12GB on NVIDIA Titan-X), the total global memory exceeds the maximum value a 4 byte unsigned long can represent.  Change type of "maxBytesInCache_" and "bytesInCache_" to size_t to avoid integer overflow.