### PR TITLE
ENH: Encourage unified container interface.

### DIFF
--- a/core/vnl/tests/CMakeLists.txt
+++ b/core/vnl/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable( vnl_test_all
   test_math.cxx
   test_na.cxx
   test_matrix.cxx
+  test_container_interface.cxx
   test_matrix_exp.cxx
   test_matrix_fixed.cxx
   test_vector_fixed_ref.cxx
@@ -82,6 +83,7 @@ add_test( NAME vnl_test_finite COMMAND $<TARGET_FILE:vnl_test_all> test_finite  
 add_test( NAME vnl_test_inverse COMMAND $<TARGET_FILE:vnl_test_all> test_inverse                )
 add_test( NAME vnl_test_math COMMAND $<TARGET_FILE:vnl_test_all> test_math                   )
 add_test( NAME vnl_test_matrix COMMAND $<TARGET_FILE:vnl_test_all> test_matrix                 )
+add_test( NAME vnl_test_container_interface COMMAND $<TARGET_FILE:vnl_test_all> test_container_interface )
 add_test( NAME vnl_test_matrix_exp COMMAND $<TARGET_FILE:vnl_test_all> test_matrix_exp             )
 add_test( NAME vnl_test_matrix_fixed COMMAND $<TARGET_FILE:vnl_test_all> test_matrix_fixed           )
 add_test( NAME vnl_test_vector_fixed_ref COMMAND $<TARGET_FILE:vnl_test_all> test_vector_fixed_ref       )

--- a/core/vnl/tests/test_container_interface.cxx
+++ b/core/vnl/tests/test_container_interface.cxx
@@ -1,0 +1,195 @@
+// This is core/vnl/tests/test_matrix_interface.cxx
+#include <iostream>
+#include <cmath>
+#include <exception>
+#include <vnl/vnl_matrix.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_vector.h>
+#include <vnl/vnl_copy.h>
+#include <testlib/testlib_test.h>
+#include <vcl_compiler.h>
+
+template< typename TValue >
+TValue square(TValue v)
+{
+  return v * v;
+}
+
+// This function is used in testing later.
+template< typename T >
+T sum_vector(const vnl_vector<T> &v) { return v.sum(); }
+
+template< typename T >
+T sum_vector(const vnl_vector_fixed<T, 2> &v) { return v.sum(); }
+
+template< class TVector >
+typename TVector::element_type sum(TVector v)
+{
+  return v.sum();
+}
+
+template< class TContainer >
+void test_common_interface()
+{
+  {
+  TContainer m;
+  }
+
+  int data[4] = {0, 1, 2, 3};
+
+  TContainer m(2,2);
+  m.size();
+  m.rows();
+  m.cols();
+  m.columns();
+  m.put(0, 0, 0);
+  m.get(0, 0);
+  m[0];
+  m(0,0);
+  m.fill(0);
+  m.fill_diagonal(0);
+  vnl_vector<int> v(2, 1);
+  m.set_diagonal(v);
+  m.copy_in(data);
+  m.set(data);
+  m.copy_out(data);
+  TContainer n(2,2);
+  n.fill(12);
+  m = n;
+  m += 4;
+  m -= 4;
+  m *= 4;
+  m /= 4;
+  m += n;
+  m -= n;
+  m *= n;
+  m.apply(square);
+  m.apply_rowwise( sum_vector );
+  m.apply_columnwise( sum_vector );
+  m.transpose();
+  m.conjugate_transpose();
+  m.update(n);
+  m.update(n,0);
+  m.update(n,0,0);
+  m.set_column(0, data); // OK: data is longer than one column
+  m.set_column(0, 0);
+  m.set_column(0, v);
+  m.set_row(0, data);
+  m.set_row(0, 0);
+  m.set_row(0, v);
+  m.extract(2,2);
+  m.extract(2,2,0);
+  m.extract(2,2,0,0);
+  vnl_matrix<int> e(2,2);
+  m.extract(e);
+  m.get_row(0);
+  m.get_column(0);
+
+    ///////////////////////////////////////////////
+    // Test `get_rows` and `get_columns` Methods //
+    ///////////////////////////////////////////////
+
+    {
+    typename TContainer::element_type data[4] = {1, 2, 3, 4};
+    unsigned int indices[2] = {1, 0};
+    vnl_vector<unsigned int> i(indices, 2);
+    TContainer matrix(2, 2);
+    matrix.copy_in(data);
+    TContainer matrix_lr(matrix);
+    matrix_lr.fliplr();
+    TContainer matrix_ud(matrix);
+    matrix_ud.flipud();
+    TEST("get_rows", matrix_lr.is_equal(matrix.get_columns(i), 10e-6), true);
+    TEST("get_columns", matrix_ud.is_equal(matrix.get_rows(i), 10e-6), true);
+    }
+
+  m.get_n_rows(0,1);
+  m.get_n_columns(0,1);
+  m.get_diagonal();
+  m.flatten_row_major();
+  m.flatten_column_major();
+  m.set_identity();
+  m.inplace_transpose();
+  m.flipud();
+  m.fliplr();
+  m.normalize_rows();
+  m.normalize_columns();
+  m.scale_row(0,10);
+  m.scale_column(0,10);
+
+    ////////////////////////
+    // Test `swap` Method //
+    ////////////////////////
+
+    {
+    typename TContainer::element_type data1[4] = {0, 1, 2, 3};
+    typename TContainer::element_type data2[4] = {4, 5, 6, 7};
+    TContainer l(2, 2);
+    l.copy_in(data1);
+    TContainer r(2, 2);
+    l.copy_in(data2);
+    TContainer l_swap(l);
+    TContainer r_swap(r);
+    l_swap.swap(r_swap);
+    TEST("swap left-right", l.is_equal(r_swap, 10e-6), true);
+    TEST("swap right-left", r.is_equal(l_swap, 10e-6), true);
+    }
+
+  typename TContainer::abs_t a = 25;
+  m.array_one_norm();
+  m.array_two_norm();
+  m.array_inf_norm();
+  m.absolute_value_sum();
+  m.absolute_value_max();
+  m.operator_one_norm();
+  m.operator_inf_norm();
+  m.frobenius_norm();
+  m.fro_norm();
+  m.rms();
+  m.min_value();
+  m.max_value();
+  m.arg_min();
+  m.arg_max();
+  m.mean();
+  m.empty();
+  m.is_identity();
+  m.is_identity(10e-6);
+  m.is_zero();
+  m.is_zero(10e-6);
+
+    ////////////////////////////
+    // Test `is_equal` Method //
+    ////////////////////////////
+
+    {
+    TContainer l(2,2);
+    TContainer r(2,2);
+    l.copy_in(data);
+    r.copy_in(data);
+    TEST("is_equal (true)", l.is_equal(r, 10e-6), true);
+    r.put(0, 0, 25);
+    TEST("is_equal (false)", !l.is_equal(r, 10e-6), true);
+    }
+
+  m.is_finite();
+  m.has_nans();
+  m.assert_size(2,2);
+  m.assert_finite();
+  m.data_block();
+  m.as_ref();
+  typename TContainer::element_type value = 7;
+  typename TContainer::iterator it = m.begin();
+  it = m.end();
+  typename TContainer::const_iterator cit = m.begin();
+  cit = m.end();
+
+}
+
+static
+void test_container_interface()
+{
+  test_common_interface< vnl_matrix<int> >();
+  test_common_interface< vnl_matrix_fixed<int, 2, 2> >();
+}
+
+TESTMAIN(test_container_interface);

--- a/core/vnl/tests/test_container_interface.cxx
+++ b/core/vnl/tests/test_container_interface.cxx
@@ -188,7 +188,10 @@ void test_common_interface()
 static
 void test_container_interface()
 {
+  vcl_cout << "Testing vnl_matrix<int>" << std::endl;
   test_common_interface< vnl_matrix<int> >();
+
+  vcl_cout << "Testing vnl_matrix_fixed<int, 2, 2>" << std::endl;
   test_common_interface< vnl_matrix_fixed<int, 2, 2> >();
 }
 

--- a/core/vnl/tests/test_driver.cxx
+++ b/core/vnl/tests/test_driver.cxx
@@ -12,6 +12,7 @@ DECLARE( test_finite );
 DECLARE( test_math );
 DECLARE( test_na );
 DECLARE( test_matrix );
+DECLARE( test_container_interface );
 DECLARE( test_matrix_exp );
 DECLARE( test_matrix_fixed );
 DECLARE( test_matrix_fixed_ref );
@@ -57,6 +58,7 @@ register_tests()
   REGISTER( test_finite );
   REGISTER( test_math );
   REGISTER( test_matrix );
+  REGISTER( test_container_interface );
   REGISTER( test_matrix_exp );
   REGISTER( test_matrix_fixed );
   REGISTER( test_matrix_fixed_ref );

--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -160,18 +160,30 @@ void test_int()
        (m0.set_diagonal(vnl_vector<int>(2,2,m0values)),
         (m0.get(0,0)==7 && m0.get(1,1)==9 && m0.get(0,1)==2 && m0.get(1,0)==2)), true);
 
-  // Flip the matrix, otherwise it is the same whichever way it is flattened
-  m0.flipud();
-  // | 2 9 |
-  // | 7 2 |
-  vnl_vector<int> flat;
-  TEST("m0.flatten_row_major()",
-       (flat = m0.flatten_row_major(),
-       (flat.get(0)==2 && flat.get(1)==9 && flat.get(2)==7 && flat.get(3)==2)), true);
-  TEST("m0.flatten_column_major()",
-       (flat = m0.flatten_column_major(),
-       (flat.get(0)==2 && flat.get(1)==7 && flat.get(2)==9 && flat.get(3)==2)), true);
-  m0.flipud();
+    /////////////////////////////////////////////////////////////////
+    // Test `flatten_row_major` and `flatten_column_major` Methods //
+    /////////////////////////////////////////////////////////////////
+
+    {
+    int data[16] = { 0,  1,  2,  3,
+                     4,  5,  6,  7,
+                     8,  9, 10, 11,
+                    12, 13, 14, 15};
+
+    vnl_vector<int> flat(data, 16);
+
+    vnl_matrix<int> sq(data, 4, 4);
+    vnl_matrix<int> lg(data, 2, 8);
+    vnl_matrix<int> wd(data, 8, 2);
+
+    TEST("sq.flatten_row_major", flat.is_equal(sq.flatten_row_major(), 10e-6), true);
+    TEST("lg.flatten_row_major", flat.is_equal(lg.flatten_row_major(), 10e-6), true);
+    TEST("wd.flatten_row_major", flat.is_equal(wd.flatten_row_major(), 10e-6), true);
+
+    TEST("sq.flatten_column_major", flat.is_equal(sq.transpose().flatten_column_major(), 10e-6), true);
+    TEST("lg.flatten_column_major", flat.is_equal(lg.transpose().flatten_column_major(), 10e-6), true);
+    TEST("wd.flatten_column_major", flat.is_equal(wd.transpose().flatten_column_major(), 10e-6), true);
+    }
 
   int m3values [] = {1,2,3};
   vnl_matrix<int> m3(1,3,3, m3values);

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -10,7 +10,7 @@
 #endif
 #include <vcl_compiler.h>
 
-#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_matrix_fixed.hxx>
 #include <vnl/vnl_vector_fixed.h>
 #include <vnl/vnl_double_3x3.h>
 #include <vnl/vnl_double_3.h>
@@ -238,15 +238,31 @@ void test_int()
        ((m6*=m7),
         (m6.get(0,0)==19 && m6.get(0,1)==22 && m6.get(1,0)==43 && m6.get(1,1)==50)), true);
 
