### PR TITLE
COMP: Reduce travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ script:
   - mkdir -p ${HERE}/install
   - cd ${HERE}/build
   - ${HOME}/deps/bin/cmake
-          -DCMAKE_INSTALL_PREFIX=${HERE}/install
-          -DCMAKE_CXX_STANDARD=98
+          -DCMAKE_INSTALL_PREFIX:PATH=${HERE}/install
+          -DCMAKE_CXX_STANDARD:STRING=98
+          -DBUILD_BRL:BOOL=OFF
           ../
   - ${HOME}/deps/bin/ctest -D ExperimentalStart
   - ${HOME}/deps/bin/ctest -D ExperimentalConfigure


### PR DESCRIPTION
All Travis CI builds were failing due to excessive
build times.

This patch turns off the brl contributed library
in order to reduce the build & testing time to
fit into the time constraints of the Travis CI
build environment.

Build times for the contributed libraries.

============
brl
real	19m37.929s
user	35m3.023s
sys	3m57.498s
============
conversions
real	0m12.131s
user	0m19.362s
sys	0m3.080s
============
gel
real	0m58.859s
user	1m43.370s
sys	0m11.452s
============
mul
real	2m30.535s
user	4m26.628s
sys	0m31.357s
============
oul
real	0m5.226s
user	0m6.455s
sys	0m1.260s
============
oxl
real	0m6.294s
user	0m8.430s
sys	0m2.037s
============
prip
real	0m9.181s
user	0m14.919s
sys	0m1.795s
============
rpl
real	0m56.946s
user	1m40.825s
sys	0m10.785s
============
tbl
real	0m26.589s
user	0m43.419s
sys	0m6.304s
============