### PR TITLE
STYLE: Replace redundant code with local template function

### DIFF
--- a/contrib/brl/bbas/bvgl/bvgl_scaled_shape_3d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_scaled_shape_3d.h
@@ -27,7 +27,7 @@ class bvgl_scaled_shape_3d
     stype_(LINEAR){reset_def_params(); reset_scale_params();}
   //: Construct using spline knots (must be closed curve)
  bvgl_scaled_shape_3d(bvgl_spline_region_3d<Type> const& region, Type max_norm_distance, Type scale_at_max, Type tolerance):
-  base_(region), max_norm_distance_(max_norm_distance), scale_at_max_(scale_at_max),scale_at_midpt_(Type(0.5)*scale_at_max_),
+  base_(region), max_norm_distance_(max_norm_distance), scale_at_max_(scale_at_max),scale_at_midpt_(Type(0.5)*scale_at_max),
   tolerance_(tolerance), stype_(LINEAR){
     reset_def_params(); reset_scale_params();
     this->compute_cross_sections();

--- a/core/vsl/vsl_binary_io.cxx
+++ b/core/vsl/vsl_binary_io.cxx
@@ -79,33 +79,36 @@ MACRO_MAKE_INTEGER_READ_WRITE(std::size_t);
 
 void vsl_b_write(vsl_b_ostream& os, char n )
 {
-  os.os().write( ( char* )&n, sizeof( n ) );
+  os.os().write( reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 void vsl_b_read(vsl_b_istream &is, char& n )
 {
-  is.is().read( ( char* )&n, sizeof( n ) );
+  const int value = is.is().get();
+  n = static_cast<signed char>(value);
 }
 
 void vsl_b_write(vsl_b_ostream& os, signed char n )
 {
-  os.os().write( ( char* )&n, sizeof( n ) );
+  os.os().write( reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 void vsl_b_read(vsl_b_istream &is, signed char& n )
 {
-  is.is().read( ( char* )&n, sizeof( n ) );
+  const int value = is.is().get();
+  n = static_cast<signed char>(value);
 }
 
 
 void vsl_b_write(vsl_b_ostream& os,unsigned char n )
 {
-  os.os().write( ( char* )&n, 1 );
+  os.os().write( reinterpret_cast<char *>(&n), 1 );
 }
 
 void vsl_b_read(vsl_b_istream &is,unsigned char& n )
 {
-  is.is().read( ( char* )&n, 1 );
+  const int value = is.is().get();
+  n = static_cast<unsigned char>(value);
 }
 
 
@@ -169,26 +172,26 @@ void vsl_b_read(vsl_b_istream &is,bool& b)
 
 void vsl_b_write(vsl_b_ostream& os,float n )
 {
-  vsl_swap_bytes(( char* )&n, sizeof( n ) );
-  os.os().write( ( char* )&n, sizeof( n ) );
+  vsl_swap_bytes(reinterpret_cast<char *>(&n), sizeof( n ) );
+  os.os().write( reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 void vsl_b_read(vsl_b_istream &is,float& n )
 {
-  is.is().read( ( char* )&n, sizeof( n ) );
-  vsl_swap_bytes(( char* )&n, sizeof( n ) );
+  is.is().read( reinterpret_cast<char *>(&n), sizeof( n ) );
+  vsl_swap_bytes(reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 void vsl_b_write(vsl_b_ostream& os,double n )
 {
-  vsl_swap_bytes(( char* )&n, sizeof( n ) );
-  os.os().write( ( char* )&n, sizeof( n ) );
+  vsl_swap_bytes(reinterpret_cast<char *>(&n), sizeof( n ) );
+  os.os().write( reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 void vsl_b_read(vsl_b_istream &is,double& n )
 {
-  is.is().read( ( char* )&n, sizeof( n ) );
-  vsl_swap_bytes(( char* )&n, sizeof( n ) );
+  is.is().read( reinterpret_cast<char *>(&n), sizeof( n ) );
+  vsl_swap_bytes(reinterpret_cast<char *>(&n), sizeof( n ) );
 }
 
 


### PR DESCRIPTION
There was redundant code for all integer type vsl_read/write_io functions
that was implicated in a valgrind error of an uninitialized read
operation that caused frequent dashboard failures.