### PR TITLE
BUG: Missing VNL_EXPORTS for shared libs

### DIFF
--- a/core/vnl/algo/vnl_adjugate.hxx
+++ b/core/vnl/algo/vnl_adjugate.hxx
@@ -48,7 +48,7 @@ vnl_matrix<T> vnl_adjugate(vnl_matrix<T> const &A)
 
 #undef VNL_ADJUGATE_INSTANTIATE
 #define VNL_ADJUGATE_INSTANTIATE(T) \
-template void vnl_adjugate(vnl_matrix<T > const &, vnl_matrix<T > *); \
-template vnl_matrix<T > vnl_adjugate(vnl_matrix<T > const &)
+template VNL_EXPORT void vnl_adjugate(vnl_matrix<T > const &, vnl_matrix<T > *); \
+template VNL_EXPORT vnl_matrix<T > vnl_adjugate(vnl_matrix<T > const &)
 
 #endif

--- a/core/vnl/algo/vnl_chi_squared.h
+++ b/core/vnl/algo/vnl_chi_squared.h
@@ -4,6 +4,7 @@
 #ifdef VCL_NEEDS_PRAGMA_INTERFACE
 #pragma interface
 #endif
+#include "vnl/vnl_export.h"
 //:
 // \file
 // \brief Name space for various (mostly templated) chi-squared distribution functions.

--- a/core/vnl/algo/vnl_chi_squared.hxx
+++ b/core/vnl/algo/vnl_chi_squared.hxx
@@ -96,9 +96,9 @@ double vnl_chi_squared_statistic_12(T const *A, T const *B, int n, bool normaliz
 
 #undef VNL_CHI_SQUARED_INSTANTIATE
 #define VNL_CHI_SQUARED_INSTANTIATE(T) \
-template double vnl_chi_squared_cumulative  (T chisq, long dof); \
-template double vnl_chi_squared_statistic_1 (T const *, T const *, int, bool); \
-template double vnl_chi_squared_statistic_2 (T const *, T const *, int, bool); \
-template double vnl_chi_squared_statistic_12(T const *, T const *, int, bool)
+template VNL_EXPORT double vnl_chi_squared_cumulative  (T chisq, long dof); \
+template VNL_EXPORT double vnl_chi_squared_statistic_1 (T const *, T const *, int, bool); \
+template VNL_EXPORT double vnl_chi_squared_statistic_2 (T const *, T const *, int, bool); \
+template VNL_EXPORT double vnl_chi_squared_statistic_12(T const *, T const *, int, bool)
 
 #endif // vnl_chi_squared_hxx_

--- a/core/vnl/algo/vnl_determinant.hxx
+++ b/core/vnl/algo/vnl_determinant.hxx
@@ -109,12 +109,12 @@ T vnl_determinant(vnl_matrix<T> const &M, bool balance)
 //--------------------------------------------------------------------------------
 
 #define VNL_DETERMINANT_INSTANTIATE_1(T) \
-template T vnl_determinant(T const *, T const *); \
-template T vnl_determinant(T const *, T const *, T const *); \
-template T vnl_determinant(T const *, T const *, T const *, T const *)
+template VNL_EXPORT T vnl_determinant(T const *, T const *); \
+template VNL_EXPORT T vnl_determinant(T const *, T const *, T const *); \
+template VNL_EXPORT T vnl_determinant(T const *, T const *, T const *, T const *)
 
 #define VNL_DETERMINANT_INSTANTIATE_2(T) \
-template T vnl_determinant(vnl_matrix<T > const &, bool)
+template VNL_EXPORT T vnl_determinant(vnl_matrix<T > const &, bool)
 
 #undef VNL_DETERMINANT_INSTANTIATE
 #define VNL_DETERMINANT_INSTANTIATE(T) \

--- a/core/vnl/algo/vnl_fft_1d.hxx
+++ b/core/vnl/algo/vnl_fft_1d.hxx
@@ -6,6 +6,6 @@
 
 #undef VNL_FFT_1D_INSTANTIATE
 #define VNL_FFT_1D_INSTANTIATE(T) \
-template struct vnl_fft_1d<T >
+template struct VNL_EXPORT vnl_fft_1d<T >
 
 #endif

--- a/core/vnl/algo/vnl_fft_2d.hxx
+++ b/core/vnl/algo/vnl_fft_2d.hxx
@@ -6,6 +6,6 @@
 
 #undef VNL_FFT_2D_INSTANTIATE
 #define VNL_FFT_2D_INSTANTIATE(T) \
-template struct vnl_fft_2d<T >
+template struct VNL_EXPORT vnl_fft_2d<T >
 
 #endif

--- a/core/vnl/algo/vnl_fft_prime_factors.h
+++ b/core/vnl/algo/vnl_fft_prime_factors.h
@@ -13,6 +13,7 @@
 // \endverbatim
 
 #include <vcl_compiler.h> // for "export" keyword
+#include "vnl/vnl_export.h"
 
 //: Holds prime factor information
 // Helper class used by the vnl_fft_xd<> FFT routines

--- a/core/vnl/algo/vnl_fft_prime_factors.hxx
+++ b/core/vnl/algo/vnl_fft_prime_factors.hxx
@@ -35,6 +35,6 @@ void vnl_fft_prime_factors<T>::destruct()
 
 #undef VNL_FFT_PRIME_FACTORS_INSTANTIATE
 #define VNL_FFT_PRIME_FACTORS_INSTANTIATE(T) \
-template struct vnl_fft_prime_factors<T >
+template struct VNL_EXPORT vnl_fft_prime_factors<T >
 
 #endif

--- a/core/vnl/algo/vnl_matrix_inverse.hxx
+++ b/core/vnl/algo/vnl_matrix_inverse.hxx
@@ -10,7 +10,7 @@
 
 #undef VNL_MATRIX_INVERSE_INSTANTIATE
 #define VNL_MATRIX_INVERSE_INSTANTIATE(T) \
-template struct vnl_matrix_inverse<T >;\
+template struct VNL_EXPORT vnl_matrix_inverse<T >;\
 VCL_INSTANTIATE_INLINE( vnl_vector<T > operator*(vnl_matrix_inverse<T > const &, vnl_vector<T > const &) ); \
 VCL_INSTANTIATE_INLINE( vnl_matrix<T > operator*(vnl_matrix_inverse<T > const &, vnl_matrix<T > const &) )
 

--- a/core/vnl/algo/vnl_orthogonal_complement.hxx
+++ b/core/vnl/algo/vnl_orthogonal_complement.hxx
@@ -21,6 +21,6 @@ vnl_matrix<T> vnl_orthogonal_complement(vnl_vector<T> const &v)
 #undef VNL_ORTHOGONAL_COMPLEMENT_INSTANTIATE
 #define VNL_ORTHOGONAL_COMPLEMENT_INSTANTIATE(T) \
 /* template vnl_matrix<T > vnl_orthogonal_complement(vnl_matrix<T > const &); */ \
-template vnl_matrix<T > vnl_orthogonal_complement(vnl_vector<T > const &)
+template VNL_EXPORT vnl_matrix<T > vnl_orthogonal_complement(vnl_vector<T > const &)
 
 #endif // vnl_orthogonal_complement_hxx_

--- a/core/vnl/algo/vnl_qr.hxx
+++ b/core/vnl/algo/vnl_qr.hxx
@@ -303,7 +303,7 @@ vnl_matrix<T> vnl_qr<T>::solve(vnl_matrix<T> const& rhs) const
 //------------------------------------------------------------------------------
 
 #define VNL_QR_INSTANTIATE(T) \
- template class vnl_qr<T >; \
+ template class VNL_EXPORT vnl_qr<T >; \
  VCL_INSTANTIATE_INLINE(T vnl_qr_determinant(vnl_matrix<T > const&))
 
 #endif

--- a/core/vnl/algo/vnl_scatter_3x3.hxx
+++ b/core/vnl/algo/vnl_scatter_3x3.hxx
@@ -102,6 +102,6 @@ void vnl_scatter_3x3<T>::compute_eigensystem()
 //--------------------------------------------------------------------------------
 
 #define VNL_SCATTER_3X3_INSTANTIATE(T) \
-template class vnl_scatter_3x3<T >
+template class VNL_EXPORT vnl_scatter_3x3<T >
 
 #endif // vnl_scatter_3x3_hxx_

--- a/core/vnl/algo/vnl_svd.hxx
+++ b/core/vnl/algo/vnl_svd.hxx
@@ -426,7 +426,7 @@ vnl_vector <T> vnl_svd<T>::left_nullvector()  const
 
 #undef VNL_SVD_INSTANTIATE
 #define VNL_SVD_INSTANTIATE(T) \
-template class vnl_svd<T >; \
-template std::ostream& operator<<(std::ostream &, vnl_svd<T > const &)
+template class VNL_EXPORT vnl_svd<T >; \
+template VNL_EXPORT std::ostream& operator<<(std::ostream &, vnl_svd<T > const &)
 
 #endif // vnl_svd_hxx_

--- a/core/vnl/algo/vnl_svd_economy.hxx
+++ b/core/vnl/algo/vnl_svd_economy.hxx
@@ -109,6 +109,7 @@ vnl_svd_economy<real_t>::nullvector()
 }
 
 #undef VNL_SVD_ECONOMY_INSTANTIATE
