### PR TITLE
VXL fix: VIL1 jpeg compress compile error

### DIFF
--- a/core/vil1/file_formats/vil1_jpeg_compressor.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_compressor.cxx
@@ -55,7 +55,7 @@ bool vil1_jpeg_compressor::write_scanline(unsigned line, JSAMPLE const *scanline
     jpeg_set_defaults(&jobj);
 
     // start compression
-    bool write_all_tables = true;
+    jpeg_boolean write_all_tables = TRUE;
     jpeg_start_compress (&jobj, write_all_tables);
 
     //


### PR DESCRIPTION
Needed to compile vil1 in OSX and GNU/Linux (Ubuntu)

(cherry picked from commit lemsvpe@86fbdcebed27809a35997117aaa7cde5950128d8)