### PR TITLE
Make pixel formats conditional.

### DIFF
--- a/core/vidl/vidl_ffmpeg_pixel_format.cxx
+++ b/core/vidl/vidl_ffmpeg_pixel_format.cxx
@@ -62,8 +62,15 @@ extern "C" {
 #define AV_PIX_FMT_RGB8          PIX_FMT_RGB8
 #define AV_PIX_FMT_RGB4          PIX_FMT_RGB4
 #define AV_PIX_FMT_RGB4_BYTE     PIX_FMT_RGB4_BYTE
+
+#if !defined AV_PIX_FMT_RGB565
 #define AV_PIX_FMT_RGB565        PIX_FMT_RGB565
+#endif
+
+#if !defined AV_PIX_FMT_RGB555
 #define AV_PIX_FMT_RGB555        PIX_FMT_RGB555
+#endif
+
 #define AV_PIX_FMT_NV12          PIX_FMT_NV12
 #define AV_PIX_FMT_NV21          PIX_FMT_NV21
 


### PR DESCRIPTION
Some systems define them, some do not. VXL always requires them.
libavutil does not define these symbols in Ubuntu 12.04 does not have these symbols defined where 14.04 does, and they both have the same libavutil version number.