-#define VNL_SVD_ECONOMY_INSTANTIATE(T) template class vnl_svd_economy<T >
+#define VNL_SVD_ECONOMY_INSTANTIATE(T) \
+template class VNL_EXPORT vnl_svd_economy<T >
 
 #endif // vnl_svd_economy_hxx_

--- a/core/vnl/algo/vnl_symmetric_eigensystem.hxx
+++ b/core/vnl/algo/vnl_symmetric_eigensystem.hxx
@@ -233,8 +233,8 @@ vnl_matrix<T> vnl_symmetric_eigensystem<T>::inverse_square_root() const
 
 #undef VNL_SYMMETRIC_EIGENSYSTEM_INSTANTIATE
 #define VNL_SYMMETRIC_EIGENSYSTEM_INSTANTIATE(T) \
-template class vnl_symmetric_eigensystem<T >; \
-template void vnl_symmetric_eigensystem_compute_eigenvals(T,T,T,T,T,T,T&,T&,T&); \
-template bool vnl_symmetric_eigensystem_compute(vnl_matrix<T > const&, vnl_matrix<T > &, vnl_vector<T >&)
+template class VNL_EXPORT vnl_symmetric_eigensystem<T >; \
+template VNL_EXPORT void vnl_symmetric_eigensystem_compute_eigenvals(T,T,T,T,T,T,T&,T&,T&); \
+template VNL_EXPORT bool vnl_symmetric_eigensystem_compute(vnl_matrix<T > const&, vnl_matrix<T > &, vnl_vector<T >&)
 
 #endif // vnl_symmetric_eigensystem_hxx_

--- a/core/vnl/io/vnl_io_diag_matrix.hxx
+++ b/core/vnl/io/vnl_io_diag_matrix.hxx
@@ -55,8 +55,8 @@ void vsl_print_summary(std::ostream & os,const vnl_diag_matrix<T> & p)
 }
 
 #define VNL_IO_DIAG_MATRIX_INSTANTIATE(T) \
-template void vsl_print_summary(std::ostream &, const vnl_diag_matrix<T > &); \
-template void vsl_b_read(vsl_b_istream &, vnl_diag_matrix<T > &); \
-template void vsl_b_write(vsl_b_ostream &, const vnl_diag_matrix<T > &)
+template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_diag_matrix<T > &); \
+template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_diag_matrix<T > &); \
+template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_diag_matrix<T > &)
 
 #endif // vnl_io_diag_matrix_hxx_

--- a/core/vnl/io/vnl_io_matrix.hxx
+++ b/core/vnl/io/vnl_io_matrix.hxx
@@ -92,8 +92,8 @@ void vsl_print_summary(std::ostream & os,const vnl_matrix<T> & p)
 
 
 #define VNL_IO_MATRIX_INSTANTIATE(T) \
-template void vsl_print_summary(std::ostream &, const vnl_matrix<T > &); \
-template void vsl_b_read(vsl_b_istream &, vnl_matrix<T > &); \
-template void vsl_b_write(vsl_b_ostream &, const vnl_matrix<T > &)
+template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_matrix<T > &); \
+template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_matrix<T > &); \
+template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_matrix<T > &)
 
 #endif // vnl_io_matrix_hxx_

--- a/core/vnl/io/vnl_io_sparse_matrix.hxx
+++ b/core/vnl/io/vnl_io_sparse_matrix.hxx
@@ -154,8 +154,8 @@ void vsl_print_summary(std::ostream & os,const vnl_sparse_matrix<T> & p)
 }
 
 #define VNL_IO_SPARSE_MATRIX_INSTANTIATE(T) \
-  template void vsl_print_summary(std::ostream &, const vnl_sparse_matrix<T > &); \
-  template void vsl_b_read(vsl_b_istream &, vnl_sparse_matrix<T > &); \
-  template void vsl_b_write(vsl_b_ostream &, const vnl_sparse_matrix<T > &)
+  template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_sparse_matrix<T > &); \
+  template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_sparse_matrix<T > &); \
+  template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_sparse_matrix<T > &)
 
 #endif // vnl_io_sparse_matrix_hxx_

