### PR TITLE
Expose VXL's include_directories as SYSTEM. Its intent is API.

### DIFF
--- a/config/cmake/Modules/UseVXL.cmake
+++ b/config/cmake/Modules/UseVXL.cmake
@@ -74,7 +74,7 @@ if(VXL_CONFIG_CMAKE)
   endif()
 
   # Use the standard VXL include directories.
-  include_directories(${VXL_VCL_INCLUDE_DIRS} ${VXL_CORE_INCLUDE_DIRS})
+  include_directories(SYSTEM ${VXL_VCL_INCLUDE_DIRS} ${VXL_CORE_INCLUDE_DIRS})
 
   # Add link directories needed to use VXL.
   link_directories(${VXL_LIBRARY_DIR})


### PR DESCRIPTION
One of the benefits is consumers may not get the VXL warnings during their compiles.`