### PR TITLE
BUG:  jpeg_boolean not convertable to C++ bool

### DIFF
--- a/core/vil/file_formats/vil_jpeg_compressor.cxx
+++ b/core/vil/file_formats/vil_jpeg_compressor.cxx
@@ -72,7 +72,8 @@ bool vil_jpeg_compressor::write_scanline(unsigned line, JSAMPLE const *scanline)
     jpeg_set_quality(&jobj, quality, TRUE);
 
     // start compression
-    bool write_all_tables = true;
+    //JPEG boolean is not compatible with c++ bool
+    const jpeg_boolean write_all_tables = TRUE;
     jpeg_start_compress (&jobj, write_all_tables);
 
     //

--- a/core/vil1/file_formats/vil1_jpeg_compressor.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_compressor.cxx
@@ -55,7 +55,8 @@ bool vil1_jpeg_compressor::write_scanline(unsigned line, JSAMPLE const *scanline
     jpeg_set_defaults(&jobj);
 
     // start compression
-    bool write_all_tables = true;
+    //JPEG boolean is not compatible with c++ bool
+    const jpeg_boolean write_all_tables = TRUE;
     jpeg_start_compress (&jobj, write_all_tables);
 
     //


### PR DESCRIPTION
vxl/core/vil/file_formats/vil_jpeg_compressor.cxx:76:5: error: no matching function for call to 'jpeg_start_compress'
    jpeg_start_compress (&jobj, write_all_tables);
    ^~~~~~~~~~~~~~~~~~~
<..>/include/jpeglib.h:1010:14: note: candidate function not viable: no known conversion from 'bool' to 'jpeg_boolean' for 2nd argument
EXTERN(void) jpeg_start_compress JPP((j_compress_ptr cinfo,
             ^