--- a/core/vnl/io/vnl_io_sym_matrix.hxx
+++ b/core/vnl/io/vnl_io_sym_matrix.hxx
@@ -87,8 +87,8 @@ void vsl_print_summary(std::ostream & os,const vnl_sym_matrix<T> & p)
 
 
 #define VNL_IO_SYM_MATRIX_INSTANTIATE(T) \
-template void vsl_print_summary(std::ostream &, const vnl_sym_matrix<T > &); \
-template void vsl_b_read(vsl_b_istream &, vnl_sym_matrix<T > &); \
-template void vsl_b_write(vsl_b_ostream &, const vnl_sym_matrix<T > &)
+template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_sym_matrix<T > &); \
+template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_sym_matrix<T > &); \
+template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_sym_matrix<T > &)
 
 #endif // vnl_io_sym_matrix_hxx_

--- a/core/vnl/io/vnl_io_vector.hxx
+++ b/core/vnl/io/vnl_io_vector.hxx
@@ -68,8 +68,8 @@ void vsl_print_summary(std::ostream & os,const vnl_vector<T> & p)
 }
 
 #define VNL_IO_VECTOR_INSTANTIATE(T) \
-template void vsl_print_summary(std::ostream &, const vnl_vector<T > &); \
-template void vsl_b_read(vsl_b_istream &, vnl_vector<T > &); \
-template void vsl_b_write(vsl_b_ostream &, const vnl_vector<T > &)
+template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_vector<T > &); \
+template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_vector<T > &); \
+template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_vector<T > &)
 
 #endif // vnl_io_vector_hxx_

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -59,7 +59,7 @@ void vnl_vector_test_int()
   try { v0.get(25); }  // Raise out of bounds exception.
   catch(...) { exceptionThrownAndCaught = true; }
   TEST("Out of bounds get()", exceptionThrownAndCaught, true);
-  
+
   exceptionThrownAndCaught = false;
   try { v0.put(25,0); }  // Raise out of bounds exception.
   catch(...) { exceptionThrownAndCaught = true; }
@@ -710,6 +710,12 @@ void vnl_vector_test_euclid_dist_sq_timing(unsigned size, unsigned long num)
 {
   vnl_vector<double> a(size);
   vnl_vector<double> b(size);
+
+  vnl_vector< std::complex<double> > cmpxa(size);
+  vnl_vector< std::complex<double> > cmpxb(size);
+  vnl_vector< std::complex<double> > cmpxc =
+            vnl_c_vector<std::complex<double> >::euclid_dist_sq(cmpxa.begin(), cmpxb.begin(), size);
+
   for (unsigned i= 0; i < size; i++)
   {
     a(i) = i / size;

--- a/core/vnl/vnl_c_vector.h
+++ b/core/vnl/vnl_c_vector.h
@@ -143,10 +143,10 @@ class VNL_EXPORT vnl_c_vector
   static T euclid_dist_sq(T const *, T const *, unsigned);
 
   //: Memory allocation
-  static T** allocate_Tptr(std::size_t n);
-  static T*  allocate_T(std::size_t n);
-  static void deallocate(T**, std::size_t n_when_allocated);
-  static void deallocate(T*, std::size_t n_when_allocated);
+  static VNL_EXPORT T** allocate_Tptr(const std::size_t n);
+  static VNL_EXPORT T*  allocate_T(const std::size_t n);
+  static VNL_EXPORT void deallocate(T**, const std::size_t n_when_allocated);
+  static VNL_EXPORT void deallocate(T*, const std::size_t n_when_allocated);
 };
 
 //: Input & output

--- a/core/vnl/vnl_c_vector.hxx
+++ b/core/vnl/vnl_c_vector.hxx
@@ -365,14 +365,14 @@ inline void vnl_c_vector_dealloc(void* v, std::size_t n, unsigned size)
   vnl_sse_dealloc(v,n,size);
 }
 
-template<class T>
-T** vnl_c_vector<T>::allocate_Tptr(std::size_t n)
+template<class T> VNL_EXPORT
+T** vnl_c_vector<T>::allocate_Tptr(const std::size_t n)
 {
   return (T**)vnl_c_vector_alloc(n, sizeof (T*));
 }
 
-template<class T>
-void vnl_c_vector<T>::deallocate(T** v, std::size_t n)
+template<class T> VNL_EXPORT
+void vnl_c_vector<T>::deallocate(T** v, const std::size_t n)
 {
   vnl_c_vector_dealloc(v, n, sizeof (T*));
 }
@@ -406,7 +406,7 @@ inline void vnl_c_vector_destruct(std::complex<double> *, std::size_t) { }
 inline void vnl_c_vector_destruct(std::complex<long double> *, std::size_t) { }
 
 template<class T>
-T* vnl_c_vector<T>::allocate_T(std::size_t n)
+T* vnl_c_vector<T>::allocate_T(const std::size_t n)
 {
   T *p = (T*)vnl_c_vector_alloc(n, sizeof (T));
   vnl_c_vector_construct(p, n);
@@ -414,7 +414,7 @@ T* vnl_c_vector<T>::allocate_T(std::size_t n)
 }
 
 template<class T>