-  // | 19 22 |
-  // | 43 50 |
-  vnl_vector<int> flat;
-  TEST("m6.flatten_row_major()",
-       (flat = m6.flatten_row_major(),
-       (flat.get(0)==19 && flat.get(1)==22 && flat.get(2)==43 && flat.get(3)==50)), true);
-  TEST("m6.flatten_column_major()",
-       (flat = m6.flatten_column_major(),
-       (flat.get(0)==19 && flat.get(1)==43 && flat.get(2)==22 && flat.get(3)==50)), true);
+    /////////////////////////////////////////////////////////////////
+    // Test `flatten_row_major` and `flatten_column_major` Methods //
+    /////////////////////////////////////////////////////////////////
+
+    {
+    int data[16] = { 0,  1,  2,  3,
+                     4,  5,  6,  7,
+                     8,  9, 10, 11,
+                    12, 13, 14, 15};
+
+    vnl_vector<int> flat(data, 16);
+
+    vnl_matrix_fixed<int, 4, 4> sq(data);
+    vnl_matrix_fixed<int, 2, 8> lg(data);
+    vnl_matrix_fixed<int, 8, 2> wd(data);
+
+    TEST("sq.flatten_row_major", flat.is_equal(sq.flatten_row_major(), 10e-6), true);
+    TEST("lg.flatten_row_major", flat.is_equal(lg.flatten_row_major(), 10e-6), true);
+    TEST("wd.flatten_row_major", flat.is_equal(wd.flatten_row_major(), 10e-6), true);
+
+    TEST("sq.flatten_column_major", flat.is_equal(sq.transpose().flatten_column_major(), 10e-6), true);
+    TEST("lg.flatten_column_major", flat.is_equal(lg.transpose().flatten_column_major(), 10e-6), true);
+    TEST("wd.flatten_column_major", flat.is_equal(wd.transpose().flatten_column_major(), 10e-6), true);
+    }
+
 
   // additional tests
   int mvalues [] = {0,-2,2,0};

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -1028,7 +1028,7 @@ vnl_vector<T> vnl_matrix<T>::flatten_column_major() const
   vnl_vector<T> v(this->num_rows * this->num_cols);
   for (unsigned int c = 0; c < this->num_cols; ++c)
     for (unsigned int r = 0; r < this->num_rows; ++r)
