### PR TITLE
Old fix for third order missing

### DIFF
--- a/contrib/brl/bseg/sdet/sdet_third_order_edge_det.cxx
+++ b/contrib/brl/bseg/sdet/sdet_third_order_edge_det.cxx
@@ -707,7 +707,7 @@ sdet_edgemap_sptr sdet_third_order_edge_det::edgemap() {
 
   for (unsigned i=0; i<edgels_.size(); i++)
   {
-    sdet_edgel* new_edgel = new sdet_edgel(edgels_[i].get_pt(), std::tan(edgels_[i].get_theta()), edgels_[i].get_grad());
+    sdet_edgel* new_edgel = new sdet_edgel(edgels_[i].get_pt(), edgels_[i].get_theta(), edgels_[i].get_grad());
     edge_map->insert(new_edgel);
   }
   return edge_map;


### PR DESCRIPTION
We're heavily developing the edge detectors,
and noticed this bug which was causing all edge orientations to be off.

This is tested and have been in agreeement with Yuliang Guo from LEMS/Brown,
the main researcher improving edge detection. I'm the main vxl maintainer of this edge feature system and a main user of it.