### PR TITLE
BUG: Convert define 0/1 paradigm to ifdef

### DIFF
--- a/core/vil/vil_config.h.in
+++ b/core/vil/vil_config.h.in
@@ -32,6 +32,6 @@
 
 //: Set to 0 if you don't want to use SSE2 instructions to implement rounding, floor, and ceil functions.
 #define VIL_CONFIG_ENABLE_SSE2_ROUNDING @VIL_CONFIG_ENABLE_SSE2_ROUNDING@
-#define VXL_HAS_SSE2_HARDWARE_SUPPORT @VXL_HAS_SSE2_HARDWARE_SUPPORT@
+#cmakedefine VXL_HAS_SSE2_HARDWARE_SUPPORT
 
 #endif // vil_config_h_in_


### PR DESCRIPTION
The vil_config.h file was configured with a define for VXL_HAS_SSE2_HARDWARE_SUPPORT
that was either 0 or 1. All uses of this symbol were of the #ifdef style.
The result is that the symbol is always defined. This change uses the
#cmakedefine feature which will define the symbol if it has a TRUE
value in cmake. Otherwise it will not be defined. This approach matches
the usage in the code.