### PR TITLE
COMP: Do not use export macro in vnl_amoeba default_verbose

### DIFF
--- a/core/vnl/algo/vnl_amoeba.h
+++ b/core/vnl/algo/vnl_amoeba.h
@@ -103,7 +103,7 @@ class VNL_ALGO_EXPORT vnl_amoeba
   //: Modify x so as to minimise f(x)
   static void minimize(vnl_least_squares_function& f, vnl_vector<double>& x);
 
-  static VNL_ALGO_EXPORT bool default_verbose;
+  static bool default_verbose;
 
  protected:
   vnl_cost_function* fptr;


### PR DESCRIPTION
This avoids the build error

vnl\src\vxl\core\vnl\algo\vnl_amoeba.h(106)
: error C2487: 'default_verbose' : member of dll interface class may not be
declared with dll interface

when BUILD_SHARED_LIBS=ON and CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON are
set following the addition of the export macro to the vnl_amoeba class in vnl.