### PR TITLE
COMP: Prefer size_t for memory indicies access

### DIFF
--- a/core/vil/algo/tests/test_algo_find_plateaus.cxx
+++ b/core/vil/algo/tests/test_algo_find_plateaus.cxx
@@ -22,7 +22,7 @@ static void test_find_plateaus_byte()
   std::vector<unsigned> pi, pj;
   vil_find_plateaus_3x3(pi, pj, image0, vxl_byte(10)); // Ignore pixels below 10
 
-  const unsigned nplat = pi.size();
+  const size_t nplat = pi.size();
   TEST("Number of plateaus==4", nplat, 4);
 
   TEST("Plateau at (4,3)", pi[0]==4 && pj[0]==3, true);

--- a/core/vil/algo/vil_quad_distance_function.h
+++ b/core/vil/algo/vil_quad_distance_function.h
@@ -18,7 +18,7 @@ inline void vil_update_parabola_set(std::vector<double>& x,
                                     std::vector<double>& z, double a,
                                     double x0, double y0, double n)
 {
-  unsigned int k=x.size()-1;
+  size_t k=x.size()-1;
   while (true)
   {
     // Compute intercept of parabola centred at x0 with that at v[k]
@@ -55,7 +55,7 @@ inline void vil_update_parabola_set(std::vector<double>& x,
 //  Thus z.size()==x.size()+1
 template<class srcT>
 inline void vil_quad_envelope(const srcT* src,std::ptrdiff_t s_step,
-                              unsigned int n,
+                              size_t n,
                               std::vector<double>& x,
                               std::vector<double>& y,
                               std::vector<double>& z, double a)
@@ -68,7 +68,7 @@ inline void vil_quad_envelope(const srcT* src,std::ptrdiff_t s_step,
   {
     vil_update_parabola_set(x,y,z,a,x0,double(*src),double(n));
   }
-  z.push_back(n);
+  z.push_back(static_cast<double>(n));
 }
 
 //: Sample from lower envelope of a set of parabolas
@@ -80,7 +80,7 @@ inline void vil_sample_quad_envelope(const std::vector<double>& x,
                                      const std::vector<double>& y,
                                      const std::vector<double>& z, double a,
                                      destT* dest, std::ptrdiff_t d_step,
-                                     unsigned int n)
+                                     size_t n)
 {
   unsigned int k=0;
   for (unsigned int i=0;i<n;++i,dest+=d_step)
@@ -104,7 +104,7 @@ inline void vil_sample_quad_envelope_with_pos(const std::vector<double>& x,
                                               const std::vector<double>& z,
                                               double a,
                                               destT* dest, std::ptrdiff_t d_step,
-                                              unsigned int n,
+                                              size_t n,
                                               iT* pos, std::ptrdiff_t p_step)
 {
   unsigned int k=0;
@@ -124,7 +124,7 @@ inline void vil_sample_quad_envelope_with_pos(const std::vector<double>& x,
 //  dest(x) = dest[x*d_step], src(x)=src[x*s_step]
 template<class srcT, class destT>
 inline void vil_quad_distance_function_1D(const srcT* src,std::ptrdiff_t s_step,
-                                          unsigned int n,
+                                          size_t n,
                                           double a,
                                           destT* dest, std::ptrdiff_t d_step)
 {

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -84,18 +84,18 @@ class VNL_EXPORT vnl_vector
   vnl_vector() : num_elmts(0) , data(VXL_NULLPTR) {}
 
   //: Creates a vector containing n uninitialized elements.
-  explicit vnl_vector(unsigned int len);
+  explicit vnl_vector(size_t len);
 
   //: Creates a vector containing n elements, all set to v0.
-  vnl_vector(unsigned int len, T const& v0);
+  vnl_vector(size_t len, T const& v0);
 
   //: Creates a vector containing len elements, with the first n
   // elements taken from the array values[]. O(n).
-  vnl_vector(unsigned int len, int n, T const values[]);
+  vnl_vector(size_t len, size_t n, T const values[]);
 
   //: Creates a vector containing len elements, initialized with values from
   // a data block.
-  vnl_vector(T const* data_block,unsigned int n);
+  vnl_vector(T const* data_block,size_t n);
 
   //: Copy constructor.
   vnl_vector(vnl_vector<T> const&);
@@ -105,19 +105,19 @@ class VNL_EXPORT vnl_vector
   //  Requires that len==2.
   //  Consider using vnl_vector_fixed<T,2> instead!
   // \deprecated
-  vnl_vector(unsigned len, T const& px, T const& py);
+  vnl_vector(size_t len, T const& px, T const& py);
 
   //: Creates a vector of length 3 and initializes with the arguments, px,py,pz.
   //  Requires that len==3.
   //  Consider using vnl_vector_fixed<T,3> instead!
   // \deprecated
-  vnl_vector(unsigned len, T const& px, T const& py, T const& pz);
+  vnl_vector(size_t len, T const& px, T const& py, T const& pz);
 
   //: Creates a vector of length 4 and initializes with the arguments.
   //  Requires that len==4.
   //  Consider using vnl_vector_fixed<T,4> instead!
   // \deprecated
-  vnl_vector(unsigned len, T const& px, T const& py, T const& pz, T const& pw);
+  vnl_vector(size_t len, T const& px, T const& py, T const& pz, T const& pw);
 #endif
 
 #ifndef VXL_DOXYGEN_SHOULD_SKIP_THIS
@@ -147,13 +147,13 @@ class VNL_EXPORT vnl_vector
   ~vnl_vector();
 
   //: Return the length, number of elements, dimension of this vector.
-  unsigned int size() const { return this->num_elmts; }
+  size_t size() const { return this->num_elmts; }
 
   //: Put value at given position in vector.
-  inline void put(unsigned int i, T const& v);
+  inline void put(size_t i, T const& v);
 
   //: Get value at element i
-  inline T get(unsigned int i) const;
+  inline T get(size_t  i) const;
 
   //: Set all values to v
   vnl_vector& fill(T const& v);
@@ -172,7 +172,7 @@ class VNL_EXPORT vnl_vector
 
   //: Return reference to the element at specified index.
   // There are assert style boundary checks - #define NDEBUG to turn them off.
-  T       & operator()(unsigned int i)
+  T       & operator()(size_t i)
   {
 #if VNL_CONFIG_CHECK_BOUNDS
     assert(i<size());   // Check the index is valid.
@@ -181,7 +181,7 @@ class VNL_EXPORT vnl_vector
   }
   //: Return reference to the element at specified index. No range checking.
   // There are assert style boundary checks - #define NDEBUG to turn them off.
-  T const & operator()(unsigned int i) const
+  T const & operator()(size_t i) const
   {
 #if VNL_CONFIG_CHECK_BOUNDS
     assert(i<size());   // Check the index is valid
@@ -190,9 +190,9 @@ class VNL_EXPORT vnl_vector
   }
 
   //: Return reference to the element at specified index. No range checking.
-  T       & operator[](unsigned int i) { return data[i]; }
+  T       & operator[](size_t i) { return data[i]; }
   //: Return reference to the element at specified index. No range checking.
-  T const & operator[](unsigned int i) const { return data[i]; }
+  T const & operator[](size_t i) const { return data[i]; }
 
   //: Set all elements to value v
   vnl_vector<T>& operator=(T const&v) { fill(v); return *this; }
@@ -291,10 +291,10 @@ class VNL_EXPORT vnl_vector
   vnl_vector<T> apply(T (*f)(T const&)) const;
 
   //: Returns a subvector specified by the start index and length. O(n).
-  vnl_vector<T> extract(unsigned int len, unsigned int start=0) const;
+  vnl_vector<T> extract(size_t len, size_t start=0) const;
 
   //: Replaces elements with index beginning at start, by values of v. O(n).
-  vnl_vector<T>& update(vnl_vector<T> const&, unsigned int start=0);
+  vnl_vector<T>& update(vnl_vector<T> const&, size_t start=0);
 
   // norms etc
   typedef typename vnl_c_vector<T>::abs_t abs_t;
@@ -330,10 +330,10 @@ class VNL_EXPORT vnl_vector
   T max_value() const { return vnl_c_vector<T>::max_value(begin(), size()); }
 
   //: Location of smallest value
-  unsigned arg_min() const { return vnl_c_vector<T>::arg_min(begin(), size()); }
+  size_t arg_min() const { return vnl_c_vector<T>::arg_min(begin(), size()); }
 
   //: Location of largest value
-  unsigned arg_max() const { return vnl_c_vector<T>::arg_max(begin(), size()); }
+  size_t arg_max() const { return vnl_c_vector<T>::arg_max(begin(), size()); }
 
   //: Mean of values in vector
   T mean() const { return vnl_c_vector<T>::mean(begin(), size()); }
@@ -347,7 +347,7 @@ class VNL_EXPORT vnl_vector
 
   //: Reverse the order of the elements from index b to 1-e, inclusive.
   //  When b = 0 and e = size(), this is equivalent to flip();
-  vnl_vector<T>& flip(const unsigned int &b, const unsigned int &e);
+  vnl_vector<T>& flip(const size_t &b, const size_t &e);
 
   //: Roll the vector forward by the specified shift.
   //  The shift is cyclical, such that the elements which
@@ -395,7 +395,7 @@ class VNL_EXPORT vnl_vector
 
   //: Check that size()==sz if not, abort();
   // This function does or tests nothing if NDEBUG is defined
-  void assert_size(unsigned VXL_USED_IN_DEBUG(sz) ) const {
+  void assert_size(size_t VXL_USED_IN_DEBUG(sz) ) const {
 #ifndef NDEBUG
     assert_size_internal(sz);
 #endif
@@ -433,7 +433,7 @@ class VNL_EXPORT vnl_vector
   //: Resize to n elements.
   // This is a destructive resize, in that the old data is lost if size() != \a n before the call.
   // If size() is already \a n, this is a null operation.
-  bool set_size(unsigned n);
+  bool set_size(size_t n);
 
   //: Make the vector as if it had been default-constructed.
   void clear();
@@ -445,7 +445,7 @@ class VNL_EXPORT vnl_vector
   static vnl_vector<T> read(std::istream& s);
 
  protected:
-  unsigned num_elmts;           // Number of elements (length)
+  size_t num_elmts;           // Number of elements (length)
   T* data;                      // Pointer to the actual data
 
 #if VCL_HAS_SLICED_DESTRUCTOR_BUG
@@ -454,7 +454,7 @@ class VNL_EXPORT vnl_vector
   char vnl_vector_own_data;
 #endif
 
-  void assert_size_internal(unsigned sz) const;
+  void assert_size_internal(size_t sz) const;
   void assert_finite_internal() const;
 
   void destroy();
@@ -493,7 +493,7 @@ class VNL_EXPORT vnl_vector
 
 template <class T>
 inline T vnl_vector<T>
-::get(unsigned int i) const
+::get(size_t i) const
 {
 #if VNL_CONFIG_CHECK_BOUNDS
   if (i >= this->size())     // If invalid index specified
@@ -507,7 +507,7 @@ inline T vnl_vector<T>
 
 template <class T>
 inline void vnl_vector<T>
-::put(unsigned int i, T const& v)
+::put(size_t i, T const& v)
 {
 #if VNL_CONFIG_CHECK_BOUNDS
   if (i >= this->size())     // If invalid index specified

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -80,7 +80,7 @@ do { \
 // Elements are not initialized.
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len)
+vnl_vector<T>::vnl_vector (size_t len)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(len);
@@ -90,7 +90,7 @@ vnl_vector<T>::vnl_vector (unsigned len)
 //: Creates a vector of specified length, and initialize all elements with value. O(n).
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len, T const& value)
+vnl_vector<T>::vnl_vector (size_t len, T const& value)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(len);
@@ -103,12 +103,12 @@ vnl_vector<T>::vnl_vector (unsigned len, T const& value)
 //: Creates a vector of specified length and initialize first n elements with values. O(n).
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len, int n, T const values[])
+vnl_vector<T>::vnl_vector (size_t len, size_t n, T const values[])
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(len);
   if (n > 0) {                                  // If user specified values
-    for (unsigned i = 0; i < len && n; i++, n--)        // Initialize first n elements
+    for (size_t i = 0; i < len && n; i++, n--)        // Initialize first n elements
       this->data[i] = values[i];                // with values
   }
 }
@@ -116,7 +116,7 @@ vnl_vector<T>::vnl_vector (unsigned len, int n, T const values[])
 #if VNL_CONFIG_LEGACY_METHODS // these constructors are deprecated and should not be used
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len, T const& px, T const& py)
+vnl_vector<T>::vnl_vector (size_t len, T const& px, T const& py)
 {
   VXL_DEPRECATED_MACRO("vnl_vector<T>::vnl_vector(2, T const& px, T const& py)");
   assert(len==2);
@@ -127,7 +127,7 @@ vnl_vector<T>::vnl_vector (unsigned len, T const& px, T const& py)
 }
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len, T const& px, T const& py, T const& pz)
+vnl_vector<T>::vnl_vector (size_t len, T const& px, T const& py, T const& pz)
 {
   VXL_DEPRECATED_MACRO("vnl_vector<T>::vnl_vector(3, T const& px, T const& py, T const& pz)");
   assert(len==3);
@@ -139,7 +139,7 @@ vnl_vector<T>::vnl_vector (unsigned len, T const& px, T const& py, T const& pz)
 }
 
 template<class T>
-vnl_vector<T>::vnl_vector (unsigned len, T const& px, T const& py, T const& pz, T const& pw)
+vnl_vector<T>::vnl_vector (size_t len, T const& px, T const& py, T const& pz, T const& pw)
 {
   VXL_DEPRECATED_MACRO("vnl_vector<T>::vnl_vector(4, T const& px, T const& py, T const& pz, T const& pt)");
   assert(len==4);
@@ -168,7 +168,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const& v)
 // Values in datablck are copied. O(n).
 
 template<class T>
-vnl_vector<T>::vnl_vector (T const* datablck, unsigned len)
+vnl_vector<T>::vnl_vector (T const* datablck, size_t len)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(len);
@@ -186,7 +186,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, vnl_vector<T> const &v, vnl_t
   if (u.size() != v.size())
     vnl_error_vector_dimension ("vnl_vector<>::vnl_vector(v, v, vnl_vector_add_tag)", u.size(), v.size());
 #endif
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] + v[i];
 }
 
@@ -199,7 +199,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, vnl_vector<T> const &v, vnl_t
   if (u.size() != v.size())
     vnl_error_vector_dimension ("vnl_vector<>::vnl_vector(v, v, vnl_vector_sub_tag)", u.size(), v.size());
 #endif
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] - v[i];
 }
 
@@ -208,7 +208,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, T s, vnl_tag_mul)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(u.num_elmts);
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] * s;
 }
 