-      v[c*this->num_cols+r] = this->data[r][c];
+      v[c*this->num_rows+r] = this->data[r][c];
   return v;
 }
 

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -468,6 +468,12 @@ class VNL_EXPORT vnl_matrix_fixed
   //: Get a vector equal to the given column
   vnl_vector_fixed<T,num_rows> get_column(unsigned col) const;
 
+  //: Get a matrix composed of rows from the indices specified in the supplied vector.
+  vnl_matrix<T> get_rows(vnl_vector<unsigned int> i) const;
+
+  //: Get a matrix composed of columns from the indices specified in the supplied vector.
+  vnl_matrix<T> get_columns(vnl_vector<unsigned int> i) const;
+
   //: Get n rows beginning at rowstart
   vnl_matrix<T> get_n_rows   (unsigned rowstart, unsigned n) const;
 
@@ -559,6 +565,9 @@ class VNL_EXPORT vnl_matrix_fixed
   //  \endcode
   vnl_matrix_fixed& scale_column(unsigned col, T value);
 
+  //: Swap this matrix with that matrix
+  void swap(vnl_matrix_fixed<T,num_rows,num_cols> & that);
+
   //: Type def for norms.
   typedef typename vnl_c_vector<T>::abs_t abs_t;
 
@@ -623,6 +632,9 @@ class VNL_EXPORT vnl_matrix_fixed
 
   //: Return true if all elements equal to zero, within given tolerance
   bool is_zero(double tol) const;
