### PR TITLE
Do not use target_include_directories with CMake 2.8.11.2.

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -113,7 +113,7 @@ macro( vxl_add_library )
       ## Identify the relative path for installing the header files and txx files
       string(REPLACE ${VXL_ROOT_SOURCE_DIR} "${VXL_INSTALL_INCLUDE_DIR}" relative_install_path ${CMAKE_CURRENT_SOURCE_DIR})
       ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
-      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11)
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11.2)
         target_include_directories(${lib_name}
           PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -126,7 +126,7 @@ macro( vxl_add_library )
         set(relative_install_path "${relative_install_path}/${header_install_dir}")
       endif()
       ## Added in 2.8.11 http://stackoverflow.com/questions/19460707/how-to-set-include-directories-from-a-cmakelists-txt-file
-      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11)
+      if(${CMAKE_VERSION} VERSION_GREATER 2.8.11.2)
         target_include_directories(${lib_name}
           PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
As a follow up to vxl/vxl@d7d6314fb9846b923a5e90e8f7f65b3ab28bfc8e
target_include_directories does not work with relative paths in 2.8.11.2 also.