@@ -217,7 +217,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, T s, vnl_tag_div)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(u.num_elmts);
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] / s;
 }
 
@@ -226,7 +226,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, T s, vnl_tag_add)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(u.num_elmts);
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] + s;
 }
 
@@ -235,7 +235,7 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const &u, T s, vnl_tag_sub)
 {
   vnl_vector_construct_hack();
   vnl_vector_alloc_blah(u.num_elmts);
-  for (unsigned int i=0; i<num_elmts; ++i)
+  for (size_t i=0; i<num_elmts; ++i)
     data[i] = u[i] - s;
 }
 
@@ -293,7 +293,7 @@ void vnl_vector<T>::clear()
 }
 
 template<class T>
-bool vnl_vector<T>::set_size(unsigned n)
+bool vnl_vector<T>::set_size(size_t n)
 {
   if (this->data) {
     // if no change in size, do not reallocate.
@@ -323,7 +323,7 @@ bool vnl_vector<T>::read_ascii(std::istream& s)
 {
   bool size_known = (this->size() != 0);
   if (size_known) {
-    for (unsigned i = 0; i < this->size(); ++i) {
+    for (size_t i = 0; i < this->size(); ++i) {
       if ( ! (s >> (*this)(i)) ) {
         return false;
       }
@@ -333,14 +333,14 @@ bool vnl_vector<T>::read_ascii(std::istream& s)
 
   // Just read until EOF
   std::vector<T> allvals;
-  unsigned n = 0;
+  size_t n = 0;
   T value;
   while ( s >> value ) {
     allvals.push_back(value);
     ++n;
   }
   this->set_size(n); //*this = vnl_vector<T>(n);
-  for (unsigned i = 0; i < n; ++i)
+  for (size_t i = 0; i < n; ++i)
     (*this)[i] = allvals[i];
   return true;
 }
@@ -409,7 +409,7 @@ vnl_vector<T>& vnl_vector<T>::operator= (vnl_vector<T> const& rhs)
 template<class T>
 vnl_vector<T>& vnl_vector<T>::operator+= (T value)
 {
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     this->data[i] += value;
   return *this;
 }
@@ -419,7 +419,7 @@ vnl_vector<T>& vnl_vector<T>::operator+= (T value)
 template<class T>
 vnl_vector<T>& vnl_vector<T>::operator*= (T value)
 {
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     this->data[i] *= value;
   return *this;
 }
@@ -429,7 +429,7 @@ vnl_vector<T>& vnl_vector<T>::operator*= (T value)
 template<class T>
 vnl_vector<T>& vnl_vector<T>::operator/= (T value)
 {
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     this->data[i] /= value;
   return *this;
 }
@@ -444,7 +444,7 @@ vnl_vector<T>& vnl_vector<T>::operator+= (vnl_vector<T> const& rhs)
   if (this->num_elmts != rhs.num_elmts)
     vnl_error_vector_dimension ("operator+=", this->num_elmts, rhs.num_elmts);
 #endif
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     this->data[i] += rhs.data[i];
   return *this;
 }
@@ -459,7 +459,7 @@ vnl_vector<T>& vnl_vector<T>::operator-= (vnl_vector<T> const& rhs)
   if (this->num_elmts != rhs.num_elmts)
     vnl_error_vector_dimension ("operator-=", this->num_elmts, rhs.num_elmts);
 #endif
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     this->data[i] -= rhs.data[i];
   return *this;
 }
@@ -475,9 +475,9 @@ vnl_vector<T>& vnl_vector<T>::pre_multiply (vnl_matrix<T> const& m)
     vnl_error_vector_dimension ("operator*=", this->num_elmts, m.columns());
 #endif
   T* temp= vnl_c_vector<T>::allocate_T(m.rows()); // Temporary
-  for (unsigned i = 0; i < m.rows(); i++) {     // For each index
+  for (size_t i = 0; i < m.rows(); i++) {     // For each index
     temp[i] = (T)0;                             // Initialize element value
-    for (unsigned k = 0; k < this->num_elmts; k++)      // Loop over column values
+    for (size_t k = 0; k < this->num_elmts; k++)      // Loop over column values
       temp[i] += (m.get(i,k) * this->data[k]);  // Multiply
   }
   vnl_c_vector<T>::deallocate(this->data, this->num_elmts); // Free up the data space
@@ -497,9 +497,9 @@ vnl_vector<T>& vnl_vector<T>::post_multiply (vnl_matrix<T> const& m)
     vnl_error_vector_dimension ("operator*=", this->num_elmts, m.rows());
 #endif
   T* temp= vnl_c_vector<T>::allocate_T(m.columns()); // Temporary
-  for (unsigned i = 0; i < m.columns(); i++) {  // For each index
+  for (size_t i = 0; i < m.columns(); i++) {  // For each index
     temp[i] = (T)0;                             // Initialize element value
-    for (unsigned k = 0; k < this->num_elmts; k++) // Loop over column values
+    for (size_t k = 0; k < this->num_elmts; k++) // Loop over column values
       temp[i] += (this->data[k] * m.get(k,i));  // Multiply
   }
   vnl_c_vector<T>::deallocate(this->data, num_elmts); // Free up the data space
@@ -515,7 +515,7 @@ template<class T>
 vnl_vector<T> vnl_vector<T>::operator- () const
 {
   vnl_vector<T> result(this->num_elmts);
-  for (unsigned i = 0; i < this->num_elmts; i++)
+  for (size_t i = 0; i < this->num_elmts; i++)
     result.data[i] = - this->data[i];           // negate element
   return result;
 }
@@ -523,15 +523,15 @@ vnl_vector<T> vnl_vector<T>::operator- () const
 //: Replaces elements with index beginning at start, by values of v. O(n).
 
 template<class T>
-vnl_vector<T>& vnl_vector<T>::update (vnl_vector<T> const& v, unsigned start)
+vnl_vector<T>& vnl_vector<T>::update (vnl_vector<T> const& v, size_t start)
 {
-  unsigned stop = start + v.size();
+  size_t stop = start + v.size();
 #ifndef NDEBUG
   if ( stop > this->num_elmts)
     vnl_error_vector_dimension ("update", stop-start, v.size());
 #endif
   //std::copy_n( v.data, stop - start, this->data + start );
-  for (unsigned i = start; i < stop; i++)
+  for (size_t i = start; i < stop; i++)
     this->data[i] = v.data[i-start];
   return *this;
 }
@@ -540,16 +540,16 @@ vnl_vector<T>& vnl_vector<T>::update (vnl_vector<T> const& v, unsigned start)
 //: Returns a subvector specified by the start index and length. O(n).
 
 template<class T>
-vnl_vector<T> vnl_vector<T>::extract (unsigned len, unsigned start) const
+vnl_vector<T> vnl_vector<T>::extract (size_t len, size_t start) const
 {
 #ifndef NDEBUG
-  unsigned stop = start + len;
+  size_t stop = start + len;
   if (this->num_elmts < stop)
     vnl_error_vector_dimension ("extract", stop-start, len);
 #endif
   vnl_vector<T> result(len);
   //std::copy_n( this->data + start, len, result.data );
-  for (unsigned i = 0; i < len; i++)
+  for (size_t i = 0; i < len; i++)
     result.data[i] = data[start+i];
   return result;
 }
@@ -581,7 +581,7 @@ vnl_vector<T> element_quotient (vnl_vector<T> const& v1, vnl_vector<T> const& v2
     vnl_error_vector_dimension ("element_quotient", v1.size(), v2.size());
 #endif
   vnl_vector<T> result(v1.size());
-  for (unsigned i = 0; i < v1.size(); i++)
+  for (size_t i = 0; i < v1.size(); i++)
     result[i] = v1[i] / v2[i];
   return result;
 }
@@ -644,8 +644,8 @@ T bracket(vnl_vector<T> const &u, vnl_matrix<T> const &A, vnl_vector<T> const &v
     vnl_error_vector_dimension("bracket",A.columns(),v.size());
 #endif
   T brak(0);
-  for (unsigned i=0; i<u.size(); ++i)
-    for (unsigned j=0; j<v.size(); ++j)
+  for (size_t i=0; i<u.size(); ++i)
+    for (size_t j=0; j<v.size(); ++j)
       brak += u[i]*A(i,j)*v[j];
   return brak;
 }
@@ -656,8 +656,8 @@ template<class T>
 vnl_matrix<T> outer_product (vnl_vector<T> const& v1,
                              vnl_vector<T> const& v2) {
   vnl_matrix<T> out(v1.size(), v2.size());
-  for (unsigned i = 0; i < out.rows(); i++)             // v1.column() * v2.row()
-    for (unsigned j = 0; j < out.columns(); j++)
+  for (size_t i = 0; i < out.rows(); i++)             // v1.column() * v2.row()
+    for (size_t j = 0; j < out.columns(); j++)
       out[i][j] = v1[i] * v2[j];
   return out;
 }
@@ -669,7 +669,7 @@ template <class T>
 vnl_vector<T>&
 vnl_vector<T>::flip()
 {
-  for (unsigned i=0;i<num_elmts/2;++i) {
+  for (size_t i=0;i<num_elmts/2;++i) {
     T tmp=data[i];
     data[i]=data[num_elmts-1-i];
     data[num_elmts-1-i]=tmp;
@@ -679,16 +679,16 @@ vnl_vector<T>::flip()
 
 template <class T>
 vnl_vector<T>&
-vnl_vector<T>::flip(const unsigned int &b, const unsigned int &e)
+vnl_vector<T>::flip(const size_t &b, const size_t &e)
 {
 
 #if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
   assert (!(b > this->num_elmts || e > this->num_elmts || b > e));
 #endif
 
-  for (unsigned i=b;i<(e-b)/2+b;++i) {
+  for (size_t i=b;i<(e-b)/2+b;++i) {
     T tmp=data[i];
-    const unsigned int endIndex = e - 1 - (i-b);
+    const size_t endIndex = e - 1 - (i-b);
     data[i]=data[endIndex];
     data[endIndex]=tmp;
   }
@@ -701,10 +701,10 @@ vnl_vector<T>
 vnl_vector<T>::roll(const int &shift) const
 {
   vnl_vector<T> v(this->num_elmts);
-  const unsigned int wrapped_shift = shift % this->num_elmts;
+  const size_t wrapped_shift = shift % this->num_elmts;
   if (0 == wrapped_shift)
     return v.copy_in(this->data_block());
-  for (unsigned int i = 0; i < this->num_elmts; ++i)
+  for (size_t i = 0; i < this->num_elmts; ++i)
     {
     v[(i + wrapped_shift)%this->num_elmts] = this->data_block()[i];
     }
@@ -715,7 +715,7 @@ template <class T>
 vnl_vector<T>&
 vnl_vector<T>::roll_inplace(const int &shift)
 {
-  const unsigned int wrapped_shift = shift % this->num_elmts;
+  const size_t wrapped_shift = shift % this->num_elmts;
   if (0 == wrapped_shift)
     return *this;
   return this->flip().flip(0,wrapped_shift).flip(wrapped_shift,this->num_elmts);
@@ -773,7 +773,7 @@ double angle (vnl_vector<T> const& a, vnl_vector<T> const& b)
 template <class T>
 bool vnl_vector<T>::is_finite() const
 {
-  for (unsigned i = 0; i < this->size();++i)
+  for (size_t i = 0; i < this->size();++i)
     if (!vnl_math::isfinite( (*this)[i] ))
       return false;
 
@@ -784,7 +784,7 @@ template <class T>
 bool vnl_vector<T>::is_zero() const
 {
   T const zero(0);
-  for (unsigned i = 0; i < this->size();++i)
+  for (size_t i = 0; i < this->size();++i)
     if ( !( (*this)[i] == zero) )
       return false;
 
@@ -802,7 +802,7 @@ void vnl_vector<T>::assert_finite_internal() const
 }
 
 template <class T>
-void vnl_vector<T>::assert_size_internal(unsigned sz) const
+void vnl_vector<T>::assert_size_internal(size_t sz) const
 {
   if (this->size() != sz) {
     std::cerr << __FILE__ ": Size is " << this->size() << ". Should be " << sz << '\n';
@@ -818,7 +818,7 @@ bool vnl_vector<T>::is_equal(vnl_vector<T> const& rhs, double tol) const
 
   if (this->size() != rhs.size())                           //Size different ?
     return false;
-  for (unsigned i = 0; i < size(); i++)
+  for (size_t i = 0; i < size(); i++)
     if (vnl_math::abs(this->data[i] - rhs.data[i]) > tol)    //Element different ?
       return false;
 
@@ -833,7 +833,7 @@ bool vnl_vector<T>::operator_eq (vnl_vector<T> const& rhs) const
 
   if (this->size() != rhs.size())                 // Size different ?
     return false;                                 // Then not equal.
-  for (unsigned i = 0; i < size(); i++)           // For each index
+  for (size_t i = 0; i < size(); i++)           // For each index
     if (!(this->data[i] == rhs.data[i]))          // Element different ?
       return false;                               // Then not equal.
 
@@ -847,7 +847,7 @@ bool vnl_vector<T>::operator_eq (vnl_vector<T> const& rhs) const
 template<class T>
 std::ostream& operator<< (std::ostream& s, vnl_vector<T> const& v)
 {
-  for (unsigned i = 0; i+1 < v.size(); ++i)   // For each index in vector
+  for (size_t i = 0; i+1 < v.size(); ++i)   // For each index in vector
     s << v[i] << ' ';                              // Output data element
   if (v.size() > 0)  s << v[v.size()-1];
   return s;

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -260,10 +260,10 @@ class VNL_EXPORT vnl_vector_fixed
   }
 
   //: Return the i-th element
-  T& operator[] ( unsigned int i ) { return data_[i]; }
+  T& operator[] ( const size_t i ) { return data_[i]; }
 
   //: Return the i-th element
-  const T& operator[] ( unsigned int i ) const { return data_[i]; }
+  const T& operator[] ( const size_t i ) const { return data_[i]; }
 
   //: Access the contiguous block storing the elements in the vector.
   //  O(1).

--- a/core/vnl/vnl_vector_fixed.hxx
+++ b/core/vnl/vnl_vector_fixed.hxx
@@ -82,7 +82,7 @@ template <class T, unsigned int n>
 bool
 vnl_vector_fixed<T,n>::read_ascii(std::istream& s)
 {
-  for (unsigned i = 0; i < this->size(); ++i)
+  for (size_type i = 0; i < this->size(); ++i)
     s >> (*this)(i);
 
   return s.good() || s.eof();

--- a/core/vpgl/algo/examples/vpgl_synth_bundle_adjust.cxx
+++ b/core/vpgl/algo/examples/vpgl_synth_bundle_adjust.cxx
@@ -79,15 +79,15 @@ int main(int argc, char** argv)
   // make the mask (using all the points)
   std::vector<std::vector<bool> > mask(cameras.size(), std::vector<bool>(world.size(),true) );
 
-  unsigned int num_missing = (unsigned int)std::floor(a_frac_miss()*cameras.size()*world.size());
+  size_t num_missing = (unsigned int)std::floor(a_frac_miss()*cameras.size()*world.size());
   if (a_frac_miss() >= 1.0 )
     num_missing = cameras.size()*world.size();
 
   std::cout << "removing "<<num_missing<<" random correspondences"<<std::endl;
   for (unsigned int i=0; i<num_missing; /* */)
   {
-    int c = rnd.lrand32(cameras.size()-1);
-    int w = rnd.lrand32(world.size()-1);
+    const size_t c = rnd.lrand32(static_cast<int>(cameras.size()-1));
+    const size_t w = rnd.lrand32(static_cast<int>(world.size()-1));
     if (mask[c][w]) {
       mask[c][w] = false;
       ++i;

--- a/core/vpgl/algo/vpgl_em_compute_5_point.hxx
+++ b/core/vpgl/algo/vpgl_em_compute_5_point.hxx
@@ -466,7 +466,7 @@ bool vpgl_em_compute_5_point_ransac<T>::compute(
     }
 
     // ----- Good input! Do the ransac
-    const unsigned num_points = right_points.size();
+    const size_t num_points = right_points.size();
 
     unsigned best_inlier_count = 0u;
 

--- a/core/vpgl/tests/test_poly_radial_distortion.cxx
+++ b/core/vpgl/tests/test_poly_radial_distortion.cxx
@@ -17,6 +17,7 @@ static void test_poly_radial_distortion_constructors()
     }
     catch( std::exception& exception )
     {
+                std::cout << exception.what() << std::endl;
     }
     TEST( "Centre & Coefficients Constructor with NULL pointer", did_construct, true );
 

--- a/core/vsl/vsl_basic_xml_element.h
+++ b/core/vsl/vsl_basic_xml_element.h
@@ -44,7 +44,7 @@ class vsl_basic_xml_element
   void add_attribute(std::string attr_name, float value) { add_attribute(attr_name, (double)value); }
   void add_attribute(std::string attr_name, long value);
   void add_attribute(std::string attr_name, int value) { add_attribute(attr_name, (long)value); }
-  void add_attribute(std::string attr_name, unsigned long value) { add_attribute(attr_name, (long)value); }
+  void add_attribute(std::string attr_name, size_t value) { add_attribute(attr_name, (long)value); }
   void add_attribute(std::string attr_name, unsigned int value) { add_attribute(attr_name, (long)value); }
 
   void add_attribute_list(std::vector<std::pair<std::string, std::string> > attrs);


### PR DESCRIPTION
Variables that identify memory locations (either size, or access)
should use size_t.

http://stackoverflow.com/questions/1951519/when-should-i-use-stdsize-t

A good rule of thumb is for anything that you need to compare in the loop condition against something that is naturally a std::size_t itself.

std::size_t is the type of any sizeof expression and as is guaranteed to be able to express the maximum size of any object (including any array) in C++. By extension it is also guaranteed to be big enough for any array index so it is a natural type for a loop by index over an array.

If you are just counting up to a number then it may be more natural to use either the type of the variable that holds that number or an int or unsigned int (if large enough) as these should be a natural size for the machine.