### PR TITLE
Add option to compute rigid transform via vgl_compute_similarity_3d

### DIFF
--- a/core/vgl/algo/CMakeLists.txt
+++ b/core/vgl/algo/CMakeLists.txt
@@ -18,6 +18,7 @@ set( vgl_algo_sources
   vgl_norm_trans_2d.hxx                    vgl_norm_trans_2d.h
   vgl_norm_trans_3d.hxx                    vgl_norm_trans_3d.h
   vgl_compute_similarity_3d.hxx            vgl_compute_similarity_3d.h
+  vgl_compute_rigid_3d.hxx            vgl_compute_rigid_3d.h
                                            vgl_h_matrix_1d_compute.h
   vgl_h_matrix_1d_compute_linear.cxx       vgl_h_matrix_1d_compute_linear.h
   vgl_h_matrix_1d_compute_3point.cxx       vgl_h_matrix_1d_compute_3point.h

--- a/core/vgl/algo/Templates/compute_rigid_3d+double-.cxx
+++ b/core/vgl/algo/Templates/compute_rigid_3d+double-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of vgl_compute_rigid_3d<double>
+#include <vgl/algo/vgl_compute_rigid_3d.hxx>
+VGL_COMPUTE_RIGID_3D_INSTANTIATE(double);

--- a/core/vgl/algo/tests/CMakeLists.txt
+++ b/core/vgl/algo/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable( vgl_algo_test_all
   test_driver.cxx
 
   test_compute_similarity_3d.cxx
+  test_compute_rigid_3d.cxx
   test_conic.cxx
   test_convex_hull_2d.cxx
   test_ellipsoid.cxx
@@ -24,6 +25,7 @@ add_executable( vgl_algo_test_all
 target_link_libraries( vgl_algo_test_all ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}testlib )
 
 add_test( NAME vgl_test_compute_similarity_3d COMMAND $<TARGET_FILE:vgl_algo_test_all> test_compute_similarity_3d )
+add_test( NAME vgl_test_compute_rigid_3d COMMAND $<TARGET_FILE:vgl_algo_test_all> test_compute_rigid_3d )
 add_test( NAME vgl_test_conic COMMAND $<TARGET_FILE:vgl_algo_test_all> test_conic )
 add_test( NAME vgl_test_convex_hull_2d COMMAND $<TARGET_FILE:vgl_algo_test_all> test_convex_hull_2d)
 add_test( NAME vgl_test_ellipsoid COMMAND $<TARGET_FILE:vgl_algo_test_all> test_ellipsoid)

--- a/core/vgl/algo/tests/test_compute_rigid_3d.cxx
+++ b/core/vgl/algo/tests/test_compute_rigid_3d.cxx
@@ -1,23 +1,22 @@
 #include <iostream>
 #include <testlib/testlib_test.h>
-#include <vgl/algo/vgl_compute_similarity_3d.h>
+#include <vgl/algo/vgl_compute_rigid_3d.h>
 #include <vgl/vgl_vector_3d.h>
 #include <vcl_compiler.h>
 #include <vnl/vnl_random.h>
 
 
+namespace vgl_test_compute_rigid_3d {
+
 std::vector<vgl_point_3d<double> >
 transform_points(const std::vector<vgl_point_3d<double> >& points,
-                 double s,
                  vgl_rotation_3d<double> R,
                  vgl_vector_3d<double> t)
 {
   std::vector<vgl_point_3d<double> > t_pts;
   for (unsigned i=0; i<points.size(); ++i)
   {
-    vgl_point_3d<double> p = R*points[i];
-    p.set(s*p.x(), s*p.y(), s*p.z());
-    p += t;
+    vgl_point_3d<double> p = R*points[i] + t;
     t_pts.push_back(p);
   }
   return t_pts;
@@ -44,9 +43,9 @@ double alignment_error(const std::vector<vgl_point_3d<double> >& points1,
   }
   return std::sqrt(error/points1.size());
 }
+}
 
-
-static void test_compute_similarity_3d()
+static void test_compute_rigid_3d()
 {
   std::vector<vgl_point_3d<double> > points1;
   points1.push_back(vgl_point_3d<double>(10.5, 200.0, -340.5));
@@ -56,44 +55,45 @@ static void test_compute_similarity_3d()
   points1.push_back(vgl_point_3d<double>(42.3, 205.0, -325.0));
   points1.push_back(vgl_point_3d<double>(-5.0, 265.0, -305.0));
 
-  double s = 3.0;
   vgl_vector_3d<double> t(100, -200, 200);
   vgl_rotation_3d<double> R(3.0, -1.0, 0.5);
 
-  std::vector<vgl_point_3d<double> > points2 = transform_points(points1,s,R,t);
+  std::vector<vgl_point_3d<double> > points2 =
+    vgl_test_compute_rigid_3d::transform_points(points1,R,t);
 
-  vgl_compute_similarity_3d<double> est_sim(points1, points2);
+  vgl_compute_rigid_3d<double> est_sim(points1, points2);
   est_sim.estimate();
 
-  TEST_NEAR("scale estimate",est_sim.scale(),s,1e-8);
   TEST_NEAR("translation estimate",(est_sim.translation()-t).length(),0.0,1e-8);
   TEST_NEAR("rotation estimate",
             (est_sim.rotation().as_matrix()-R.as_matrix()).array_inf_norm(),0.0,1e-8);
   TEST_NEAR("RMS alignment error",
-            alignment_error(transform_points(points1,
-                                             est_sim.scale(),
-                                             est_sim.rotation(),
-                                             est_sim.translation()), points2),
+            vgl_test_compute_rigid_3d::
+            alignment_error( vgl_test_compute_rigid_3d::
+                             transform_points(points1,
+                                              est_sim.rotation(),
+                                              est_sim.translation()), points2),
             0.0, 1e-8);
 
   // add noise and try again
   double sigma = 1e-2;
-  add_noise(points1, sigma);
-  add_noise(points2, sigma);
+  vgl_test_compute_rigid_3d::add_noise(points1, sigma);
+  vgl_test_compute_rigid_3d::add_noise(points2, sigma);
 
-  vgl_compute_similarity_3d<double> est_sim2(points1, points2);
+  vgl_compute_rigid_3d<double> est_sim2(points1, points2);
   est_sim2.estimate();
 
-  TEST_NEAR("noisy scale estimate",est_sim2.scale(),s,sigma);
   TEST_NEAR("noisy translation estimate",(est_sim2.translation()-t).length(),0.0,150*sigma);
   TEST_NEAR("noisy rotation estimate",
             (est_sim2.rotation().as_matrix()-R.as_matrix()).array_inf_norm(),0.0,sigma);
   TEST_NEAR("RMS alignment error",
-            alignment_error(transform_points(points1,
-                                             est_sim2.scale(),
+            vgl_test_compute_rigid_3d::
+            alignment_error(vgl_test_compute_rigid_3d::
+                            transform_points(points1,
                                              est_sim2.rotation(),
                                              est_sim2.translation()), points2),
             0.0, 10*sigma);
+
 }
 
-TESTMAIN(test_compute_similarity_3d);
+TESTMAIN(test_compute_rigid_3d);

--- a/core/vgl/algo/tests/test_compute_similarity_3d.cxx
+++ b/core/vgl/algo/tests/test_compute_similarity_3d.cxx
@@ -94,6 +94,35 @@ static void test_compute_similarity_3d()
                                              est_sim2.rotation(),
                                              est_sim2.translation()), points2),
             0.0, 10*sigma);
+
+  // constrain scale to be 1
+  {
+    double s = 1.0;
+    vgl_vector_3d<double> t(100, -200, 200);
+    vgl_rotation_3d<double> R(3.0, -1.0, 0.5);
+
+    std::vector<vgl_point_3d<double> > points2 = transform_points(points1,s,R,t);
+    // add noise
+    double sigma = 1e-2;
+    add_noise(points2, sigma);
+
+    vgl_compute_similarity_3d<double> est_sim(points1, points2);
+    bool fix_scale = true;
+    est_sim.estimate(fix_scale);
+
+    // scale should be exactly 1
+    TEST_EQUAL("scale estimate (fixed)",est_sim.scale(),1);
+    // rotation and translation should still be correct
+    TEST_NEAR("translation estimate (fixed scale)",(est_sim.translation()-t).length(),0.0,150*sigma);
+    TEST_NEAR("rotation estimate (fixed scale)",
+              (est_sim.rotation().as_matrix()-R.as_matrix()).array_inf_norm(),0.0,sigma);
+    TEST_NEAR("RMS alignment error (fixed scale)",
+              alignment_error(transform_points(points1,
+                                               est_sim.scale(),
+                                               est_sim.rotation(),
+                                               est_sim.translation()), points2),
+              0.0, 10*sigma);
+  }
 }
 
 TESTMAIN(test_compute_similarity_3d);

