### PR TITLE
BUG: Maintain header installation locations compatible with ITK

### DIFF
--- a/core/vnl/CMakeLists.txt
+++ b/core/vnl/CMakeLists.txt
@@ -74,9 +74,15 @@ else()
   set(VNL_CONFIG_ENABLE_SSE2_ROUNDING 0)
 endif()
 
+# If VXL_INSTALL_INCLUDE_DIR is the default value
+if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
+  set(_config_install_dir ${VXL_INSTALL_INCLUDE_DIR}/core/vnl)
+else()
+  set(_config_install_dir ${VXL_INSTALL_INCLUDE_DIR}/vnl)
+endif()
 vxl_configure_file(${CMAKE_CURRENT_LIST_DIR}/vnl_config.h.in
                    ${PROJECT_BINARY_DIR}/vnl_config.h
-                   ${VXL_INSTALL_INCLUDE_DIR}/core/vnl)
+                   ${_config_install_dir})
 
 set( vnl_sources
   dll.h

--- a/core/vnl/algo/CMakeLists.txt
+++ b/core/vnl/algo/CMakeLists.txt
@@ -102,6 +102,12 @@ if(NETLIB_FOUND)
 
   aux_source_directory(Templates vnl_algo_sources)
 
+  # If VXL_INSTALL_INCLUDE_DIR is the default value
+  if("$VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
+    set(_algo_install_dir ${VXL_INSTALL_INCLUDE_DIR}/core/vnl/algo)
+  else()
+    set(_algo_install_dir ${VXL_INSTALL_INCLUDE_DIR}/vnl/algo)
+  endif()
   vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vnl_algo
     LIBRARY_SOURCES ${vnl_algo_sources}
     HEADER_INSTALL_DIR vnl/algo)
@@ -111,7 +117,7 @@ if(NETLIB_FOUND)
      TARGET_NAME ${VXL_LIB_PREFIX}${CURR_LIB_NAME}
      BASE_NAME ${CURR_LIB_NAME}
      EXPORT_HEADER_FILE ${VXLCORE_BINARY_INCLUDE_DIR}/vnl/algo/${CURR_LIB_NAME}_export.h
-     INSTALL_DIR   ${VXL_INSTALL_INCLUDE_DIR}/core/vnl/algo
+     INSTALL_DIR   ${_algo_install_dir}
      #USE_HIDDEN_VISIBILITY
   )
 


### PR DESCRIPTION
This is a follow-up to bf529035221b7 and 5840b695d958379c. ITK uses modified
VXL header locations, and these locations should be retained for backwards
compatibility. This helps ITK and VXL remain in sync.