### PR TITLE
VXL fix: VIL jpeg compress compile error

### DIFF
--- a/core/vil/file_formats/vil_jpeg_compressor.cxx
+++ b/core/vil/file_formats/vil_jpeg_compressor.cxx
@@ -72,7 +72,7 @@ bool vil_jpeg_compressor::write_scanline(unsigned line, JSAMPLE const *scanline)
     jpeg_set_quality(&jobj, quality, TRUE);
 
     // start compression
-    bool write_all_tables = true;
+    jpeg_boolean write_all_tables = TRUE;
     jpeg_start_compress (&jobj, write_all_tables);
 
     //


### PR DESCRIPTION
This was needed to compile in recent OSX and GNU/LInux

(cherry picked from commit lemsvpe@7f5c3f793d0b0ac070f2bf7975e85e28b40d7a7f)