### PR TITLE
BUG: There was a logical error in the test

### DIFF
--- a/core/vnl/tests/test_container_interface.cxx
+++ b/core/vnl/tests/test_container_interface.cxx
@@ -122,14 +122,16 @@ void test_common_interface()
     ////////////////////////
 
     {
-    typename TContainer::element_type data1[4] = {0, 1, 2, 3};
-    typename TContainer::element_type data2[4] = {4, 5, 6, 7};
+    const typename TContainer::element_type data1[4] = {0, 1, 2, 3};
     TContainer l(2, 2);
     l.copy_in(data1);
-    TContainer r(2, 2);
-    l.copy_in(data2);
     TContainer l_swap(l);
+
+    const typename TContainer::element_type data2[4] = {4, 5, 6, 7};
+    TContainer r(2, 2);
+    r.copy_in(data2);
     TContainer r_swap(r);
+
     l_swap.swap(r_swap);
     TEST("swap left-right", l.is_equal(r_swap, 10e-6), true);
     TEST("swap right-left", r.is_equal(l_swap, 10e-6), true);


### PR DESCRIPTION
The "r" variable was not being initialized due
to a copy-n-paste bug.

This was identified by valgrind as an uninitialized
memory read error.