### PR TITLE
COMP: Fix VXL_NOEXCEPT macro.

### DIFF
--- a/vcl/vcl_compiler_detection.h
+++ b/vcl/vcl_compiler_detection.h
@@ -249,10 +249,8 @@
 
 #  if VXL_COMPILER_CXX_NOEXCEPT
 #    define VXL_NOEXCEPT noexcept
-#    define VXL_NOEXCEPT_EXPR(X) noexcept(X)
 #  else
-#    define VXL_NOEXCEPT
-#    define VXL_NOEXCEPT_EXPR(X)
+#    define VXL_NOEXCEPT throw()
 #  endif
 
 


### PR DESCRIPTION
Remove VXL_NOEXCEPT_EXPR, invalid in c++03.
Use empty `throw()` if noexcept specifier is not available.

Originated from ITK, see gerrit: http://review.source.kitware.com/22861