### PR TITLE
Fix linking issues with shared builds on VS 2015

### DIFF
--- a/core/vnl/io/vnl_io_matrix.hxx
+++ b/core/vnl/io/vnl_io_matrix.hxx
@@ -92,8 +92,8 @@ void vsl_print_summary(std::ostream & os,const vnl_matrix<T> & p)
 
 
 #define VNL_IO_MATRIX_INSTANTIATE(T) \
-template VNL_EXPORT void vsl_print_summary(std::ostream &, const vnl_matrix<T > &); \
-template VNL_EXPORT void vsl_b_read(vsl_b_istream &, vnl_matrix<T > &); \
-template VNL_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_matrix<T > &)
+template VNL_TEMPLATE_EXPORT void vsl_print_summary(std::ostream &, const vnl_matrix<T > &); \
+template VNL_TEMPLATE_EXPORT void vsl_b_read(vsl_b_istream &, vnl_matrix<T > &); \
+template VNL_TEMPLATE_EXPORT void vsl_b_write(vsl_b_ostream &, const vnl_matrix<T > &)
 
 #endif // vnl_io_matrix_hxx_

--- a/core/vnl/vnl_identity_3x3.h
+++ b/core/vnl/vnl_identity_3x3.h
@@ -19,7 +19,7 @@
 #include <vnl/vnl_double_3x3.h>
 #include "vnl/vnl_export.h"
 
-struct VNL_EXPORT vnl_identity_3x3 : public vnl_double_3x3
+struct VNL_TEMPLATE_EXPORT vnl_identity_3x3 : public vnl_double_3x3
 {
   vnl_identity_3x3() { set_identity(); }
 };

--- a/core/vnl/vnl_transpose.h
+++ b/core/vnl/vnl_transpose.h
@@ -36,7 +36,7 @@
 //
 //  NOTE: This only works for arguments of type vnl_matrix<double>
 
-class VNL_EXPORT vnl_transpose
+class VNL_TEMPLATE_EXPORT vnl_transpose
 {
   const vnl_matrix<double>& M_;
  public:


### PR DESCRIPTION
This solves some undefined symbols errors seen when linking shared on VS 2015.