### PR TITLE
Set initial value for best_x.

### DIFF
--- a/core/vnl/algo/vnl_lbfgs.cxx
+++ b/core/vnl/algo/vnl_lbfgs.cxx
@@ -98,6 +98,7 @@ bool vnl_lbfgs::minimize(vnl_vector<double>& x)
     f_->compute(x, &f, &g);
     if (this->num_evaluations_ == 0) {
       this->start_error_ = f;
+      best_x = x;
       best_f = f;
     } else if (f < best_f) {
       best_x = x;


### PR DESCRIPTION
This will prevent errors caused by returning an empty vector when starting at a minimum.