### PR TITLE
Fixed the version of avcodec at which PIX_FMT becomes AV_PIX_FMT

### DIFF
--- a/core/vidl/vidl_ffmpeg_pixel_format.cxx
+++ b/core/vidl/vidl_ffmpeg_pixel_format.cxx
@@ -32,7 +32,7 @@ extern "C" {
 
 //--------------------------------------------------------------------------------
 
-#if LIBAVCODEC_VERSION_MAJOR < 56
+#if LIBAVCODEC_BUILD < ((54<<16)+(31<<8)+0) // before ver 54.31.0
 
 // The enum values in the old versions have the form PIX_FMT_*,
 // whereas the new ones are AV_PIX_FMT_*.


### PR DESCRIPTION
This was failing with Ubuntu 14.04 because major version 56 is not
specific enough.