### PR TITLE
Don't halt stream processing if there is a bad frame, just ignore it …

### DIFF
--- a/core/vidl/vidl_ffmpeg_istream_v56.hxx
+++ b/core/vidl/vidl_ffmpeg_istream_v56.hxx
@@ -450,9 +450,16 @@ advance()
     // Make sure that the packet is from the actual video stream.
     if (is_->packet_.stream_index == is_->vid_index_)
     {
-      if ( avcodec_decode_video2( is_->video_enc_,
-                                  is_->frame_, &got_picture,
-                                  &is_->packet_ ) < 0 ) {
+       int err = avcodec_decode_video2( is_->video_enc_,
+                                       is_->frame_, &got_picture,
+                                       &is_->packet_); 
+       if (err == AVERROR_INVALIDDATA)
+       {// Ignore the frame and move to the next
+         av_free_packet(&is_->packet_);
+         continue;
+       }
+      if (err<0)
+      {
         std::cerr << "vidl_ffmpeg_istream: Error decoding packet!\n";
         av_free_packet(&is_->packet_);
         return false;


### PR DESCRIPTION
…and continue looking for the next good frame in the stream

Found this in processing the h264 live streams and avi files from our camera setup