### PR TITLE
BUG: Addresses 'ordered comparison between pointer and zero' error wi…

### DIFF
--- a/v3p/netlib/linalg/lsqrBase.cxx
+++ b/v3p/netlib/linalg/lsqrBase.cxx
@@ -562,7 +562,7 @@ Solve( unsigned int m, unsigned int n, const double * b, double * x )
     // See if it is time to print something.
     //----------------------------------------------------------------
     bool prnt = false;
-    if (nout > 0)
+    if ( this->nout )
       {
       if (n     <=        40) prnt = true;
       if (this->itn   <=        10) prnt = true;


### PR DESCRIPTION
…th clang-4

Clang 4 reports the following error message:

  Modules/ThirdParty/VNL/src/vxl/v3p/netlib/linalg/lsqrBase.cxx:565:14:\
    error: ordered comparison between pointer and zero ('std::ostream *'\
    (aka 'basic_ostream<char> *') and 'int')
    if (nout > 0)