### PR TITLE
vgui: better GTK2 GTKGL detection

### DIFF
--- a/core/vgui/CMakeLists.txt
+++ b/core/vgui/CMakeLists.txt
@@ -421,10 +421,26 @@ endif()
 # GTK2
 ##################################################
 
-message("GTK2_INCLUDE_DIRS: ${GTK2_INCLUDE_DIRS}")
 if(GTK2_FOUND)
-
   # We need to make sure we have the gl extension before building this component.
+  find_package(PkgConfig)
+  if (PkgConfig_FOUND)
+    pkg_search_module(GTKGL2 gtkglext-1.0) # despite the 1.0, works w/ gtk2
+    if (GTKGL2_FOUND)
+      list(APPEND GTK2_INCLUDE_DIRS ${GTKGL2_INCLUDE_DIRS})
+      list(REMOVE_DUPLICATES GTK2_INCLUDE_DIRS)
+      list(APPEND GTK2_LIBRARIES ${GTKGL2_LIBRARIES})
+      list(REMOVE_DUPLICATES GTK2_LIBRARIES)
+      # TODO: libraries are not full paths, a known limitation of pkg_*_module.
+      # If a GTK library is installed on a non-standard path, this will fail.
+      # One can either work on the cmake dev list to improve PkgConfig,
+      # or else use a function to append a full path to each library as
+      # provided by a patch in the original Mantis issue for 
+      # https://gitlab.kitware.com/cmake/cmake/issues/15804
+    endif()
+  endif()
+  # message("GTK2_INCLUDE_DIRS: ${GTK2_INCLUDE_DIRS}")
+  # message("GTK2 FINAL Libraries" "${GTK2_LIBRARIES}")
   find_file(GTKGL gtk/gtkgl.h PATHS ${GTK2_INCLUDE_DIRS})
   if (GTKGL)
     option(VGUI_USE_GTK2 "Should GTK2 support be compiled into vgui?" YES)

--- a/core/vgui/impl/gtk2/vgui_gtk2_adaptor.cxx
+++ b/core/vgui/impl/gtk2/vgui_gtk2_adaptor.cxx
@@ -22,9 +22,8 @@
 #include <vcl_compiler.h>
 #include <vcl_cassert.h>
 #include <gdk/gdkkeysyms.h>
-#include <gtk/gtk.h>
-#include <gdk/gdkgl.h>
 #include <gtk/gtkgl.h>
+#include <gdk/gdkgl.h>
 
 #include <vgui/vgui_gl.h>
 #include <vgui/vgui_popup_params.h>

--- a/core/vgui/impl/gtk2/vgui_gtk2_statusbar.h
+++ b/core/vgui/impl/gtk2/vgui_gtk2_statusbar.h
@@ -18,7 +18,7 @@
 // \endverbatim
 
 #include <string>
-#include <iosfwd>
+#include <ostream>
 #include <vcl_compiler.h>
 #include <gtk/gtk.h>
 #include <vgui/vgui_statusbuf.h>

--- a/core/vgui/impl/gtk2/vgui_gtk2_window.cxx
+++ b/core/vgui/impl/gtk2/vgui_gtk2_window.cxx
@@ -8,6 +8,7 @@
 // \date   18 Dec 99
 // \brief  See vgui_gtk2_window.h for a description of this file.
 
+#include <iostream>
 #include "vgui_gtk2_window.h"
 
 #include <vgui/vgui.h>


### PR DESCRIPTION
These fixes are general and are needed for recent systems. Tested on Ubuntu 16.04 and 14.04
The new checks for GTKGL do exactly what they did before (so they are no harm to
the current system), but if these checks fail, they try to use pkgconfig in a seamless manner.

Fixes #384