### PR TITLE
some video do not have an average frame rate

### DIFF
--- a/core/vidl/vidl_ffmpeg_istream_v56.hxx
+++ b/core/vidl/vidl_ffmpeg_istream_v56.hxx
@@ -113,6 +113,11 @@ struct vidl_ffmpeg_istream::pimpl
   double stream_time_base_to_frame()
     {
     assert(this->vid_str_);
+    if(this->vid_str_->avg_frame_rate.num == 0.0)
+    {
+      return av_q2d(av_inv_q(av_mul_q(this->vid_str_->time_base,
+                                      this->vid_str_->r_frame_rate)));
+    }
     return av_q2d(
       av_inv_q(
         av_mul_q(this->vid_str_->time_base, this->vid_str_->avg_frame_rate)));


### PR DESCRIPTION
When the is no average frame rate, switch to using the frame rate