### PR TITLE
add implementations of clone and backproject_ray to affine_camera

### DIFF
--- a/core/vpgl/vpgl_affine_camera.h
+++ b/core/vpgl/vpgl_affine_camera.h
@@ -82,8 +82,14 @@ class vpgl_affine_camera : public vpgl_proj_camera<T>
   // The finite point of the ray is at the viewing distance from the origin
   virtual  vgl_homg_line_3d_2_points<T> backproject( const vgl_homg_point_2d<T>& image_point ) const;
 
+  //: Find the 3d ray that goes through the camera center and the provided image point.
+  virtual vgl_ray_3d<T> backproject_ray( const vgl_homg_point_2d<T>& image_point ) const;
+
   //: Find the world plane perpendicular to the camera rays at viewing distance from the origin
   virtual  vgl_homg_plane_3d<T> principal_plane() const;
+
+  //: Clone `this': creation of a new object and initialization
+  virtual vpgl_affine_camera<T>* clone(void) const;
 
  private:
   T view_distance_; // distance from origin along rays

--- a/core/vpgl/vpgl_affine_camera.hxx
+++ b/core/vpgl/vpgl_affine_camera.hxx
@@ -10,6 +10,7 @@
 #include <vgl/algo/vgl_rotation_3d.h>
 #include <vgl/vgl_closest_point.h>
 #include <vgl/vgl_tolerance.h>
+#include <vgl/vgl_ray_3d.h>
 #include <vcl_cassert.h>
 
 //-------------------------------------------
@@ -181,6 +182,21 @@ backproject( const vgl_homg_point_2d<T>& image_point ) const
     std::cout << "Warning vpgl_affine_camera::backproject produced line at infinity\n";
   return ret;
 }
+
+template <class T>
+vgl_ray_3d<T> vpgl_affine_camera<T>::
+backproject_ray( const vgl_homg_point_2d<T>& image_point ) const
+{
+  vgl_homg_line_3d_2_points<T> line = backproject( image_point );
+  return vgl_ray_3d<T>(vgl_point_3d<T>(line.point_finite()), ray_dir_);
+}
+
+template <class T>
+vpgl_affine_camera<T>* vpgl_affine_camera<T>::clone(void) const
+{
+  return new vpgl_affine_camera<T>(*this);
+}
+
 
 //: Find the world plane parallel to the image plane intersecting the camera center.
 template <class T>


### PR DESCRIPTION
Previously, the implementations (incorrectly) fell back to those defined in `vpgl_proj_camera`.  The `backproject_ray` implementation in` vpgl_proj_camera` would sometimes give incorrect ray direction in the case of affine cameras.