### PR TITLE
Fix ffmpeg stubs

### DIFF
--- a/core/vidl/vidl_ffmpeg_istream_stub.hxx
+++ b/core/vidl/vidl_ffmpeg_istream_stub.hxx
@@ -3,6 +3,7 @@
 #define vidl_ffmpeg_istream_stub_hxx_
 #include <string>
 #include "vidl_ffmpeg_istream.h"
+#include <stdexcept>>
 //:
 // \file
 // \brief A null implementation for the ffmpeg video reader
@@ -20,11 +21,13 @@ struct vidl_ffmpeg_istream::pimpl
 vidl_ffmpeg_istream
 ::vidl_ffmpeg_istream()
 {
+  std::cerr << "vidl_ffmpeg_istream: warning: ffmpeg support is not compiled in\n";
 }
 
 vidl_ffmpeg_istream
 ::vidl_ffmpeg_istream(const std::string& /*filename*/)
 {
+  std::cerr << "vidl_ffmpeg_istream: warning: ffmpeg support is not compiled in\n";
 }
 
 
@@ -37,7 +40,7 @@ bool
 vidl_ffmpeg_istream
 ::open(const std::string& /*filename*/)
 {
-  return false;
+  throw std::runtime_error( "vidl_ffmpeg_istream: ffmpeg support is not compiled in";
 }
 
 

--- a/core/vidl/vidl_ffmpeg_ostream_stub.hxx
+++ b/core/vidl/vidl_ffmpeg_ostream_stub.hxx
@@ -3,6 +3,7 @@
 #define vidl_ffmpeg_ostream_stub_hxx_
 #include <iostream>
 #include "vidl_ffmpeg_ostream.h"
+#include <stdexcept>>
 //:
 // \file
 // \brief A stub implementation when ffmpeg is not available.
@@ -21,6 +22,7 @@ vidl_ffmpeg_ostream
 ::vidl_ffmpeg_ostream()
   : os_( 0 )
 {
+  std::cerr << "vidl_ffmpeg_ostream: warning: ffmpeg support is not compiled in\n";
 }
 
 vidl_ffmpeg_ostream
@@ -42,8 +44,7 @@ bool
 vidl_ffmpeg_ostream
 ::open()
 {
-  std::cerr << "vidl_ffmpeg_ostream: warning: ffmpeg support is not compiled in\n";
-  return false;
+  throw std::runtime_error( "vidl_ffmpeg_ostream: ffmpeg support is not compiled in";
 }
 
 

--- a/core/vidl/vidl_ffmpeg_pixel_format.cxx
+++ b/core/vidl/vidl_ffmpeg_pixel_format.cxx
@@ -62,6 +62,8 @@ extern "C" {
 #define AV_PIX_FMT_RGB8          PIX_FMT_RGB8
 #define AV_PIX_FMT_RGB4          PIX_FMT_RGB4
 #define AV_PIX_FMT_RGB4_BYTE     PIX_FMT_RGB4_BYTE
+#define AV_PIX_FMT_RGB565        PIX_FMT_RGB565
+#define AV_PIX_FMT_RGB555        PIX_FMT_RGB555
 #define AV_PIX_FMT_NV12          PIX_FMT_NV12
 #define AV_PIX_FMT_NV21          PIX_FMT_NV21
 


### PR DESCRIPTION
The ffmpeg_xstream_stub-s did not make it apparent that the reason they were failing is that there was no ffmpeg configured. This patch makes bot stubs behave the same and adds an exception if the application tries to open a stream.

Also added two symbols that were missing when an older ffmpeg was used.