### PR TITLE
COMP: Remove compiler warnings from gcc5

### DIFF
--- a/core/vidl/vidl_convert.cxx
+++ b/core/vidl/vidl_convert.cxx
@@ -61,13 +61,6 @@ bool copy_conversion(vidl_frame const& in_frame, vidl_frame& out_frame)
 }
 
 
-//: Convert to an intermediate RGB_24 frame
-// This is inefficient, but will provide the functionality until
-// an optimized version is written
-// defined later because it uses conversion_table
-bool intermediate_rgb24_conversion(vidl_frame const& in_frame, vidl_frame& out_frame);
-
-
 // Default pixel format conversion - it fails
 template <vidl_pixel_format in_Fmt, vidl_pixel_format out_Fmt>
 struct convert
@@ -453,6 +446,14 @@ class converter
 //: Instantiate a global conversion function table
 converter conversion_table;
 
+#if 0
+//: Convert to an intermediate RGB_24 frame
+// This is inefficient, but will provide the functionality until
+// an optimized version is written
+// defined later because it uses conversion_table
+bool intermediate_rgb24_conversion(vidl_frame const& in_frame, vidl_frame& out_frame);
+
+
 //: Convert to an intermediate RGB_24 frame
 // Defined here because it uses conversion_table
 bool intermediate_rgb24_conversion(vidl_frame const& in_frame, vidl_frame& out_frame)
@@ -463,6 +464,7 @@ bool intermediate_rgb24_conversion(vidl_frame const& in_frame, vidl_frame& out_f
   return conversion_table(in_frame, temp_frame) &&
       conversion_table(temp_frame, out_frame);
 }
+#endif
 
 } // end anonymous namespace
 

