### PR TITLE
VXL: dbsol to bsold_circ_arc in vsol curve

### DIFF
--- a/contrib/gel/vsol/vsol_curve_2d.h
+++ b/contrib/gel/vsol/vsol_curve_2d.h
@@ -28,7 +28,7 @@ class vsol_line_2d;
 class vsol_conic_2d;
 class vsol_polyline_2d;
 class vsol_digital_curve_2d;
-class dbsol_circ_arc_2d;
+class bsold_circ_arc_2d;
 
 class vsol_curve_2d : public vsol_spatial_object_2d
 {
@@ -94,8 +94,8 @@ class vsol_curve_2d : public vsol_spatial_object_2d
   //---------------------------------------------------------------------------
   //: Return `this' if `this' is a conic, 0 otherwise
   //---------------------------------------------------------------------------
-  virtual dbsol_circ_arc_2d const*cast_to_circ_arc()const{return VXL_NULLPTR;}
-  virtual dbsol_circ_arc_2d *cast_to_circ_arc() {return VXL_NULLPTR;}
+  virtual bsold_circ_arc_2d const*cast_to_circ_arc()const{return VXL_NULLPTR;}
+  virtual bsold_circ_arc_2d *cast_to_circ_arc() {return VXL_NULLPTR;}
 
 
   //---------------------------------------------------------------------------


### PR DESCRIPTION
This code isn't great, as it cites external classes, but it needs this fix since
dbsol_circ_arc_2d doesn't exist anymore in any recent active repository (this was an old LEMS/Brown class). Only bsold_circ_arc_2d does, and this is from the VXD library http://github.com/rfabbri/vxd.

(cherry picked from internal commit lemsvpe@daa998a4616ec57902357898b0ba30614016538e)