### PR TITLE
With hidden visibility propagated we need to export symbols

### DIFF
--- a/core/vnl/algo/vnl_amoeba.h
+++ b/core/vnl/algo/vnl_amoeba.h
@@ -23,6 +23,8 @@
 #include <vnl/vnl_vector.h>
 #include <vnl/algo/vnl_algo_export.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 class vnl_cost_function;
 class vnl_least_squares_function;
 
@@ -43,7 +45,7 @@ class vnl_least_squares_function;
 //  are obtained by adding each dx[i] to the elements of x, one at a time.
 //  This is useful if you know roughly the scale of your space.
 
-class vnl_amoeba
+class VNL_ALGO_EXPORT vnl_amoeba
 {
  public:
   int verbose;

--- a/core/vnl/algo/vnl_complex_eigensystem.h
+++ b/core/vnl/algo/vnl_complex_eigensystem.h
@@ -15,6 +15,8 @@
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_matrix.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 //: Calculates eigenvalues and eigenvectors of a square complex matrix
 //
 //  Class to compute and hold the eigenvalues and (optionally) eigenvectors
@@ -35,7 +37,7 @@
 //  The ith right eigenvector v satisfies A*v = W[i]*v   \n
 //  The ith left  eigenvector u satisfies u*A = W[i]*u (no conjugation)
 
-class vnl_complex_eigensystem
+class VNL_ALGO_EXPORT vnl_complex_eigensystem
 {
  public:
   // please do not add underscores to my members - they are publicly accessible

--- a/core/vnl/algo/vnl_levenberg_marquardt.h
+++ b/core/vnl/algo/vnl_levenberg_marquardt.h
@@ -27,6 +27,8 @@
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_nonlinear_minimizer.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 class vnl_least_squares_function;
 
 //: Levenberg Marquardt nonlinear least squares
@@ -39,7 +41,7 @@ class vnl_least_squares_function;
 //  (See Hartley in ``Applications of Invariance in Computer Vision''
 //  for example).
 
-class vnl_levenberg_marquardt : public vnl_nonlinear_minimizer
+class VNL_ALGO_EXPORT vnl_levenberg_marquardt : public vnl_nonlinear_minimizer
 {
  public:
 

--- a/core/vnl/algo/vnl_lsqr.h
+++ b/core/vnl/algo/vnl_lsqr.h
@@ -28,13 +28,15 @@
 #include <vnl/vnl_linear_system.h>
 #include <vcl_compiler.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 //: Linear least squares
 //  vnl_lsqr implements an algorithm for large, sparse linear systems and
 //  sparse, linear least squares. It is a wrapper for the LSQR algorithm
 //  of Paige and Saunders (ACM TOMS 583). The sparse system is encapsulated
 //  by a vnl_linear_system.
 
-class vnl_lsqr
+class VNL_ALGO_EXPORT vnl_lsqr
 {
  public:
   vnl_lsqr(vnl_linear_system& ls) :

--- a/core/vnl/algo/vnl_real_eigensystem.h
+++ b/core/vnl/algo/vnl_real_eigensystem.h
@@ -21,11 +21,13 @@
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_diag_matrix.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 //: Extract eigensystem of asymmetric matrix M, using the EISPACK routine
 //  vnl_eigensystem is a full-bore real eigensystem.  If your matrix
 //  is symmetric, it is \e much better to use \sa vnl_symmetric_eigensystem.
 
-class vnl_real_eigensystem
+class VNL_ALGO_EXPORT vnl_real_eigensystem
 {
  public:
   vnl_real_eigensystem(vnl_matrix<double> const& M);

--- a/core/vnl/algo/vnl_sparse_lm.h
+++ b/core/vnl/algo/vnl_sparse_lm.h
@@ -23,6 +23,8 @@
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_nonlinear_minimizer.h>
 
+#include <vnl/algo/vnl_algo_export.h>
+
 class vnl_sparse_lst_sqr_function;
 
 //: Sparse Levenberg Marquardt nonlinear least squares
@@ -31,7 +33,7 @@ class vnl_sparse_lst_sqr_function;
 //  the Hartley and Zisserman "Multiple View Geometry" book and further
 //  described in a technical report on sparse bundle adjustment available
 //  at http://www.ics.forth.gr/~lourakis/sba
-class vnl_sparse_lm : public vnl_nonlinear_minimizer
+class VNL_ALGO_EXPORT vnl_sparse_lm : public vnl_nonlinear_minimizer
 {
  public:
 


### PR DESCRIPTION
With visibility set to hidden applications can't link vnl_algo. This branch exports the classes that were failing for my applications. It's likely that a more comprehensive branch should follow which exports more of this libraries symbols.