### PR TITLE
BUG: Allow compilation of VNL with MSVC<1600

### DIFF
--- a/vcl/vcl_compiler_detection.h
+++ b/vcl/vcl_compiler_detection.h
@@ -128,7 +128,7 @@
 # undef VXL_COMPILER_IS_GNU
 # define VXL_COMPILER_IS_GNU 1
 
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _MSC_VER >= 1600
 # undef VXL_COMPILER_IS_MSVC
 # define VXL_COMPILER_IS_MSVC 1
 


### PR DESCRIPTION
Compiler detection and feature support is performed with files generated with
the CMake macro `WriteCompilerDetectionHeader`. This macro generate a specific
header file for several supported compilers, including MSVC. However, for
MSVC, it only supports feature detection if MSVC >= 1600. If MSVC < 1600,
an error message is thrown instead of defaulting to default unknown compiler
which uses `__cplusplus` variable to configure supported features. In the case
of MSVC < 1600, it will default to a configuration with no C++11 support.