### PR TITLE
COMP: Enable hidden visibility property with vxl static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 if( POLICY CMP0063 )
   cmake_policy(SET CMP0063 NEW)
 endif()
+# Honor visibility properties for static libraries
+if( POLICY CMP0063 )
+  cmake_policy(SET CMP0063 NEW)
+endif()
 
 project(vxl)
 


### PR DESCRIPTION
Set CMP0063 to NEW to enable the CMake visibility properties to be
honored when building static libraries.