+
+  //:  Return true if all elements of both matrices are equal, within given tolerance
+  bool is_equal(vnl_matrix_fixed<T,num_rows,num_cols> const& rhs, double tol) const;
 
   //: Return true if finite
   bool is_finite() const;

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -389,6 +389,14 @@ vnl_matrix_fixed<T,nrows,ncols>::scale_column(unsigned column_index, T value)
   return *this;
 }
 
+template <class T, unsigned int nrows, unsigned int ncols>
+void
+vnl_matrix_fixed<T,nrows,ncols>
+::swap(vnl_matrix_fixed<T,nrows,ncols> &that)
+{
+  std::swap(this->data_, that.data_);
+}
+
 //: Returns a copy of n rows, starting from "row"
 template<class T, unsigned nrows, unsigned ncols>
 vnl_matrix<T>
@@ -447,6 +455,30 @@ vnl_vector_fixed<T,nrows> vnl_matrix_fixed<T,nrows,ncols>::get_column(unsigned c
   for (unsigned int j = 0; j < nrows; ++j)
     v[j] = this->data_[j][column_index];
   return v;
+}
+
+//: Create a vector out of row[row_index].
+template <class T, unsigned int nrows, unsigned int ncols>
+vnl_matrix<T>
+vnl_matrix_fixed<T,nrows,ncols>
+::get_rows(vnl_vector<unsigned int> i) const
+{
+  vnl_matrix<T> m(i.size(), this->cols());
+  for (unsigned int j = 0; j < i.size(); ++j)
+    m.set_row(j, this->get_row(i.get(j)));
+  return m;
+}
+
+//: Create a vector out of column[column_index].
+template <class T, unsigned int nrows, unsigned int ncols>
+vnl_matrix<T>
+vnl_matrix_fixed<T,nrows,ncols>
+::get_columns(vnl_vector<unsigned int> i) const
+{
+  vnl_matrix<T> m(this->rows(), i.size());
+  for (unsigned int j = 0; j < i.size(); ++j)
+    m.set_column(j, this->get_column(i.get(j)));
+  return m;
 }
 
 //: Return a vector with the content of the (main) diagonal