--- a/core/vgl/algo/tests/test_driver.cxx
+++ b/core/vgl/algo/tests/test_driver.cxx
@@ -1,6 +1,7 @@
 #include <testlib/testlib_register.h>
 
 DECLARE( test_compute_similarity_3d );
+DECLARE( test_compute_rigid_3d );
 DECLARE( test_conic );
 DECLARE( test_convex_hull_2d );
 DECLARE( test_ellipsoid );
@@ -22,6 +23,7 @@ void
 register_tests()
 {
   REGISTER( test_compute_similarity_3d );
+  REGISTER( test_compute_rigid_3d );
   REGISTER( test_conic );
   REGISTER( test_convex_hull_2d );
   REGISTER( test_ellipsoid );

--- a/core/vgl/algo/vgl_compute_rigid_3d.h
+++ b/core/vgl/algo/vgl_compute_rigid_3d.h
@@ -1,22 +1,22 @@
-// This is core/vgl/algo/vgl_compute_similarity_3d.h
-#ifndef vgl_compute_similarity_3d_h_
-#define vgl_compute_similarity_3d_h_
+// This is core/vgl/algo/vgl_compute_rigid_3d.h
+#ifndef vgl_compute_rigid_3d_h_
+#define vgl_compute_rigid_3d_h_
 #ifdef VCL_NEEDS_PRAGMA_INTERFACE
 #pragma interface
 #endif
 //:
 // \file
-// \brief Compute a similarity transformation between two corresponding sets of 3D points
-// \author Matt Leotta
-// \date April 7, 2010
+// \brief Compute a rigid transformation between two corresponding sets of 3D points
+// \author Matt Leotta, Dan Crispell
+// \date April 15 2016
 //
 //
-//  Estimate scale \a s, translation \a t, and rotation \a R such that
-//  sum ||s*R*p1 + t - p2||  is minimized over all pairs (p1,p2)
+//  Estimate translation \a t and rotation \a R such that
+//  sum ||R*p1 + t - p2||  is minimized over all pairs (p1,p2)
 //
 // \verbatim
 //  Modifications
-//  dec: Factored out rigid transform computation to vgl_compute_rigid_3d
+//    dec: Adapted from vgl_compute_similarity_3d
 // \endverbatim
 
 #include <vector>
@@ -27,18 +27,18 @@
 
 
 template <class T>
-class vgl_compute_similarity_3d
+class vgl_compute_rigid_3d
 {
  public:
 
   // Constructors/Initializers/Destructors-------------------------------------
 
-   vgl_compute_similarity_3d() {}
+   vgl_compute_rigid_3d() {}
 
-   vgl_compute_similarity_3d(std::vector<vgl_point_3d<T> > const& points1,
+   vgl_compute_rigid_3d(std::vector<vgl_point_3d<T> > const& points1,
                              std::vector<vgl_point_3d<T> > const& points2);
 
-  ~vgl_compute_similarity_3d() {}
+  ~vgl_compute_rigid_3d() {}
 
   // Operations---------------------------------------------------------------
 
@@ -49,7 +49,7 @@ class vgl_compute_similarity_3d
   //: clear internal data
   void clear();
 
-  //: estimates the similarity transformation from the stored points
+  //: estimates the rigid transformation from the stored points
   bool estimate();
 
   // Data Access---------------------------------------------------------------
@@ -59,9 +59,6 @@ class vgl_compute_similarity_3d
 
   //: Access the estimated translation
   const vgl_vector_3d<T>& translation() const { return translation_; }
-
-  //: Access he estimated scale
-  T scale() const { return scale_; }
 
  protected:
   // Internal functions--------------------------------------------------------
@@ -78,12 +75,11 @@ class vgl_compute_similarity_3d
   // Data Members--------------------------------------------------------------
   std::vector<vgl_point_3d<T> > points1_;
   std::vector<vgl_point_3d<T> > points2_;
-  T scale_;
   vgl_rotation_3d<T> rotation_;
   vgl_vector_3d<T> translation_;
 };
 
-#define VGL_COMPUTE_SIMILARITY_3D_INSTANTIATE(T) \
-extern "please include vgl/algo/vgl_compute_similarity_3d.txx first"
+#define VGL_COMPUTE_RIGID_3D_INSTANTIATE(T) \
+extern "please include vgl/algo/vgl_compute_rigid_3d.txx first"
 
-#endif // vgl_compute_similarity_3d_h_
+#endif // vgl_compute_rigid_3d_h_

--- a/core/vgl/algo/vgl_compute_rigid_3d.hxx
+++ b/core/vgl/algo/vgl_compute_rigid_3d.hxx
@@ -1,11 +1,11 @@
-// This is core/vgl/algo/vgl_compute_similarity_3d.hxx
-#ifndef vgl_compute_similarity_3d_hxx_
-#define vgl_compute_similarity_3d_hxx_
+// This is core/vgl/algo/vgl_compute_rigid_3d.hxx
+#ifndef vgl_compute_rigid_3d_hxx_
+#define vgl_compute_rigid_3d_hxx_
 //:
 // \file
 
 #include <iostream>
-#include "vgl_compute_similarity_3d.h"
+#include "vgl_compute_rigid_3d.h"
 #include <vgl/algo/vgl_norm_trans_3d.h>
 #include <vnl/vnl_double_4.h>
 #include <vnl/algo/vnl_svd.h>
@@ -13,12 +13,11 @@
 #include <vnl/vnl_matrix.h>
 #include <vcl_compiler.h>
 #include <vcl_cassert.h>
-#include "vgl_compute_rigid_3d.h"
 
 template <class T>
-vgl_compute_similarity_3d<T>::
-vgl_compute_similarity_3d(std::vector<vgl_point_3d<T> > const& points1,
-                          std::vector<vgl_point_3d<T> > const& points2)
+vgl_compute_rigid_3d<T>::
+vgl_compute_rigid_3d(std::vector<vgl_point_3d<T> > const& points1,
+                     std::vector<vgl_point_3d<T> > const& points2)
 : points1_(points1),
   points2_(points2)
 {
@@ -26,7 +25,7 @@ vgl_compute_similarity_3d(std::vector<vgl_point_3d<T> > const& points1,
 }
 
 template <class T>
-void vgl_compute_similarity_3d<T>::
+void vgl_compute_rigid_3d<T>::
 add_points(vgl_point_3d<T> const &p1, vgl_point_3d<T> const &p2)
 {
   points1_.push_back(p1);
@@ -35,7 +34,7 @@ add_points(vgl_point_3d<T> const &p1, vgl_point_3d<T> const &p2)
 
 
 template <class T>
-void vgl_compute_similarity_3d<T>::clear()
+void vgl_compute_rigid_3d<T>::clear()
 {
   points1_.clear();
   points2_.clear();
@@ -44,7 +43,7 @@ void vgl_compute_similarity_3d<T>::clear()
 
 //: center all the points at the origin, and return the applied translation
 template <class T>
-void vgl_compute_similarity_3d<T>::
+void vgl_compute_rigid_3d<T>::
 center_points(std::vector<vgl_point_3d<T> >& pts,
               vgl_vector_3d<T>& t) const
 {
@@ -65,7 +64,7 @@ center_points(std::vector<vgl_point_3d<T> >& pts,
 //: normalize the scale of the points, and return the applied scale
 //  The average distance from the origin will be sqrt(3)
 template <class T>
-void vgl_compute_similarity_3d<T>::
+void vgl_compute_rigid_3d<T>::
 scale_points(std::vector<vgl_point_3d<T> >& pts,
              T& s) const
 {
@@ -85,7 +84,7 @@ scale_points(std::vector<vgl_point_3d<T> >& pts,
 
 
 template <class T>
-bool vgl_compute_similarity_3d<T>::estimate()
+bool vgl_compute_rigid_3d<T>::estimate()
 {
   vgl_vector_3d<T> t1, t2;
   std::vector<vgl_point_3d<T> > pts1(points1_), pts2(points2_);
@@ -94,21 +93,53 @@ bool vgl_compute_similarity_3d<T>::estimate()
 
   T s1, s2;
   scale_points(pts2, s2);
-  scale_points(pts1, s1);
-  scale_ = s1/s2;
+  s1 = s2;
+  for (unsigned i=0; i<pts1.size(); ++i)
+  {
+    vgl_point_3d<T>& p = pts1[i];
+    p.set(p.x()*s1, p.y()*s1, p.z()*s1);
+  }
 
-  vgl_compute_rigid_3d<T> rigid_comp(pts1, pts2);
-  rigid_comp.estimate();
+  // estimate rotation
+  vnl_matrix<T> M(3,3,0.0);
+  for (unsigned i=0; i<pts1.size(); ++i)
+  {
+    vgl_point_3d<T>& p1 = pts1[i];
+    vgl_point_3d<T>& p2 = pts2[i];
+    M(0,0) += p1.x()*p2.x();
+    M(0,1) += p1.x()*p2.y();
+    M(0,2) += p1.x()*p2.z();
+    M(1,0) += p1.y()*p2.x();
+    M(1,1) += p1.y()*p2.y();
+    M(1,2) += p1.y()*p2.z();
+    M(2,0) += p1.z()*p2.x();
+    M(2,1) += p1.z()*p2.y();
+    M(2,2) += p1.z()*p2.z();
+  }
 
-  rotation_ = rigid_comp.rotation();
-  translation_ = (scale_*(rotation_*t1) - t2);
+  vnl_matrix<T> N(4,4);
+  N(0,0) =   M(0,0) - M(1,1) - M(2,2);
+  N(1,1) = - M(0,0) + M(1,1) - M(2,2);
+  N(2,2) = - M(0,0) - M(1,1) + M(2,2);
+  N(3,3) =   M(0,0) + M(1,1) + M(2,2);
+  N(0,1) = N(1,0) = M(0,1) + M(1,0);
+  N(0,2) = N(2,0) = M(2,0) + M(0,2);
+  N(1,2) = N(2,1) = M(1,2) + M(2,1);
+  N(3,0) = N(0,3) = M(1,2) - M(2,1);
+  N(3,1) = N(1,3) = M(2,0) - M(0,2);
+  N(3,2) = N(2,3) = M(0,1) - M(1,0);
+
+  vnl_svd<T> svd(N);
+  vnl_double_4 q(svd.V().get_column(0));
+  rotation_ = vgl_rotation_3d<T>(vnl_quaternion<T>(q));
+  translation_ = (rotation_*t1) - t2;
 
   return true;
 }
 
 //--------------------------------------------------------------------------
-#undef VGL_COMPUTE_SIMILARITY_3D_INSTANTIATE
-#define VGL_COMPUTE_SIMILARITY_3D_INSTANTIATE(T) \
-template class vgl_compute_similarity_3d<T >
+#undef VGL_COMPUTE_RIGID_3D_INSTANTIATE
+#define VGL_COMPUTE_RIGID_3D_INSTANTIATE(T) \
+template class vgl_compute_rigid_3d<T >
 
-#endif // vgl_compute_similarity_3d_hxx_
+#endif // vgl_compute_rigid_3d_hxx_

--- a/core/vgl/algo/vgl_compute_similarity_3d.h
+++ b/core/vgl/algo/vgl_compute_similarity_3d.h
@@ -50,7 +50,7 @@ class vgl_compute_similarity_3d
   void clear();
 
   //: estimates the similarity transformation from the stored points
-  bool estimate();
+  bool estimate(bool fix_scale=false);
 
   // Data Access---------------------------------------------------------------
 

--- a/core/vgl/algo/vgl_compute_similarity_3d.hxx
+++ b/core/vgl/algo/vgl_compute_similarity_3d.hxx
@@ -84,17 +84,26 @@ scale_points(std::vector<vgl_point_3d<T> >& pts,
 
 
 template <class T>
-bool vgl_compute_similarity_3d<T>::estimate()
+bool vgl_compute_similarity_3d<T>::estimate(bool fix_scale)
 {
   vgl_vector_3d<T> t1, t2;
   std::vector<vgl_point_3d<T> > pts1(points1_), pts2(points2_);
   center_points(pts1, t1);
   center_points(pts2, t2);
 
-
   T s1, s2;
-  scale_points(pts1, s1);
   scale_points(pts2, s2);
+  if (fix_scale) {
+    s1 = s2;
+    for (unsigned i=0; i<pts1.size(); ++i)
+    {
+      vgl_point_3d<T>& p = pts1[i];
+      p.set(p.x()*s1, p.y()*s1, p.z()*s1);
+    }
+  }
+  else {
+    scale_points(pts1, s1);
+  }
   scale_ = s1/s2;
 
   // estimate rotation


### PR DESCRIPTION
This PR adds support for computing a rigid transform via the vgl_compute_similarity_3d class by fixing the scale at 1.   I thought that adding a separate "vgl_compute_rigid_3d" class (with the commonalities factored out into a third class) would be overkill but could be convinced otherwise.