### PR TITLE
COMP: Provide backwards compatible implementation

### DIFF
--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -390,7 +390,13 @@ void
 vnl_matrix_fixed<T,nrows,ncols>
 ::swap(vnl_matrix_fixed<T,nrows,ncols> &that)
 {
-  std::swap(this->data_, that.data_);
+  for (unsigned int r = 0; r < nrows; ++r)
+  {
+    for (unsigned int c = 0; c < ncols; ++c)
+    {
+    std::swap(this->data_[r][c], that.data_[r][c]);
+    }
+  }
 }
 
 //: Returns a copy of n rows, starting from "row"


### PR DESCRIPTION
Moderately old versions of compilers struggled with this
new swap of multi-dimensional array.  Provide a more robust
solution.

Standard Error
/opt/gcc-4.3/lib/gcc/x86_64-unknown-linux-gnu/4.3.5/../../../../include/c++/4.3.5/bits/stl_move.h: In function 'void std::swap(_Tp&, _Tp&) [with _Tp = double [1][6]]':
/scratch/dashboards/Linux-x86_64-gcc4.3/ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matrix_fixed.hxx:393:   instantiated from 'void vnl_matrix_fixed<T, num_rows, num_cols>::swap(vnl_matrix_fixed<T, num_rows, num_cols>&) [with T = double, unsigned int num_rows = 1u, unsigned int num_cols = 6u]'
/scratch/dashboards/Linux-x86_64-gcc4.3/ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl/Templates/vnl_matrix_fixed+double.1.6-.cxx:2:   instantiated from here
/opt/gcc-4.3/lib/gcc/x86_64-unknown-linux-gnu/4.3.5/../../../../include/c++/4.3.5/bits/stl_move.h:85: error: array must be initialized with a brace-enclosed initializer
/opt/gcc-4.3/lib/gcc/x86_64-unknown-linux-gnu/4.3.5/../../../../include/c++/4.3.5/bits/stl_move.h:86: error: invalid array assignment
/opt/gcc-4.3/lib/gcc/x86_64-unknown-linux-gnu/4.3.5/../../../../include/c++/4.3.5/bits/stl_move.h:87: error: invalid array assignment