@@ -613,6 +645,24 @@ vnl_matrix_fixed<T,nrows,ncols>::is_zero() const
     for (unsigned int j = 0; j < ncols; ++j)
       if ( !( this->data_[i][ j] == zero) )
         return false;
+
+  return true;
+}
+
+template <class T, unsigned nrows, unsigned ncols>
+bool vnl_matrix_fixed<T,nrows,ncols>
+::is_equal(vnl_matrix_fixed<T,nrows,ncols> const& rhs, double tol) const
+{
+  if (this == &rhs)                                      // same object => equal.
+    return true;
+
+  if (this->rows() != rhs.rows() || this->cols() != rhs.cols())
+    return false;                                        // different sizes => not equal.
+
+  for (unsigned int i = 0; i < this->rows(); ++i)
+    for (unsigned int j = 0; j < this->columns(); ++j)
+      if (vnl_math::abs(this->data_[i][j] - rhs.data_[i][j]) > tol)
+        return false;                                    // difference greater than tol
 
   return true;
 }

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -507,7 +507,7 @@ vnl_vector_fixed<T,nrows*ncols> vnl_matrix_fixed<T,nrows,ncols>::flatten_column_
   vnl_vector_fixed<T,nrows*ncols> v;
   for (unsigned int c = 0; c < ncols; ++c)
     for (unsigned int r = 0; r < nrows; ++r)
-      v[c*ncols+r] = this->data_[r][c];
+      v[c*nrows+r] = this->data_[r][c];
   return v;
 }
 


### PR DESCRIPTION
VNL containers are not related by inheritance; as such, maintaining
a common interface (where applicable) is not enforced.  Therefore,
container classes may diverge, causing methods to be absent which
the user would logically expect to have.  This patch is a very early
attempt at uncovering and implementing such missing methods through
test-driven-development.  In particular, the following four methods
have been added to `vnl_matrix_fixed`:

- `swap`
- `is_equal`
- `get_rows`
- `get_columns`

In addition to providing a (more) unified interface, this technique
may reduce the burden in writing unit tests, which currently are
written separately for each container, even when the behavior is
expected to be identical.  The `container_interface` unit test
which is added here provides runtime unit tests only for the
methods which were added (this will hopefully change in the future).