### PR TITLE
STYLE: Backport of changes needed for ITK integration

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -282,5 +282,3 @@ macro(GENERATE_TEST_INCLUDE LIB SOURCES PREFIX)
   add_executable(${LIB}_test_include ${CMAKE_CURRENT_BINARY_DIR}/test_include.cxx)
   target_link_libraries(${LIB}_test_include ${LIB})
 endmacro()
-
-

--- a/core/vnl/CMakeLists.txt
+++ b/core/vnl/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
 endif()
 
 vxl_configure_file(${CMAKE_CURRENT_LIST_DIR}/vnl_config.h.in
-               ${PROJECT_BINARY_DIR}/vnl_config.h include/vxl/core/vnl)
+               ${PROJECT_BINARY_DIR}/vnl_config.h ${VXL_INSTALL_INCLUDE_DIR}/vnl)
 
 set( vnl_sources
   dll.h


### PR DESCRIPTION
The relatively minor changes allow VTK to be integrated with other
packages (i.e. ITK) with less maintenance effort.