### PR TITLE
COMP: Intel compiler incompatibility

### DIFF
--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -254,13 +254,13 @@ void test_int()
     vnl_matrix_fixed<int, 2, 8> lg(data);
     vnl_matrix_fixed<int, 8, 2> wd(data);
 
-    TEST("sq.flatten_row_major", flat.is_equal(sq.flatten_row_major(), 10e-6), true);
-    TEST("lg.flatten_row_major", flat.is_equal(lg.flatten_row_major(), 10e-6), true);
-    TEST("wd.flatten_row_major", flat.is_equal(wd.flatten_row_major(), 10e-6), true);
+    TEST("sq.flatten_row_major", flat.is_equal(sq.flatten_row_major().as_vector(), 10e-6), true);
+    TEST("lg.flatten_row_major", flat.is_equal(lg.flatten_row_major().as_vector(), 10e-6), true);
+    TEST("wd.flatten_row_major", flat.is_equal(wd.flatten_row_major().as_vector(), 10e-6), true);
 
-    TEST("sq.flatten_column_major", flat.is_equal(sq.transpose().flatten_column_major(), 10e-6), true);
-    TEST("lg.flatten_column_major", flat.is_equal(lg.transpose().flatten_column_major(), 10e-6), true);
-    TEST("wd.flatten_column_major", flat.is_equal(wd.transpose().flatten_column_major(), 10e-6), true);
+    TEST("sq.flatten_column_major", flat.is_equal(sq.transpose().flatten_column_major().as_vector(), 10e-6), true);
+    TEST("lg.flatten_column_major", flat.is_equal(lg.transpose().flatten_column_major().as_vector(), 10e-6), true);
+    TEST("wd.flatten_column_major", flat.is_equal(wd.transpose().flatten_column_major().as_vector(), 10e-6), true);
     }
 
 

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -372,13 +372,17 @@ class VNL_EXPORT vnl_vector_fixed
   }
 
   //: Returns a subvector specified by the start index and length. O(n).
-  vnl_vector<T> extract (unsigned int len, unsigned int start=0) const;
+  vnl_vector<T> extract (unsigned int len, unsigned int start=0) const
+  {
+  assert( start < n && start + len <= n );
+  return vnl_vector<T>( data_ + start, len );
+  }
 
   //: Convert to a vnl_vector.
   vnl_vector<T> as_vector() const { return extract(n); }
 
   //: Replaces elements with index beginning at start, by values of v. O(n).
-  vnl_vector_fixed& update (vnl_vector<T> const&, unsigned int start=0);
+  vnl_vector_fixed& VNL_EXPORT update(vnl_vector<T> const&, unsigned int start=0);
 
   // norms etc
   typedef typename vnl_c_vector<T>::abs_t abs_t;

--- a/core/vnl/vnl_vector_fixed.hxx
+++ b/core/vnl/vnl_vector_fixed.hxx
@@ -33,15 +33,6 @@ vnl_vector_fixed<T,n>::apply( T (*f)(const T&) )
   return ret;
 }
 
-
-template<class T, unsigned int n>
-vnl_vector<T>
-vnl_vector_fixed<T,n>::extract( unsigned int len, unsigned int start ) const
-{
-  assert( start < n && start + len <= n );
-  return vnl_vector<T>( data_ + start, len );
-}
-
 template<class T, unsigned int n>
 vnl_vector_fixed<T,n>&
 vnl_vector_fixed<T,n>::update( const vnl_vector<T>& v, unsigned int start )


### PR DESCRIPTION
The intel compiler identifited that:
error: no suitable user-defined conversion from "vnl_vector_fixed" to "const vnl_vector" exists

Do the conversion explicitly.  This also exercised more code and
required a change to avoid a linking problem with vnl_vector_fixed.