### PR TITLE
COMP: Set policy to respect VISIBILITY in static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ endif()
 if( POLICY CMP0042 )
   cmake_policy(SET CMP0042 NEW)
 endif()
+# Honor visibility properties for all target
+if( POLICY CMP0063 )
+  cmake_policy(SET CMP0063 NEW)
+endif()
 
 project(vxl)
 


### PR DESCRIPTION
In cmake 3.3 and greater, visibility can be used for static
libraries so that they can later be linked into shared
libraries.