-void vnl_c_vector<T>::deallocate(T* p, std::size_t n)
+void vnl_c_vector<T>::deallocate(T* p, const std::size_t n)
 {
   vnl_c_vector_destruct(p, n);
   vnl_c_vector_dealloc(p, n, sizeof (T));
@@ -432,17 +432,17 @@ std::ostream& print_vector(std::ostream& s, T const* v, unsigned size)
 //---------------------------------------------------------------------------
 
 #define VNL_C_VECTOR_INSTANTIATE_norm(T, S) \
-template void vnl_c_vector_two_norm_squared(T const *, unsigned, S *); \
-template void vnl_c_vector_rms_norm(T const *, unsigned, S *); \
-template void vnl_c_vector_one_norm(T const *, unsigned, S *); \
-template void vnl_c_vector_two_norm(T const *, unsigned, S *); \
-template void vnl_c_vector_inf_norm(T const *, unsigned, S *)
+template VNL_EXPORT void vnl_c_vector_two_norm_squared(T const *, unsigned, S *); \
+template VNL_EXPORT void vnl_c_vector_rms_norm(T const *, unsigned, S *); \
+template VNL_EXPORT void vnl_c_vector_one_norm(T const *, unsigned, S *); \
+template VNL_EXPORT void vnl_c_vector_two_norm(T const *, unsigned, S *); \
+template VNL_EXPORT void vnl_c_vector_inf_norm(T const *, unsigned, S *)
 
 #undef VNL_C_VECTOR_INSTANTIATE_ordered
 #define VNL_C_VECTOR_INSTANTIATE_ordered(T) \
 VNL_C_VECTOR_INSTANTIATE_norm(T, vnl_c_vector<T >::abs_t); \
-template class vnl_c_vector<T >; \
-template std::ostream& print_vector(std::ostream &,T const *,unsigned)
+template class VNL_EXPORT vnl_c_vector<T >; \
+template VNL_EXPORT std::ostream& print_vector(std::ostream &,T const *,unsigned)
 
 #undef VNL_C_VECTOR_INSTANTIATE_unordered
 #define VNL_C_VECTOR_INSTANTIATE_unordered(T) \
@@ -450,8 +450,8 @@ VCL_DO_NOT_INSTANTIATE(T vnl_c_vector<T >::max_value(T const *, unsigned), T(0))
 VCL_DO_NOT_INSTANTIATE(T vnl_c_vector<T >::min_value(T const *, unsigned), T(0)); \
 VCL_DO_NOT_INSTANTIATE(unsigned vnl_c_vector<T >::arg_max(T const *, unsigned), 0U); \
 VCL_DO_NOT_INSTANTIATE(unsigned vnl_c_vector<T >::arg_min(T const *, unsigned), 0U); \
+template class VNL_EXPORT vnl_c_vector<T >; \
 VNL_C_VECTOR_INSTANTIATE_norm(T, vnl_c_vector<T >::abs_t); \
-template class vnl_c_vector<T >; \
 VCL_UNINSTANTIATE_SPECIALIZATION(T vnl_c_vector<T >::max_value(T const *, unsigned)); \
 VCL_UNINSTANTIATE_SPECIALIZATION(T vnl_c_vector<T >::min_value(T const *, unsigned)); \
 VCL_UNINSTANTIATE_SPECIALIZATION(unsigned vnl_c_vector<T >::arg_max(T const *, unsigned)); \

--- a/core/vnl/vnl_complex_ops.hxx
+++ b/core/vnl/vnl_complex_ops.hxx
@@ -273,31 +273,31 @@ vnl_sym_matrix<T>
 //-------------------------------------------------------------------------
 
 #define VNL_COMPLEX_OPS_INSTANTIATE(T) \
-template void vnl_complexify(T const *, std::complex<T > *, unsigned); \
-template void vnl_complexify(T const *, T const *, std::complex<T > *, unsigned); \
+template VNL_EXPORT void vnl_complexify(T const *, std::complex<T > *, unsigned); \
+template VNL_EXPORT void vnl_complexify(T const *, T const *, std::complex<T > *, unsigned); \
 \
-template vnl_vector<std::complex<T > > vnl_complexify(vnl_vector<T > const &); \
-template vnl_vector<std::complex<T > > vnl_complexify(vnl_vector<T > const &, vnl_vector<T > const &); \
-template vnl_matrix<std::complex<T > > vnl_complexify(vnl_matrix<T > const &); \
-template vnl_matrix<std::complex<T > > vnl_complexify(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template vnl_diag_matrix<std::complex<T > > vnl_complexify(vnl_diag_matrix<T > const &); \
-template vnl_diag_matrix<std::complex<T > > vnl_complexify(vnl_diag_matrix<T > const &,vnl_diag_matrix<T > const&); \
-template vnl_sym_matrix<std::complex<T > > vnl_complexify(vnl_sym_matrix<T > const &); \
-template vnl_sym_matrix<std::complex<T > > vnl_complexify(vnl_sym_matrix<T > const &,vnl_sym_matrix<T > const&); \
+template VNL_EXPORT vnl_vector<std::complex<T > > vnl_complexify(vnl_vector<T > const &); \
+template VNL_EXPORT vnl_vector<std::complex<T > > vnl_complexify(vnl_vector<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT vnl_matrix<std::complex<T > > vnl_complexify(vnl_matrix<T > const &); \
+template VNL_EXPORT vnl_matrix<std::complex<T > > vnl_complexify(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT vnl_diag_matrix<std::complex<T > > vnl_complexify(vnl_diag_matrix<T > const &); \
+template VNL_EXPORT vnl_diag_matrix<std::complex<T > > vnl_complexify(vnl_diag_matrix<T > const &,vnl_diag_matrix<T > const&); \
+template VNL_EXPORT vnl_sym_matrix<std::complex<T > > vnl_complexify(vnl_sym_matrix<T > const &); \
+template VNL_EXPORT vnl_sym_matrix<std::complex<T > > vnl_complexify(vnl_sym_matrix<T > const &,vnl_sym_matrix<T > const&); \
 \
-template void vnl_real(std::complex<T > const*, T*, unsigned int); \
-template void vnl_imag(std::complex<T > const*, T*, unsigned int); \
+template VNL_EXPORT void vnl_real(std::complex<T > const*, T*, unsigned int); \
+template VNL_EXPORT void vnl_imag(std::complex<T > const*, T*, unsigned int); \
 \
-template vnl_vector<T > vnl_real(vnl_vector<std::complex<T > > const&); \
-template vnl_vector<T > vnl_imag(vnl_vector<std::complex<T > > const&); \
+template VNL_EXPORT vnl_vector<T > vnl_real(vnl_vector<std::complex<T > > const&); \
+template VNL_EXPORT vnl_vector<T > vnl_imag(vnl_vector<std::complex<T > > const&); \
 \
-template vnl_matrix<T > vnl_real(vnl_matrix<std::complex<T > > const&); \
-template vnl_matrix<T > vnl_imag(vnl_matrix<std::complex<T > > const&); \
+template VNL_EXPORT vnl_matrix<T > vnl_real(vnl_matrix<std::complex<T > > const&); \
+template VNL_EXPORT vnl_matrix<T > vnl_imag(vnl_matrix<std::complex<T > > const&); \
 \
-template vnl_diag_matrix<T > vnl_real(vnl_diag_matrix<std::complex<T > > const&); \
-template vnl_diag_matrix<T > vnl_imag(vnl_diag_matrix<std::complex<T > > const&); \
+template VNL_EXPORT vnl_diag_matrix<T > vnl_real(vnl_diag_matrix<std::complex<T > > const&); \
+template VNL_EXPORT vnl_diag_matrix<T > vnl_imag(vnl_diag_matrix<std::complex<T > > const&); \
 \
-template vnl_sym_matrix<T > vnl_real(vnl_sym_matrix<std::complex<T > > const&); \
-template vnl_sym_matrix<T > vnl_imag(vnl_sym_matrix<std::complex<T > > const&)
+template VNL_EXPORT vnl_sym_matrix<T > vnl_real(vnl_sym_matrix<std::complex<T > > const&); \
+template VNL_EXPORT vnl_sym_matrix<T > vnl_imag(vnl_sym_matrix<std::complex<T > > const&)
 
 #endif // vnl_complex_ops_hxx_

--- a/core/vnl/vnl_det.hxx
+++ b/core/vnl/vnl_det.hxx
@@ -55,8 +55,8 @@ T vnl_det(T const *row0, T const *row1, T const *row2, T const *row3)
 //--------------------------------------------------------------------------------
 
 #define VNL_DET_INSTANTIATE(T) \
-template T vnl_det(T const *, T const *); \
-template T vnl_det(T const *, T const *, T const *); \
-template T vnl_det(T const *, T const *, T const *, T const *)
+template VNL_EXPORT T vnl_det(T const *, T const *); \
+template VNL_EXPORT T vnl_det(T const *, T const *, T const *); \
+template VNL_EXPORT T vnl_det(T const *, T const *, T const *, T const *)
 
 #endif // vnl_det_hxx_

--- a/core/vnl/vnl_diag_matrix.hxx
+++ b/core/vnl/vnl_diag_matrix.hxx
@@ -42,7 +42,7 @@ std::ostream& operator<< (std::ostream& s, const vnl_diag_matrix<T>& D)
 
 #undef VNL_DIAG_MATRIX_INSTANTIATE
 #define VNL_DIAG_MATRIX_INSTANTIATE(T) \
-template class vnl_diag_matrix<T >; \
+template class VNL_EXPORT vnl_diag_matrix<T >; \
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator* (vnl_matrix<T > const &, vnl_diag_matrix<T > const &));\
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator* (vnl_diag_matrix<T > const &, vnl_matrix<T > const &));\
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator+ (vnl_matrix<T > const &, vnl_diag_matrix<T > const &));\
@@ -51,7 +51,7 @@ VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator- (vnl_matrix<T > const &, vnl_dia
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator- (vnl_diag_matrix<T > const &, vnl_matrix<T > const &));\
 VCL_INSTANTIATE_INLINE(vnl_vector<T > operator* (const vnl_vector<T >&, vnl_diag_matrix<T > const &));\
 VCL_INSTANTIATE_INLINE(vnl_vector<T > operator* (vnl_diag_matrix<T > const &, const vnl_vector<T >&));\
-template std::ostream& operator<< (std::ostream& s, vnl_diag_matrix<T > const &)
+template VNL_EXPORT std::ostream& operator<< (std::ostream& s, vnl_diag_matrix<T > const &)
 
 //template bool epsilon_equals (vnl_diag_matrix<T > const & , vnl_diag_matrix<T > const & , double)
 

--- a/core/vnl/vnl_file_matrix.hxx
+++ b/core/vnl/vnl_file_matrix.hxx
@@ -32,6 +32,7 @@ vnl_file_matrix<T>::vnl_file_matrix(char const* filename)
 //--------------------------------------------------------------------------------
 
 #undef VNL_FILE_MATRIX_INSTANTIATE
-#define VNL_FILE_MATRIX_INSTANTIATE(T) template class vnl_file_matrix<T >
+#define VNL_FILE_MATRIX_INSTANTIATE(T) \
+template class VNL_EXPORT vnl_file_matrix<T >
 
 #endif // vnl_file_matrix_hxx_

--- a/core/vnl/vnl_file_vector.hxx
+++ b/core/vnl/vnl_file_vector.hxx
@@ -35,6 +35,7 @@ vnl_file_vector<T>::vnl_file_vector(char const* filename)
 //--------------------------------------------------------------------------------
 
 #undef VNL_FILE_VECTOR_INSTANTIATE
-#define VNL_FILE_VECTOR_INSTANTIATE(T) template class vnl_file_vector<T >
+#define VNL_FILE_VECTOR_INSTANTIATE(T) \
+template class VNL_EXPORT vnl_file_vector<T >
 
 #endif // vnl_file_vector_hxx_

--- a/core/vnl/vnl_fortran_copy.hxx
+++ b/core/vnl/vnl_fortran_copy.hxx
@@ -33,6 +33,7 @@ vnl_fortran_copy<T>::~vnl_fortran_copy()
 //--------------------------------------------------------------------------------
 
 #undef VNL_FORTRAN_COPY_INSTANTIATE
-#define VNL_FORTRAN_COPY_INSTANTIATE(T) template class vnl_fortran_copy<T >
+#define VNL_FORTRAN_COPY_INSTANTIATE(T) \
+template class VNL_EXPORT vnl_fortran_copy<T >
 
 #endif // vnl_fortran_copy_hxx_

--- a/core/vnl/vnl_hungarian_algorithm.hxx
+++ b/core/vnl/vnl_hungarian_algorithm.hxx
@@ -527,6 +527,6 @@ vnl_hungarian_algorithm<T>::GetAssignmentVector()
 
 #undef VNL_HUNGARIAN_ALGORITHM_INSTANTIATE
 #define VNL_HUNGARIAN_ALGORITHM_INSTANTIATE(T) \
-template class vnl_hungarian_algorithm<T >
+template class VNL_EXPORT vnl_hungarian_algorithm<T >
 
 #endif // vnl_hungarian_algorithm_hxx_

--- a/core/vnl/vnl_matlab_print.hxx
+++ b/core/vnl/vnl_matlab_print.hxx
@@ -176,26 +176,26 @@ std::ostream& vnl_matlab_print(std::ostream& s,
 
 #undef  VNL_MATLAB_PRINT_INSTANTIATE
 #define VNL_MATLAB_PRINT_INSTANTIATE(T) \
-template std::ostream &vnl_matlab_print(std::ostream &, T const*, unsigned, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, T const* const*, unsigned, unsigned, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_diag_matrix<T > const&, char const *, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix<T > const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector<T > const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_ref<T > const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,2> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,3> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,2> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,3> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,4> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,4> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,4,3> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,4,4> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,6,8> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,2> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,3> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,4> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,5> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,6> const&, char const*, vnl_matlab_print_format); \
-template std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,7> const&, char const*, vnl_matlab_print_format)
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, T const*, unsigned, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, T const* const*, unsigned, unsigned, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_diag_matrix<T > const&, char const *, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix<T > const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector<T > const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_ref<T > const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,2> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,3> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,2> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,3> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,2,4> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,3,4> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,4,3> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,4,4> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_matrix_fixed<T,6,8> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,2> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,3> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,4> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,5> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,6> const&, char const*, vnl_matlab_print_format); \
+template VNL_EXPORT std::ostream &vnl_matlab_print(std::ostream &, vnl_vector_fixed<T,7> const&, char const*, vnl_matlab_print_format)
 
 #endif // vnl_matlab_print_hxx_

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -1636,17 +1636,17 @@ vnl_matrix<T>& vnl_matrix<T>::inplace_transpose()
 //------------------------------------------------------------------------------
 
 #define VNL_MATRIX_INSTANTIATE(T) \
