### PR TITLE
Add runtime-loaded formats to the front so they can replace built-in formats.

### DIFF
--- a/core/vidl/vidl_image_list_ostream.cxx
+++ b/core/vidl/vidl_image_list_ostream.cxx
@@ -57,7 +57,8 @@ open(const std::string& directory,
   }
 
   bool valid_file_format = false;
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p) {
+  std::list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p) {
     if (file_format == (*p)->tag()) {
       valid_file_format = true;
       break;
@@ -68,8 +69,10 @@ open(const std::string& directory,
     close();
     std::cerr << __FILE__ ": File format \'"<<file_format<<"\' not supported\n"
              << "   valid formats are: ";
-    for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+    std::list<vil_file_format*>& l = vil_file_format::all();
+    for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p) {
       std::cerr << " \'" << (*p)->tag() << "\' " << std::flush;
+    }
     std::cerr << std::endl;
     return false;
   }

--- a/core/vil/vil_file_format.cxx
+++ b/core/vil/vil_file_format.cxx
@@ -81,97 +81,91 @@ const unsigned MAX_FILE_FORMATS=256;
 // Clears list on deletion.
 struct vil_file_format_storage
 {
-  vil_file_format** l;
-  vil_file_format_storage(): l(new vil_file_format*[MAX_FILE_FORMATS])
+  std::list<vil_file_format*> l;
+  vil_file_format_storage()
   {
-    unsigned c=0;
 #if HAS_JPEG
-    l[c++] = new vil_jpeg_file_format;
+    l.push_back(new vil_jpeg_file_format);
 #endif
 #if HAS_PNG
-    l[c++] = new vil_png_file_format;
+    l.push_back(new vil_png_file_format);
 #endif
 #if HAS_PNM
-    l[c++] = new vil_pnm_file_format;
-    l[c++] = new vil_pbm_file_format;
-    l[c++] = new vil_pgm_file_format;
-    l[c++] = new vil_ppm_file_format;
+    l.push_back(new vil_pnm_file_format);
+    l.push_back(new vil_pbm_file_format);
+    l.push_back(new vil_pgm_file_format);
+    l.push_back(new vil_ppm_file_format);
 #endif
 #if HAS_IRIS
-    l[c++] = new vil_iris_file_format;
+    l.push_back(new vil_iris_file_format);
 #endif
 #if HAS_MIT
-    l[c++] = new vil_mit_file_format;
+    l.push_back(new vil_mit_file_format);
 #endif
 #if HAS_VIFF
-    l[c++] = new vil_viff_file_format;
+    l.push_back(new vil_viff_file_format);
 #endif
 #if HAS_BMP
-    l[c++] = new vil_bmp_file_format;
+    l.push_back(new vil_bmp_file_format);
 #endif
 #if HAS_GIF
-    l[c++] = new vil_gif_file_format;
+    l.push_back(new vil_gif_file_format);
 #endif
 #if HAS_RAS
-    l[c++] = new vil_ras_file_format;
+    l.push_back(new vil_ras_file_format);
 #endif
 #if HAS_GEN
-    l[c++] = new vil_gen_file_format;
+    l.push_back(new vil_gen_file_format);
 #endif
 // the DCMTK based reader is more complete, so use try that
 // before the vil implementation
 #if HAS_DCMTK
-    l[c++] = new vil_dicom_file_format;
+    l.push_back(new vil_dicom_file_format);
 #endif
 
 #if HAS_NITF
-  l[c++] = new vil_nitf2_file_format;
+  l.push_back(new vil_nitf2_file_format);
 #endif
 
 #if HAS_J2K
-  l[c++] = new vil_j2k_file_format;
+  l.push_back(new vil_j2k_file_format);
 #endif
 
 #if HAS_OPENJPEG2
-  l[c++] = new vil_openjpeg_jp2_file_format;
-  //l[c++] = new vil_openjpeg_jpt_file_format;
-  l[c++] = new vil_openjpeg_j2k_file_format;
+  l.push_back(new vil_openjpeg_jp2_file_format);
+  l.push_back(new vil_openjpeg_j2k_file_format);
 #endif
 
 #if HAS_TIFF
-    l[c++] = new vil_tiff_file_format;
-    l[c++] = new vil_pyramid_image_list_format;
+    l.push_back(new vil_tiff_file_format);
+    l.push_back(new vil_pyramid_image_list_format);
 #endif
-    l[c++] = VXL_NULLPTR;
   }
 
   ~vil_file_format_storage()
   {
-    unsigned c=0;
-    while (l[c]!=VXL_NULLPTR)
-      delete l[c++];
-    delete [] l;
-    l=VXL_NULLPTR;
+    for(std::list<vil_file_format*>::iterator i = l.begin(); i != l.end(); ++i)
+    {
+      if(*i)
+      {
+        delete *i;
+      }
+    }
   }
 };
 
 //: The function will take ownership of ff;
 void vil_file_format::add_file_format(vil_file_format* ff)
 {
-  vil_file_format** l=all();
-  unsigned c=0;
-  while (c<MAX_FILE_FORMATS-1u && l[c]!=VXL_NULLPTR) ++c;
-  if (l[c]!=VXL_NULLPTR)
-  {
-    std::cerr << "ERROR vil_file_format::add_file_format Unable to add any more file formats\n";
-    std::abort();
-  }
-  l[c] = ff;
-  l[c+1] = VXL_NULLPTR;
+  std::list<vil_file_format*>& l = all();
+
+  // Always add runtime-loaded formats to the front to allow them to replace
+  // built-in formats
+  l.push_front(ff);
 }
 
 
-vil_file_format** vil_file_format::all()
+std::list<vil_file_format*>& vil_file_format::all()
 {
   static vil_file_format_storage storage;
   return storage.l;

--- a/core/vil/vil_file_format.h
+++ b/core/vil/vil_file_format.h
@@ -9,10 +9,12 @@
 // \brief Base class for image formats
 // \author awf
 
+#include <list>
 #include <vil/vil_fwd.h> // for vil_stream
 #include <vil/vil_image_resource.h>
 #include <vil/vil_blocked_image_resource.h>
 #include <vil/vil_pyramid_image_resource.h>
+
 //: Base class for image formats.
 //  There is one derived class for each handled file format in the
 // directory file_formats. E.g. vil/file_formats/vil_pnm.h etc
@@ -79,7 +81,8 @@ class vil_file_format
     {return VXL_NULLPTR;}
 
  public:
-  static vil_file_format** all();
+  typedef std::list<vil_file_format*>::iterator iterator;
+  static std::list<vil_file_format*>& all();
   static void add_file_format(vil_file_format* ff);
 };
 

--- a/core/vil/vil_load.cxx
+++ b/core/vil/vil_load.cxx
@@ -20,7 +20,8 @@
 vil_image_resource_sptr vil_load_image_resource_raw(vil_stream *is,
                                                     bool verbose)
 {
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p) {
+  std::list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p) {
 #if 0 // debugging
     std::cerr << __FILE__ " : trying \'" << (*p)->tag() << "\'\n";
 #endif
@@ -33,7 +34,7 @@ vil_image_resource_sptr vil_load_image_resource_raw(vil_stream *is,
   // failed.
   if (verbose) {
     std::cerr << __FILE__ ": Unable to load image;\ntried";
-    for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+    for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
       // 'flush' in case of segfault next time through loop. Else, we
       // will not see those printed tags still in the stream buffer.
       std::cerr << " \'" << (*p)->tag() << "\'" << std::flush;
@@ -103,7 +104,8 @@ vil_image_resource_sptr vil_load_image_resource_plugin(char const* filename)
 vil_pyramid_image_resource_sptr
 vil_load_pyramid_resource(char const* directory_or_file, bool verbose)
 {
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p) {
+  std::list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p) {
 #if 0 // debugging
     std::cerr << __FILE__ " : trying \'" << (*p)->tag() << "\'\n";
 
@@ -118,7 +120,7 @@ vil_load_pyramid_resource(char const* directory_or_file, bool verbose)
   // failed.
   if (verbose) {
     std::cerr << __FILE__ ": Unable to load pyramid image;\ntried";
-    for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+    for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
       // 'flush' in case of segfault next time through loop. Else, we
       // will not see those printed tags still in the stream buffer.
       std::cerr << " \'" << (*p)->tag() << "\'" << std::flush;

--- a/core/vil/vil_new.cxx
+++ b/core/vil/vil_new.cxx
@@ -85,7 +85,8 @@ vil_image_resource_sptr vil_new_image_resource(vil_stream* os,
     file_format = "pnm";
 
   vil_image_resource_sptr outimage = VXL_NULLPTR;
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+  vcl_list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
   {
     vil_file_format* fmt = *p;
     if (std::strcmp(fmt->tag(), file_format) == 0) {
@@ -163,7 +164,8 @@ vil_new_blocked_image_resource(vil_stream* os, unsigned ni, unsigned nj,
     file_format = "pnm";
 
   vil_blocked_image_resource_sptr outimage = VXL_NULLPTR;
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+  vcl_list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
   {
     vil_file_format* fmt = *p;
     if (std::strcmp(fmt->tag(), file_format) == 0) {
@@ -217,7 +219,8 @@ vil_new_pyramid_image_resource(char const* file_or_directory,
   if (!file_format) // avoid segfault in strcmp()
     file_format = "tiff";
   vil_pyramid_image_resource_sptr outimage = VXL_NULLPTR;
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+  vcl_list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
   {
     vil_file_format* fmt = *p;
     if (std::strcmp(fmt->tag(), file_format) == 0) {
@@ -241,7 +244,8 @@ vil_pyramid_image_resource_sptr
   if (!file_format) // avoid segfault in strcmp()
     file_format = "tiff";
   vil_pyramid_image_resource_sptr outimage = VXL_NULLPTR;
-  for (vil_file_format** p = vil_file_format::all(); *p; ++p)
+  vcl_list<vil_file_format*>& l = vil_file_format::all();
+  for (vil_file_format::iterator p = l.begin(); p != l.end(); ++p)
   {
     vil_file_format* fmt = *p;
     if (std::strcmp(fmt->tag(), file_format) == 0) {


### PR DESCRIPTION
We need to add custom, runtime generated image formats to the head of the vil_file_format_storage list. The return of a matching format happens first come, first served, which makes it impossible to use custom formats which extend, built-in types.