--- a/core/vnl/algo/vnl_sparse_lm.cxx
+++ b/core/vnl/algo/vnl_sparse_lm.cxx
@@ -644,9 +644,6 @@ void vnl_sparse_lm::compute_Mb()
 //: solve for dc
 void vnl_sparse_lm::solve_dc(vnl_vector<double>& dc)
 {
-  // sparse vector iterator
-  typedef vnl_crs_index::sparse_vector::iterator sv_itr;
-
   vnl_matrix<double> Sc(T_); // start with a copy of T
   vnl_vector<double> sec(ec_); // start with a copy of ec
 

--- a/core/vnl/io/vnl_io_sparse_matrix.hxx
+++ b/core/vnl/io/vnl_io_sparse_matrix.hxx
@@ -67,7 +67,6 @@ void vsl_b_write(vsl_b_ostream & os, const vnl_sparse_matrix<T> & p)
 {
   typedef vnl_sparse_matrix_pair<T> pair_t;
   typedef std::vector < pair_t > row;
-  typedef std::vector < row > vnl_sparse_matrix_elements;
 
   row rw;
   vnl_sparse_matrix<T> v=p;
@@ -96,8 +95,6 @@ void vsl_b_read(vsl_b_istream &is, vnl_sparse_matrix<T> & p)
   if (!is) return;
 
   typedef vnl_sparse_matrix_pair<T> pair_t;
-  typedef std::vector < pair_t > row;
-  typedef std::vector < row > vnl_sparse_matrix_elements;
 
   short ver;
   unsigned n_rows;

--- a/core/vpgl/algo/tests/test_camera_compute.cxx
+++ b/core/vpgl/algo/tests/test_camera_compute.cxx
@@ -185,7 +185,7 @@ static void test_perspective_compute_ground()
 
   // project them to the image
   std::vector< vgl_point_2d<double> > image_pts;
-  for ( int k = 0; k < ground_pts.size(); ++k )
+  for ( size_t k = 0; k < ground_pts.size(); ++k )
   {
     vgl_homg_point_3d<double> world_pt(ground_pts[k].x(), ground_pts[k].y(), 0, 1);
 
@@ -225,7 +225,7 @@ static void test_calibration_compute_natural()
 
   // project them to the image
   std::vector< vgl_point_2d<double> > image_pts;
-  for ( int k = 0; k < ground_pts.size(); ++k )
+  for ( size_t k = 0; k < ground_pts.size(); ++k )
   {
     vgl_homg_point_3d<double> world_pt( ground_pts[k].x(), ground_pts[k].y(), 0, 1 );
 

--- a/core/vpgl/algo/tests/test_camera_convert.cxx
+++ b/core/vpgl/algo/tests/test_camera_convert.cxx
@@ -227,9 +227,9 @@ void test_generic_camera_convert()
   vpgl_affine_camera<double> acam(view_dir, up, stare, 5, 5, 1.0, 1.0);
   acam.set_viewing_distance(1.0);
   vgl_homg_point_2d<double> ipt(0,0,1);
-  vgl_homg_line_3d_2_points<double> l0 = acam.backproject(ipt);
+  acam.backproject(ipt);
   ipt.set(5,5,1);
-  vgl_homg_line_3d_2_points<double> lc = acam.backproject(ipt);
+  acam.backproject(ipt);
   success = vpgl_generic_camera_convert::convert(acam, ni, nj, gcam);
   if (success) {
     vgl_ray_3d<double> rayc = gcam.ray(5,5), ray0 = gcam.ray(0, 0);

--- a/core/vpgl/algo/tests/test_optimize_camera.cxx
+++ b/core/vpgl/algo/tests/test_optimize_camera.cxx
@@ -62,7 +62,6 @@ void test_opt_orient_pos_f(vpgl_perspective_camera<double> const& cam,
 
   const double max_t_err = 0;//10.0; // maximum translation error to introduce
   const double max_r_err = 0;//vnl_math::pi/4; // maximum rotation error to introduce (radians)
-  const double max_f_err = 100.0;
 
   // select a random rotation axis
   vnl_double_3 dw = (vnl_double_3(rnd.drand32(), rnd.drand32(), rnd.drand32())-0.5).normalize();

--- a/core/vpgl/algo/vpgl_affine_rectification.cxx
+++ b/core/vpgl/algo/vpgl_affine_rectification.cxx
@@ -38,7 +38,6 @@ bool vpgl_affine_rectification::compute_affine_f(const vpgl_affine_camera<double
   vnl_vector_fixed<double,4> C1; C1[0] = C.x(); C1[1] = C.y(); C1[2] = C.z(); C1[3] = C.w();
 
   vnl_matrix_fixed<double, 3,4> M2 = cam2->get_matrix();
-  vgl_homg_point_3d<double> C2 = cam2->camera_center();
 
   vnl_vector_fixed<double,3> e2 = M2*C1;
 

--- a/core/vpgl/algo/vpgl_camera_convert.cxx
+++ b/core/vpgl/algo/vpgl_camera_convert.cxx
@@ -1119,9 +1119,9 @@ convert( vpgl_local_rational_camera<double> const& rat_cam,
   // initialize the ray pyramid
   // convert the required number of levels
 
-  int mindim = gni < gnj ? gni : gnj;
-  int factor = 256;
-  int n_levels  = 6;
+  unsigned int mindim = gni < gnj ? gni : gnj;
+  unsigned int factor = 256;
+  unsigned int n_levels  = 6;
 
   while( mindim < factor )
   {
@@ -1130,8 +1130,8 @@ convert( vpgl_local_rational_camera<double> const& rat_cam,
 
       std::cout<<"."<<std::endl;
   }
-  int numi = gni/factor;
-  int numj = gnj/factor;
+  unsigned int numi = gni/factor;
+  unsigned int numj = gnj/factor;
 
   // construct pyramid of ray indices
   // the row and column dimensions at each level
@@ -1177,7 +1177,7 @@ convert( vpgl_local_rational_camera<double> const& rat_cam,
           }
       }
   }
-  if ((int)level < n_levels) {
+  if (level < n_levels) {
       gen_cam = vpgl_generic_camera<double>(finalrays);
       return true;
   }

--- a/v3p/netlib/laso/urand.c
+++ b/v3p/netlib/laso/urand.c
@@ -21,7 +21,7 @@ doublereal urand_(integer *iy)
     /* Initialized data */
 
     static integer m2 = 0; /* constant */
-    static integer itwo = 2; /* constant */
+    //UNUSED VAR static integer itwo = 2; /* constant */
 
     /* System generated locals */
     real ret_val;


### PR DESCRIPTION
The gcc5 compiler identified a few unused variables and
type mis-matches.