### PR TITLE
COMP: Address compiler warnings on OSX

### DIFF
--- a/contrib/brl/b3p/expatpp/expatpp.cpp
+++ b/contrib/brl/b3p/expatpp/expatpp.cpp
@@ -132,7 +132,7 @@ expatpp::parseFile(FILE* inFile)
       return parseStatus;
     }
   } while (!done);
-  delete buf;
+  delete[] buf;
   return XML_STATUS_OK;
 }
 

--- a/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
+++ b/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
@@ -703,7 +703,7 @@ vil_image_view<float> bil_detect_compass_edges(vil_image_view<vxl_byte>& image,
   delete mask;
   delete [] masksum;
   delete [] wHist;
-  delete dist;
+  delete[] dist;
   vil_image_view<float> magimg=NMS.mag();
 
   return  magimg;

--- a/contrib/brl/bbas/bnabo/bnabo_index_heap.h
+++ b/contrib/brl/bbas/bnabo/bnabo_index_heap.h
@@ -334,7 +334,7 @@ namespace Nabo
      *         \param value new distance value */
     inline void replaceHead(const Index index, const Value value)
     {
-      register size_t i;
+      size_t i;
       for (i = sizeMinusOne; i > 0; --i)
         {
           if (data[i-1].value > value)

--- a/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_filter.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/ocl/boxm2_vecf_ocl_filter.cxx
@@ -246,6 +246,6 @@ bool boxm2_vecf_ocl_filter::filter(std::vector<float> const& weights, unsigned n
    delete info_buffer_source;
    blk_info_temp->release_memory();
    delete info_buffer;
-   delete output_buff;
+   delete[] output_buff;
    return true;
 }

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
@@ -304,7 +304,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;     delete [] n_ind_;
+      delete n_ind_cl_mem_;     delete n_ind_;
       delete [] index_buff_;    delete [] score_buff_;    delete [] mu_buff_;
       delete [] index_orient_buff_;  delete [] index_land_buff_;
       //delete [] index_combine_buff_;
@@ -357,7 +357,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;     delete [] n_ind_;
+      delete n_ind_cl_mem_;     delete n_ind_;
       delete index_cl_mem_;
       delete [] index_buff_;    delete [] score_buff_;    delete [] mu_buff_;
       delete [] index_orient_buff_;  delete [] index_land_buff_;
@@ -388,7 +388,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;     delete [] n_ind_;
+      delete n_ind_cl_mem_;     delete n_ind_;
       delete index_cl_mem_;
       delete [] index_buff_;    delete [] score_buff_;    delete [] mu_buff_;
       delete [] index_orient_buff_; delete index_orient_cl_mem_;
@@ -403,7 +403,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;         delete [] n_ind_;
+      delete n_ind_cl_mem_;         delete n_ind_;
       delete index_cl_mem_;         delete [] index_buff_;
       delete index_orient_cl_mem_;  delete [] index_orient_buff_;
       delete index_land_cl_mem_;    delete [] index_land_buff_;
@@ -420,7 +420,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;          delete [] n_ind_;
+      delete n_ind_cl_mem_;          delete n_ind_;
       delete index_cl_mem_;          delete [] index_buff_;
       /*delete index_combine_cl_mem_;  delete [] index_combine_buff_;*/
       delete index_orient_cl_mem_;   delete [] index_orient_buff_;
@@ -438,7 +438,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;          delete [] n_ind_;
+      delete n_ind_cl_mem_;          delete n_ind_;
       delete index_cl_mem_;          delete [] index_buff_;
       /*delete index_combine_cl_mem_;  delete [] index_combine_buff_;*/
       delete index_orient_cl_mem_;   delete [] index_orient_buff_;
@@ -462,7 +462,7 @@ bool boxm2_volm_matcher_p1::volm_matcher_p1(int const& num_locs_to_kernel)
       delete depth_interval_cl_mem_;        delete depth_length_cl_mem_;
       delete layer_size_cl_mem_;
       delete fallback_size_cl_mem_;
-      delete n_ind_cl_mem_;          delete [] n_ind_;
+      delete n_ind_cl_mem_;          delete n_ind_;
       delete index_cl_mem_;          delete [] index_buff_;
       //delete index_combine_cl_mem_;  delete [] index_combine_buff_;
       delete index_orient_cl_mem_;   delete [] index_orient_buff_;
@@ -830,7 +830,7 @@ bool boxm2_volm_matcher_p1::execute_matcher_kernel_orient(bocl_device_sptr      
   if (!kern->execute(queue, work_dim_, local_threads_, global_threads_)) {
     std::cerr << "\n ERROR: kernel execution failed\n";
     delete debug_cl_mem_;
-    delete debug_buff_;
+    delete[] debug_buff_;
     return false;
   }
   status = clFinish(queue);  // block to ensure kernel finishes

--- a/contrib/tbl/vipl/vipl_add_random_noise.hxx
+++ b/contrib/tbl/vipl/vipl_add_random_noise.hxx
@@ -11,8 +11,8 @@ bool vipl_add_random_noise <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_app
   int starty = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->Y_Axis());
   int stopx = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->X_Axis());
   int stopy = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
-  for (register int j = starty; j < stopy; ++j)
-    for (register int i = startx; i < stopx; ++i)
+  for (int j = starty; j < stopy; ++j)
+    for (int i = startx; i < stopx; ++i)
     {
       double rnd = type_ == UNIFORM_NOISE ? vnl_sample_uniform(-maxdev_,maxdev_)
                  : type_ == GAUSSIAN_NOISE ? vnl_sample_normal(0,maxdev_)

--- a/contrib/tbl/vipl/vipl_dilate_disk.hxx
+++ b/contrib/tbl/vipl/vipl_dilate_disk.hxx
@@ -18,12 +18,12 @@ bool vipl_dilate_disk <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop(
   int starty = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->Y_Axis());
   int stopx  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->X_Axis());
   int stopy  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
-  for (register int j = starty, ej =  stopy; j < ej  ; ++j)
-    for (register int i = startx, ei = stopx; i < ei ; ++i)
+  for (int j = starty, ej =  stopy; j < ej  ; ++j)
+    for (int i = startx, ei = stopx; i < ei ; ++i)
     {
       DataIn v = fgetpixel(in, i, j, DataIn(0)); // set v to max of surrounding pixels:
-      for (register int x=0; x<=size; ++x)
-      for (register int y=0; y<=size; ++y)
+      for (int x=0; x<=size; ++x)
+      for (int y=0; y<=size; ++y)
         if (mask()[x][y]) {
           v = std::max(v, getpixel(in, i+x, j+y, DataIn(0)));
           v = std::max(v, getpixel(in, i-x, j+y, DataIn(0)));

--- a/contrib/tbl/vipl/vipl_erode_disk.hxx
+++ b/contrib/tbl/vipl/vipl_erode_disk.hxx
@@ -30,12 +30,12 @@ bool vipl_erode_disk <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop()
   std::cout << " (" << startx << ':' << stopx << ',' << starty << ':' << stopy << ')';
   std::cout << " run over image ...";
 #endif
-  for (register int j = starty; j < stopy; ++j)
-    for (register int i = startx; i < stopx; ++i)
+  for (int j = starty; j < stopy; ++j)
+    for (int i = startx; i < stopx; ++i)
     {
       DataIn v = fgetpixel(in, i, j, DataIn(0)); // set v to min of surrounding pixels:
-      for (register int x=0; x<=size; ++x)
-      for (register int y=0; y<=size; ++y)
+      for (int x=0; x<=size; ++x)
+      for (int y=0; y<=size; ++y)
         if (mask()[x][y]) {
           v = std::min(v, getpixel(in, i+x, j+y, DataIn(0)));
           v = std::min(v, getpixel(in, i-x, j+y, DataIn(0)));

--- a/contrib/tbl/vipl/vipl_gradient_dir.hxx
+++ b/contrib/tbl/vipl/vipl_gradient_dir.hxx
@@ -18,8 +18,8 @@ bool vipl_gradient_dir <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop
   int stopy  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
   for (int j = starty; j < stopy; ++j)
     for (int i = startx; i < stopx; ++i) {
-      register double dx = fgetpixel(in, i, j, DataIn(0)) - getpixel(in, i-1, j, DataIn(0));
-      register double dy = fgetpixel(in, i, j, DataIn(0)) - getpixel(in, i, j-1, DataIn(0));
+      double dx = fgetpixel(in, i, j, DataIn(0)) - getpixel(in, i-1, j, DataIn(0));
+      double dy = fgetpixel(in, i, j, DataIn(0)) - getpixel(in, i, j-1, DataIn(0));
       if (dx==0 && dy==0) dx=1.0; // to avoid an atan2() domain error
       dx = (std::atan2( dy, dx ) + shift()) * scale();
       fsetpixel(out, i, j, DataOut(dx));

--- a/contrib/tbl/vipl/vipl_gradient_mag.hxx
+++ b/contrib/tbl/vipl/vipl_gradient_mag.hxx
@@ -12,7 +12,7 @@ bool vipl_gradient_mag <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop
   const ImgIn &in = this->in_data(0);
   ImgOut &out = *this->out_data_ptr();
 
-  register double dx, dy;
+  double dx, dy;
   int startx = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->X_Axis());
   int starty = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->Y_Axis());
   int stopx  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->X_Axis());

--- a/contrib/tbl/vipl/vipl_median.hxx
+++ b/contrib/tbl/vipl/vipl_median.hxx
@@ -20,7 +20,7 @@ bool vipl_median <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop()
   int stopy  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
   for (int j = starty; j < stopy; ++j)
     for (int i = startx; i < stopx; ++i) {
-      register unsigned int count = 0;
+      unsigned int count = 0;
       v[count++] = fgetpixel(in, i, j, DataIn(0));
       for (int x=0; x<=size; ++x) for (int y=0; y<=size; ++y) if (mask()[x][y]) {
         v[count++] = getpixel(in, i+x, j+y, DataIn(0));

--- a/contrib/tbl/vipl/vipl_x_gradient.hxx
+++ b/contrib/tbl/vipl/vipl_x_gradient.hxx
@@ -13,8 +13,8 @@ bool vipl_x_gradient <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop()
   int starty = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->Y_Axis());
   int stopx  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->X_Axis());
   int stopy  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
-  for (register int j = starty; j < stopy; ++j)
-    for (register int i = startx+1; i < stopx; ++i) {
+  for (int j = starty; j < stopy; ++j)
+    for (int i = startx+1; i < stopx; ++i) {
       DataIn w = fgetpixel(in, i,  j, DataIn(0))
                - fgetpixel(in, i-1,j, DataIn(0)) /* + shift() */;
 #if 0

--- a/contrib/tbl/vipl/vipl_y_gradient.hxx
+++ b/contrib/tbl/vipl/vipl_y_gradient.hxx
@@ -13,8 +13,8 @@ bool vipl_y_gradient <ImgIn,ImgOut,DataIn,DataOut,PixelItr> :: section_applyop()
   int starty = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::start(this->Y_Axis());
   int stopx  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->X_Axis());
   int stopy  = vipl_filter<ImgIn,ImgOut,DataIn,DataOut,2,PixelItr>::stop(this->Y_Axis());
-  for (register int j = starty+1; j < stopy; ++j)
-    for (register int i = startx; i < stopx; ++i) {
+  for (int j = starty+1; j < stopy; ++j)
+    for (int i = startx; i < stopx; ++i) {
       DataIn w = fgetpixel(in, i, j,   DataIn(0))
                - fgetpixel(in, i, j-1, DataIn(0)) /* + shift() */;
 #if 0

--- a/core/vil/file_formats/vil_nitf2_tagged_record.cxx
+++ b/core/vil/file_formats/vil_nitf2_tagged_record.cxx
@@ -360,7 +360,7 @@ bool vil_nitf2_tagged_record::test()
       std::cerr << "\nWrite failed!\n";
       error = true;
     }
-    delete buf;
+    delete[] buf;
     std::cerr << "Testing get_value:\n";
     int mti_dp;
     if (!record->get_value("MTI_DP", mti_dp) || mti_dp!=2) {

--- a/core/vsl/tests/test_arbitrary_length_int_conversion.cxx
+++ b/core/vsl/tests/test_arbitrary_length_int_conversion.cxx
@@ -57,9 +57,9 @@ void test_arbitrary_length_int_conversion_int()
   TEST("Checking that the results are correct", i, 25000000);
   if (i != 25000000)
     std::cout << "Failed at number " << i <<std::endl;
-  delete a;
-  delete b;
-  delete buf;
+  delete[] a;
+  delete[] b;
+  delete[] buf;
 }
 
 


### PR DESCRIPTION
This PR addresses two types of compiler warnings I'm getting on OSX:
-- deprecated use of the `register` keyword
-- Mismatched `new` / `delete` and `new[]` / `delete[]`

This has been verified on my system on top of this [pull request](https://github.com/vxl/vxl/pull/308), without which vxl does not build.