### PR TITLE
vxl: removed curvelet defs from edgel .h

### DIFF
--- a/contrib/brl/bseg/sdet/sdet_curvelet.h
+++ b/contrib/brl/bseg/sdet/sdet_curvelet.h
@@ -39,8 +39,9 @@
 //forward declaration
 class sdet_curvelet;
 
-typedef std::list<sdet_curvelet*> cvlet_list;
-typedef std::list<sdet_curvelet*>::iterator cvlet_list_iter;
+typedef std::list<sdet_curvelet*> sdet_curvelet_list;
+typedef std::list<sdet_curvelet*>::iterator sdet_curvelet_list_iter;
+typedef std::list<sdet_curvelet*>::const_iterator sdet_curvelet_list_const_iter;
 
 //: The curvelet class: stores the ordered list of edgels defining the curvelet
 //  and also the curve model defined by the grouping

--- a/contrib/brl/bseg/sdet/sdet_curvelet_map.h
+++ b/contrib/brl/bseg/sdet/sdet_curvelet_map.h
@@ -87,10 +87,10 @@ public:
   sdet_curvelet_params params_;
 
   //: The curvelet map, indexed by edgel IDs
-  std::vector<cvlet_list > map_;
+  std::vector<sdet_curvelet_list > map_;
 
   //: The curvelet map for the other direction (only for DHT mode)
-  std::vector<cvlet_list > map2_;
+  std::vector<sdet_curvelet_list > map2_;
 
   //: constructor
   sdet_curvelet_map(sdet_edgemap_sptr EM=0, sdet_curvelet_params params=sdet_curvelet_params());
@@ -108,10 +108,10 @@ public:
   void set_parameters(sdet_curvelet_params params) { params_ = params; }
 
   //: access the curvelets for an edge using its id
-  const cvlet_list& curvelets(unsigned id) const { return map_[id]; }
-  cvlet_list& curvelets(unsigned id) { return map_[id]; }
+  const sdet_curvelet_list& curvelets(unsigned id) const { return map_[id]; }
+  sdet_curvelet_list& curvelets(unsigned id) { return map_[id]; }
 
-  cvlet_list& Rcurvelets(unsigned id) { return map2_[id]; }
+  sdet_curvelet_list& Rcurvelets(unsigned id) { return map2_[id]; }
 
   //: resize the graph
   void resize(unsigned size);

--- a/contrib/brl/bseg/sdet/sdet_edgel.h
+++ b/contrib/brl/bseg/sdet/sdet_edgel.h
@@ -39,10 +39,6 @@ typedef std::deque<sdet_edgel* > sdet_edgel_list;
 typedef std::deque<sdet_edgel* >::iterator sdet_edgel_list_iter;
 typedef std::deque<sdet_edgel* >::const_iterator sdet_edgel_list_const_iter;
 
-typedef std::list<sdet_curvelet* > sdet_curvelet_list;
-typedef std::list<sdet_curvelet* >::iterator sdet_curvelet_list_iter;
-typedef std::list<sdet_curvelet* >::const_iterator sdet_curvelet_list_const_iter;
-
 //: edgel class: contains pt, tangent and collection of all the groupings around it
 class sdet_edgel
 {


### PR DESCRIPTION
We had defs in the wrong place and with bad names.

(cherry picked from commit lemsvpe@9fddf6caee05c3837f5a9c1976ef8940ab1d1286)