-template class vnl_matrix<T >; \
-template vnl_matrix<T > operator-(T const &, vnl_matrix<T > const &); \
+template class VNL_EXPORT vnl_matrix<T >; \
+template VNL_EXPORT vnl_matrix<T > operator-(T const &, vnl_matrix<T > const &); \
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator+(T const &, vnl_matrix<T > const &)); \
 VCL_INSTANTIATE_INLINE(vnl_matrix<T > operator*(T const &, vnl_matrix<T > const &)); \
-template T dot_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template T inner_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template T cos_angle(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template vnl_matrix<T > element_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template vnl_matrix<T > element_quotient(vnl_matrix<T > const &, vnl_matrix<T > const &); \
-template int vnl_inplace_transpose(T*, unsigned, unsigned, char*, unsigned); \
-template std::ostream & operator<<(std::ostream &, vnl_matrix<T > const &); \
-template std::istream & operator>>(std::istream &, vnl_matrix<T >       &)
+template VNL_EXPORT T dot_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT T inner_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT T cos_angle(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT vnl_matrix<T > element_product(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT vnl_matrix<T > element_quotient(vnl_matrix<T > const &, vnl_matrix<T > const &); \
+template VNL_EXPORT int vnl_inplace_transpose(T*, unsigned, unsigned, char*, unsigned); \
+template VNL_EXPORT std::ostream & operator<<(std::ostream &, vnl_matrix<T > const &); \
+template VNL_EXPORT std::istream & operator>>(std::istream &, vnl_matrix<T >       &)
 
 #endif // vnl_matrix_hxx_

--- a/core/vnl/vnl_polynomial.hxx
+++ b/core/vnl/vnl_polynomial.hxx
@@ -150,7 +150,7 @@ void vnl_polynomial<T>::print(std::ostream& os) const
 
 #undef VNL_POLYNOMIAL_INSTANTIATE
 #define VNL_POLYNOMIAL_INSTANTIATE(T) \
-template class vnl_polynomial<T >; \
-template std::ostream& operator<<(std::ostream& os, vnl_polynomial<T > const&)
+template class VNL_EXPORT vnl_polynomial<T >; \
+template VNL_EXPORT std::ostream& operator<<(std::ostream& os, vnl_polynomial<T > const&)
 
 #endif // vnl_polynomial_hxx_

--- a/core/vnl/vnl_quaternion.hxx
+++ b/core/vnl/vnl_quaternion.hxx
@@ -304,7 +304,7 @@ vnl_vector_fixed<T,3> vnl_quaternion<T>::rotate(vnl_vector_fixed<T,3> const& v) 
 
 #undef VNL_QUATERNION_INSTANTIATE
 #define VNL_QUATERNION_INSTANTIATE(T) \
-template class vnl_quaternion<T >;\
+template class VNL_EXPORT vnl_quaternion<T >;\
 VCL_INSTANTIATE_INLINE(std::ostream& operator<< (std::ostream&, vnl_quaternion<T > const&))
 
 #endif // vnl_quaternion_hxx_

--- a/core/vnl/vnl_rank.hxx
+++ b/core/vnl/vnl_rank.hxx
@@ -211,9 +211,9 @@ unsigned int vnl_rank(vnl_matrix<T> const& mat, vnl_rank_type t)
 
 #undef VNL_RANK_INSTANTIATE
 #define VNL_RANK_INSTANTIATE(T) \
-template vnl_matrix<T > vnl_rank_row_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
-template vnl_matrix<T > vnl_rank_column_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
-template vnl_matrix<T > vnl_rank_row_column_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
-template unsigned int vnl_rank(vnl_matrix<T > const&, vnl_rank_type)
+template VNL_EXPORT vnl_matrix<T > vnl_rank_row_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
+template VNL_EXPORT vnl_matrix<T > vnl_rank_column_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
+template VNL_EXPORT vnl_matrix<T > vnl_rank_row_column_reduce(vnl_matrix<T > const&, vnl_rank_pivot_type);\
+template VNL_EXPORT unsigned int vnl_rank(vnl_matrix<T > const&, vnl_rank_type)
 
 #endif // vnl_rank_hxx_

--- a/core/vnl/vnl_scalar_join_iterator.hxx
+++ b/core/vnl/vnl_scalar_join_iterator.hxx
@@ -15,9 +15,9 @@
 #include <vcl_compiler.h>
 
 #define VNL_SCALAR_JOIN_ITERATOR_INSTANTIATE(T) \
-template class vnl_scalar_join_iterator_indexed_pair<T >;\
-template class vnl_scalar_join_iterator<T >; \
-template std::ostream& operator<<(std::ostream& s, const vnl_scalar_join_iterator_indexed_pair<T >& p);\
+template class VNL_EXPORT vnl_scalar_join_iterator_indexed_pair<T >;\
+template class VNL_EXPORT vnl_scalar_join_iterator<T >; \
+template VNL_EXPORT std::ostream& operator<<(std::ostream& s, const vnl_scalar_join_iterator_indexed_pair<T >& p);\
 
 #include <vcl_cassert.h>
 #include <vnl/vnl_matrix.h>

--- a/core/vnl/vnl_sparse_matrix.hxx
+++ b/core/vnl/vnl_sparse_matrix.hxx
@@ -972,6 +972,6 @@ vnl_sparse_matrix<T> vnl_sparse_matrix<T>::conjugate_transpose() const
 }
 
 #define VNL_SPARSE_MATRIX_INSTANTIATE(T) \
-template class vnl_sparse_matrix<T >
+template class VNL_EXPORT vnl_sparse_matrix<T >
 
 #endif // vnl_sparse_matrix_hxx_

--- a/core/vnl/vnl_sym_matrix.h
+++ b/core/vnl/vnl_sym_matrix.h
@@ -52,45 +52,43 @@ class VNL_EXPORT vnl_sym_matrix
   //: Copy constructor
   inline vnl_sym_matrix(vnl_sym_matrix<T> const& that);
 
-  ~vnl_sym_matrix()
-  { vnl_c_vector<T>::deallocate(data_, size());
-    vnl_c_vector<T>::deallocate(index_, nn_);}
+  ~vnl_sym_matrix();
 
   vnl_sym_matrix<T>& operator=(vnl_sym_matrix<T> const& that);
 
   // Operations----------------------------------------------------------------
 
   //: In-place arithmetic operations
-  vnl_sym_matrix<T>& operator*=(T v) { vnl_c_vector<T>::scale(data_, data_, size(), v); return *this; }
+  inline vnl_sym_matrix<T>& operator*=(T v) { vnl_c_vector<T>::scale(data_, data_, size(), v); return *this; }
   //: In-place arithmetic operations
-  vnl_sym_matrix<T>& operator/=(T v) { vnl_c_vector<T>::scale(data_, data_, size(), ((T)1)/v); return *this; }
+  inline vnl_sym_matrix<T>& operator/=(T v) { vnl_c_vector<T>::scale(data_, data_, size(), ((T)1)/v); return *this; }
 
 
   // Data Access---------------------------------------------------------------
 
-  T operator () (unsigned i, unsigned j) const {
+  inline T operator () (unsigned i, unsigned j) const {
     return (i > j) ? index_[i][j] : index_[j][i];
   }
 
-  T& operator () (unsigned i, unsigned j) {
+  inline T& operator () (unsigned i, unsigned j) {
     return (i > j) ? index_[i][j] : index_[j][i];
   }
 
   //: Access a half-row of data.
   // Only the first i+1 values from this pointer are valid.
-  const T* operator [] (unsigned i) const {
+  inline const T* operator [] (unsigned i) const {
     assert (i < nn_);
     return index_[i];
   }
 
   //: fast access, however i >= j
-  T fast (unsigned i, unsigned j) const {
+  inline T fast (unsigned i, unsigned j) const {
     assert (i >= j);
     return index_[i][j];
   }
 
   //: fast access, however i >= j
-  T& fast (unsigned i, unsigned j) {
+  inline T& fast (unsigned i, unsigned j) {
     assert (i >= j);
     return index_[i][j];
   }
@@ -171,10 +169,7 @@ class VNL_EXPORT vnl_sym_matrix
 
  protected:
 //: Set up the index array
-  inline void setup_index() {
-    T * data = data_;
-    for (unsigned i=0; i< nn_; ++i) { index_[i] = data; data += i+1; }
-  }
+  void setup_index();
 
   T* data_;
   T** index_;
@@ -250,8 +245,8 @@ inline void vnl_sym_matrix<T>::set_size(int n)
 {
   if (n == (int)nn_) return;
 
-  vnl_c_vector<T>::deallocate(data_, size());
-  vnl_c_vector<T>::deallocate(index_, nn_);
+  vnl_c_vector<T>::deallocate(data_, static_cast<std::size_t>(size()));
+  vnl_c_vector<T>::deallocate(index_, static_cast<std::size_t>( nn_));
 
   nn_ = n;
   data_ = vnl_c_vector<T>::allocate_T(size());

--- a/core/vnl/vnl_sym_matrix.hxx
+++ b/core/vnl/vnl_sym_matrix.hxx
@@ -55,6 +55,21 @@ vnl_sym_matrix<T>& vnl_sym_matrix<T>::operator=(vnl_sym_matrix<T> const& that)
   update(that);
   return *this;
 }
+// ==========================================================================
+template <class T>
+vnl_sym_matrix<T>::~vnl_sym_matrix()
+  {
+    vnl_c_vector<T>::deallocate(data_, static_cast<std::size_t>( size() ) );
+    vnl_c_vector<T>::deallocate(index_, static_cast<std::size_t> ( nn_ ) );
+  }
+
+
+template <class T>
+void vnl_sym_matrix<T>::setup_index()
+{
+    T * data = data_;
+    for (unsigned i=0; i< nn_; ++i) { index_[i] = data; data += i+1; }
+}
 
 // ==========================================================================
 //: Set the first i values of row i
@@ -130,10 +145,10 @@ bool operator==(const vnl_matrix<T> &a, const vnl_sym_matrix<T> &b)
 
 #undef VNL_SYM_MATRIX_INSTANTIATE
 #define VNL_SYM_MATRIX_INSTANTIATE(T) \
-template class vnl_sym_matrix<T >; \
-template std::ostream& operator<< (std::ostream& s, vnl_sym_matrix<T > const &); \
-template bool operator==(const vnl_sym_matrix<T > &a, const vnl_sym_matrix<T > &b); \
-template bool operator==(const vnl_sym_matrix<T > &a, const vnl_matrix<T > &b); \
-template bool operator==(const vnl_matrix<T > &a, const vnl_sym_matrix<T > &b)
+template class VNL_EXPORT vnl_sym_matrix<T >; \
+template VNL_EXPORT std::ostream& operator<< (std::ostream& s, vnl_sym_matrix<T > const &); \
+template VNL_EXPORT bool operator==(const vnl_sym_matrix<T > &a, const vnl_sym_matrix<T > &b); \
+template VNL_EXPORT bool operator==(const vnl_sym_matrix<T > &a, const vnl_matrix<T > &b); \
+template VNL_EXPORT bool operator==(const vnl_matrix<T > &a, const vnl_sym_matrix<T > &b)
 
 #endif // vnl_sym_matrix_hxx_

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -464,18 +464,18 @@ class VNL_EXPORT vnl_vector
 # define v vnl_vector<T>
 # define m vnl_matrix<T>
 #endif // DOXYGEN_SHOULD_SKIP_THIS
-  friend T      dot_product      VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend T      inner_product    VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend T      bracket          VCL_NULL_TMPL_ARGS (v const&, m const&, v const&);
-  friend T      cos_angle        VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend double angle            VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend m      outer_product    VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend v      operator+        VCL_NULL_TMPL_ARGS (T const,  v const&);
-  friend v      operator-        VCL_NULL_TMPL_ARGS (T const,  v const&);
-  friend v      operator*        VCL_NULL_TMPL_ARGS (T const,  v const&);
-  friend v      operator*        VCL_NULL_TMPL_ARGS (m const&, v const&);
-  friend v      element_product  VCL_NULL_TMPL_ARGS (v const&, v const&);
-  friend v      element_quotient VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT T      dot_product      VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT T      inner_product    VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT T      bracket          VCL_NULL_TMPL_ARGS (v const&, m const&, v const&);
+  friend VNL_EXPORT T      cos_angle        VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT double angle            VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT m      outer_product    VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT v      operator+        VCL_NULL_TMPL_ARGS (T const,  v const&);
+  friend VNL_EXPORT v      operator-        VCL_NULL_TMPL_ARGS (T const,  v const&);
+  friend VNL_EXPORT v      operator*        VCL_NULL_TMPL_ARGS (T const,  v const&);
+  friend VNL_EXPORT v      operator*        VCL_NULL_TMPL_ARGS (m const&, v const&);
+  friend VNL_EXPORT v      element_product  VCL_NULL_TMPL_ARGS (v const&, v const&);
+  friend VNL_EXPORT v      element_quotient VCL_NULL_TMPL_ARGS (v const&, v const&);
 # undef v
 # undef m
 #endif

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -879,31 +879,31 @@ void vnl_vector<T>::inline_function_tickler()
 // shouldn't be instantiated for complex and/or integral types.
 
 #define VNL_VECTOR_INSTANTIATE_COMMON(T) \
-template class vnl_vector<T >; \
+template class VNL_EXPORT vnl_vector<T >; \
 /* arithmetic, comparison etc */ \
 VCL_INSTANTIATE_INLINE(vnl_vector<T > operator+(T const, vnl_vector<T > const &)); \
 VCL_INSTANTIATE_INLINE(vnl_vector<T > operator-(T const, vnl_vector<T > const &)); \
 VCL_INSTANTIATE_INLINE(vnl_vector<T > operator*(T const, vnl_vector<T > const &)); \
-template vnl_vector<T > operator*(vnl_matrix<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT vnl_vector<T > operator*(vnl_matrix<T > const &, vnl_vector<T > const &); \
 /* element-wise */ \
-template vnl_vector<T > element_product(vnl_vector<T > const &, vnl_vector<T > const &); \
-template vnl_vector<T > element_quotient(vnl_vector<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT vnl_vector<T > element_product(vnl_vector<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT vnl_vector<T > element_quotient(vnl_vector<T > const &, vnl_vector<T > const &); \
 /* dot products, angles etc */ \
-template T inner_product(vnl_vector<T > const &, vnl_vector<T > const &); \
-template T dot_product(vnl_vector<T > const &, vnl_vector<T > const &); \
-template T bracket(vnl_vector<T > const &, vnl_matrix<T > const &, vnl_vector<T > const &); \
-template vnl_matrix<T > outer_product(vnl_vector<T > const &,vnl_vector<T > const &); \
+template VNL_EXPORT T inner_product(vnl_vector<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT T dot_product(vnl_vector<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT T bracket(vnl_vector<T > const &, vnl_matrix<T > const &, vnl_vector<T > const &); \
+template VNL_EXPORT vnl_matrix<T > outer_product(vnl_vector<T > const &,vnl_vector<T > const &); \
 /* I/O */ \
-template std::ostream & operator<<(std::ostream &, vnl_vector<T > const &); \
-template std::istream & operator>>(std::istream &, vnl_vector<T >       &)
+template VNL_EXPORT std::ostream & operator<<(std::ostream &, vnl_vector<T > const &); \
+template VNL_EXPORT std::istream & operator>>(std::istream &, vnl_vector<T >       &)
 
 #define VNL_VECTOR_INSTANTIATE(T) \
 VNL_VECTOR_INSTANTIATE_COMMON(T); \
-template T cos_angle(vnl_vector<T > const & , vnl_vector<T > const &); \
-template double angle(vnl_vector<T > const & , vnl_vector<T > const &)
+template VNL_EXPORT T cos_angle(vnl_vector<T > const & , vnl_vector<T > const &); \
+template VNL_EXPORT double angle(vnl_vector<T > const & , vnl_vector<T > const &)
 
 #define VNL_VECTOR_INSTANTIATE_COMPLEX(T) \
 VNL_VECTOR_INSTANTIATE_COMMON(T); \
-template T cos_angle(vnl_vector<T > const & , vnl_vector<T > const &)
+template VNL_EXPORT T cos_angle(vnl_vector<T > const & , vnl_vector<T > const &)
 
 #endif // vnl_vector_hxx_

--- a/core/vnl/xio/vnl_xio_matrix.hxx
+++ b/core/vnl/xio/vnl_xio_matrix.hxx
@@ -41,7 +41,7 @@ void x_write_tree(std::ostream & os, vnl_matrix<T> const& M, std::string name)
 
 #undef VNL_XIO_MATRIX_INSTANTIATE
 #define VNL_XIO_MATRIX_INSTANTIATE(T) \
-template void x_write(std::ostream &, vnl_matrix<T > const&, std::string); \
-template void x_write_tree(std::ostream &, vnl_matrix<T > const&, std::string)
+template VNL_EXPORT void x_write(std::ostream &, vnl_matrix<T > const&, std::string); \
+template VNL_EXPORT void x_write_tree(std::ostream &, vnl_matrix<T > const&, std::string)
 
 #endif // vnl_xio_matrix_hxx_

--- a/core/vnl/xio/vnl_xio_quaternion.hxx
+++ b/core/vnl/xio/vnl_xio_quaternion.hxx
@@ -32,7 +32,7 @@ void x_write_tree(std::ostream & os, vnl_quaternion<T> const& q, std::string nam
 
 #undef VNL_XIO_QUATERNION_INSTANTIATE
 #define VNL_XIO_QUATERNION_INSTANTIATE(T) \
-template void x_write(std::ostream &, vnl_quaternion<T > const&, std::string); \
-template void x_write_tree(std::ostream &, vnl_quaternion<T > const&, std::string)
+template VNL_EXPORT void x_write(std::ostream &, vnl_quaternion<T > const&, std::string); \
+template VNL_EXPORT void x_write_tree(std::ostream &, vnl_quaternion<T > const&, std::string)
 
 #endif // vnl_xio_quaternion_hxx_

--- a/core/vnl/xio/vnl_xio_vector.hxx
+++ b/core/vnl/xio/vnl_xio_vector.hxx
@@ -32,7 +32,7 @@ void x_write_tree(std::ostream & os, vnl_vector<T> const& v, std::string name)
 
 #undef VNL_XIO_VECTOR_INSTANTIATE
 #define VNL_XIO_VECTOR_INSTANTIATE(T) \
-template void x_write(std::ostream &, vnl_vector<T > const&, std::string); \
-template void x_write_tree(std::ostream &, vnl_vector<T > const&, std::string)
+template VNL_EXPORT void x_write(std::ostream &, vnl_vector<T > const&, std::string); \
+template VNL_EXPORT void x_write_tree(std::ostream &, vnl_vector<T > const&, std::string)
 
 #endif // vnl_xio_vector_hxx_


### PR DESCRIPTION
These missing VNL_EXPORTS were identified by
linker errors of unidentified symobols when
building a shared library.

cmake -DBUILD_SHARED_LIBS:BOOL=ON \
      -DCMAKE_CXX_FLAGS:STRING="-Wno-gnu-static-float-init -stdlib=libstdc++" \
      ../vxl

Special thanks to Ricardo Fabbri for identifying and being persistent narrowing
down the root scenario that exposed the problem.

resolves: #305