### PR TITLE
Incorrect vnl export

### DIFF
--- a/core/vbl/io/vbl_io_smart_ptr.hxx
+++ b/core/vbl/io/vbl_io_smart_ptr.hxx
@@ -24,7 +24,7 @@ void vsl_b_write(vsl_b_ostream & os, const vbl_smart_ptr<T> &p)
   vsl_b_write(os, io_version_no);
   vsl_b_write(os, p.is_protected());
 
-  if (p.ptr() == 0)  // Deal with Null pointers first.
+  if (p.ptr() == VXL_NULLPTR)  // Deal with Null pointers first.
   {
     vsl_b_write(os, true);
     vsl_b_write(os, 0ul); // Use 0 to indicate a null pointer.
@@ -118,12 +118,12 @@ void vsl_b_read(vsl_b_istream &is, vbl_smart_ptr<T> &p)
 
     if (id == 0) // Deal with Null pointers first.
     {
-      p = 0;
+      p = VXL_NULLPTR;
       return;
     }
 
     T * pointer = static_cast<T *>( is.get_serialisation_pointer(id));
-    if (first_time != (pointer == 0))
+    if (first_time != (pointer == VXL_NULLPTR))
     {
       // This checks that the saving stream and reading stream
       // both agree on whether or not this is the first time they
@@ -134,7 +134,7 @@ void vsl_b_read(vsl_b_istream &is, vbl_smart_ptr<T> &p)
       return;
     }
 
-    if (pointer == 0)
+    if (pointer == VXL_NULLPTR)
     {
       // If you get an error in the next line, it could be because your type T
       // has no vsl_b_read(vsl_b_istream&,T*&)  defined on it.

--- a/core/vbl/vbl_array_1d.h
+++ b/core/vbl/vbl_array_1d.h
@@ -43,7 +43,7 @@ class vbl_array_1d
   typedef T const &const_reference;
  public:
 
-  vbl_array_1d() : begin_(0), end_(0), alloc_(0) { }
+  vbl_array_1d() : begin_(VXL_NULLPTR), end_(VXL_NULLPTR), alloc_(VXL_NULLPTR) { }
 
   vbl_array_1d(const_iterator b, const_iterator e) {
     std::ptrdiff_t n = e - b;

--- a/core/vbl/vbl_array_2d.h
+++ b/core/vbl/vbl_array_2d.h
@@ -144,7 +144,7 @@ class vbl_array_2d
 
  private:
   void construct() {
-    rows_ = 0;
+    rows_ = VXL_NULLPTR;
     num_rows_ = 0;
     num_cols_ = 0;
   }
@@ -159,7 +159,7 @@ class vbl_array_2d
         rows_[i] = p + i * n;
     }
     else {
-      rows_ = 0;
+      rows_ = VXL_NULLPTR;
     }
   }
 

--- a/core/vbl/vbl_array_3d.h
+++ b/core/vbl/vbl_array_3d.h
@@ -56,7 +56,7 @@ class vbl_array_3d
   typedef T const &const_reference;
  public:
 
-  vbl_array_3d(): element_(0), row1_count_(0), row2_count_(0), row3_count_(0)
+  vbl_array_3d(): element_(VXL_NULLPTR), row1_count_(0), row2_count_(0), row3_count_(0)
   {}
 
   vbl_array_3d(size_type n1, size_type n2, size_type n3)
@@ -73,7 +73,7 @@ class vbl_array_3d
   }
 
   vbl_array_3d(vbl_array_3d<T> const& that)
-  : element_(0), row1_count_(0), row2_count_(0), row3_count_(0)
+  : element_(VXL_NULLPTR), row1_count_(0), row2_count_(0), row3_count_(0)
   {
     if (that.element_) {
       construct(that.row1_count_,that.row2_count_,that.row3_count_);

--- a/core/vbl/vbl_array_3d.hxx
+++ b/core/vbl/vbl_array_3d.hxx
@@ -27,7 +27,7 @@ void vbl_array_3d<T>::construct(size_type n1, size_type n2, size_type n3)
 
   // If any of the dimensions are 0, don't allocate memory, just return.
   if ((n1 * n2 * n3)==0) {
-    element_ = 0;
+    element_ = VXL_NULLPTR;
     return;
   }
 

--- a/core/vbl/vbl_scoped_ptr.h
+++ b/core/vbl/vbl_scoped_ptr.h
@@ -65,7 +65,7 @@ class vbl_scoped_ptr
   typedef T element_type;
 
   //:
-  explicit vbl_scoped_ptr( T* p = 0 )
+  explicit vbl_scoped_ptr( T* p = VXL_NULLPTR )
     : ptr_(p) // never throws
   {
   }
@@ -78,7 +78,7 @@ class vbl_scoped_ptr
   }
 
   //: Make this own \p p, releasing any existing pointer.
-  void reset( T* p = 0 ) // never throws
+  void reset( T* p = VXL_NULLPTR ) // never throws
   {
     this_type(p).swap(*this);
   }

--- a/core/vbl/vbl_shared_pointer.h
+++ b/core/vbl/vbl_shared_pointer.h
@@ -39,7 +39,7 @@ class vbl_shared_pointer
 
   typedef vbl_shared_pointer_data data_t;
 
-  vbl_shared_pointer() : pointer(0), count_data(0) { }
+  vbl_shared_pointer() : pointer(VXL_NULLPTR), count_data(VXL_NULLPTR) { }
 
   explicit
   vbl_shared_pointer(T *p) {
@@ -47,8 +47,8 @@ class vbl_shared_pointer
       pointer = p;
       count_data = new data_t(1);
     } else {
-      pointer = 0;
-      count_data = 0;
+      pointer = VXL_NULLPTR;
+      count_data = VXL_NULLPTR;
     }
   }
 

--- a/core/vbl/vbl_sparse_array_base.hxx
+++ b/core/vbl/vbl_sparse_array_base.hxx
@@ -47,7 +47,7 @@ T* vbl_sparse_array_base<T, Index>::get_addr(Index i)
   typename Map::iterator p = storage_.find(i);
 
   if (p == storage_.end())
-    return 0;
+    return VXL_NULLPTR;
 
   return &(*p).second;
 }

--- a/core/vcsl/examples/example1.cxx
+++ b/core/vcsl/examples/example1.cxx
@@ -45,12 +45,12 @@ int main()
   // Graph and coordinate systems instantiations
   std::cout<<"Creation of graph..."<< std::flush;
   vcsl_graph_sptr graph=new vcsl_graph;
-  assert(graph.ptr()!=0);
+  assert(graph.ptr()!=VXL_NULLPTR);
   std::cout<<" done\n";
 
   std::cout<<"Creation of acs..."<< std::flush;
   vcsl_spatial_sptr acs=new vcsl_cartesian_3d;
-  assert(acs.ptr()!=0);
+  assert(acs.ptr()!=VXL_NULLPTR);
   std::cout<<acs.ptr()<<" done\n"
           <<"Adding acs to graph..."<< std::flush;
   acs->set_graph(graph);
@@ -58,7 +58,7 @@ int main()
 
   std::cout<<"Creation of cs0..."<< std::flush;
   vcsl_spatial_sptr cs0=new vcsl_cartesian_3d;
-  assert(cs0.ptr()!=0);
+  assert(cs0.ptr()!=VXL_NULLPTR);
   std::cout<<cs0.ptr()<<" done\n"
           <<"Adding cs0 to graph..."<< std::flush;
   cs0->set_graph(graph);
@@ -66,7 +66,7 @@ int main()
 
   std::cout<<"Creation of lcs..."<< std::flush;
   vcsl_spatial_sptr lcs=new vcsl_cartesian_3d;
-  assert(lcs.ptr()!=0);
+  assert(lcs.ptr()!=VXL_NULLPTR);
   std::cout<<lcs.ptr()<<" done\n"
           <<"Adding lcs to graph..."<< std::flush;
   lcs->set_graph(graph);
@@ -75,7 +75,7 @@ int main()
   // Static transformation between acs and cs0
   std::cout<<"Creation of the static translation..."<< std::flush;
   vcsl_translation_sptr static_t=new vcsl_translation;
-  assert(static_t.ptr()!=0);
+  assert(static_t.ptr()!=VXL_NULLPTR);
   std::cout<<static_t.ptr()<<" done\n"
           <<"Creation of v0..."<< std::flush;
   vnl_vector<double> v0(3);
@@ -102,7 +102,7 @@ int main()
   // 1. translation
   std::cout<<"Creation of the dynamic translation..."<< std::flush;
   vcsl_translation_sptr dynamic_t=new vcsl_translation;
-  assert(dynamic_t.ptr()!=0);
+  assert(dynamic_t.ptr()!=VXL_NULLPTR);
   std::cout<<dynamic_t.ptr()<<" done\n";
 
   std::cout<<"Creation of t_beat..."<< std::flush;
@@ -164,7 +164,7 @@ int main()
   // 2. displacement
   std::cout<<"Creation of the dynamic displacement..."<< std::flush;
   vcsl_displacement_sptr dynamic_d=new vcsl_displacement;
-  assert(dynamic_d.ptr()!=0);
+  assert(dynamic_d.ptr()!=VXL_NULLPTR);
   std::cout<<dynamic_d.ptr()<<" done\n";
 
   std::cout<<"Creation of d_beat..."<< std::flush;

--- a/core/vcsl/vcsl_coordinate_system.h
+++ b/core/vcsl/vcsl_coordinate_system.h
@@ -59,7 +59,7 @@ class vcsl_coordinate_system
   //***************************************************************************
   // Because VXL does not necessarily use dynamic_cast<>
   //***************************************************************************
-  virtual const vcsl_spatial *cast_to_spatial() const { return 0; }
+  virtual const vcsl_spatial *cast_to_spatial() const { return VXL_NULLPTR; }
 
   //***************************************************************************
   // Conversion

--- a/core/vcsl/vcsl_spatial.h
+++ b/core/vcsl/vcsl_spatial.h
@@ -56,11 +56,11 @@ class vcsl_spatial
   //***************************************************************************
 
   virtual const vcsl_spatial *cast_to_spatial() const { return this; }
-  virtual const vcsl_cartesian_2d *cast_to_cartesian_2d() const {return 0; }
-  virtual const vcsl_polar *cast_to_polar() const {return 0; }
-  virtual const vcsl_cartesian_3d *cast_to_cartesian_3d() const {return 0; }
-  virtual const vcsl_cylindrical *cast_to_cylindrical() const {return 0; }
-  virtual const vcsl_spherical *cast_to_spherical() const {return 0; }
+  virtual const vcsl_cartesian_2d *cast_to_cartesian_2d() const {return VXL_NULLPTR; }
+  virtual const vcsl_polar *cast_to_polar() const {return VXL_NULLPTR; }
+  virtual const vcsl_cartesian_3d *cast_to_cartesian_3d() const {return VXL_NULLPTR; }
+  virtual const vcsl_cylindrical *cast_to_cylindrical() const {return VXL_NULLPTR; }
+  virtual const vcsl_spherical *cast_to_spherical() const {return VXL_NULLPTR; }
 
   //***************************************************************************
   // Status report

--- a/core/vcsl/vcsl_unit.h
+++ b/core/vcsl/vcsl_unit.h
@@ -67,14 +67,14 @@ class vcsl_unit
   // Because VXL does not necessarily use dynamic_cast<>
   //***************************************************************************
 
-  virtual const vcsl_acceleration_unit *cast_to_acceleration_unit() const { return 0; }
-  virtual const vcsl_angle_unit *cast_to_angle_unit() const { return 0; }
-  virtual const vcsl_charge_unit *cast_to_charge_unit() const { return 0; }
-  virtual const vcsl_length_unit *cast_to_length_unit() const { return 0; }
-  virtual const vcsl_mass_unit *cast_to_mass_unit() const { return 0; }
-  virtual const vcsl_temperature_unit *cast_to_temperature_unit() const { return 0; }
-  virtual const vcsl_time_unit *cast_to_time_unit() const { return 0; }
-  virtual const vcsl_velocity_unit *cast_to_velocity_unit() const { return 0; }
+  virtual const vcsl_acceleration_unit *cast_to_acceleration_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_angle_unit *cast_to_angle_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_charge_unit *cast_to_charge_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_length_unit *cast_to_length_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_mass_unit *cast_to_mass_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_temperature_unit *cast_to_temperature_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_time_unit *cast_to_time_unit() const { return VXL_NULLPTR; }
+  virtual const vcsl_velocity_unit *cast_to_velocity_unit() const { return VXL_NULLPTR; }
 };
 
 #endif // vcsl_unit_h_

--- a/core/vgl/algo/vgl_fit_plane_3d.h
+++ b/core/vgl/algo/vgl_fit_plane_3d.h
@@ -53,12 +53,12 @@ class vgl_fit_plane_3d
 
   //:fits a plane to the stored points
   // report issues over an ostream if declared
-  bool fit(const T error_marg, std::ostream* outstream=0);
+  bool fit(const T error_marg, std::ostream* outstream=VXL_NULLPTR);
 
   //:fits a plane returning the smallest singular value
   //:of the data scatter matrix decomposition, a measure
   //:of variance in the direction of the plane normal
-  T fit(std::ostream* outstream=0);
+  T fit(std::ostream* outstream=VXL_NULLPTR);
 
   // Data Access---------------------------------------------------------------
 

--- a/core/vgl/algo/vgl_fit_sphere_3d.h
+++ b/core/vgl/algo/vgl_fit_sphere_3d.h
@@ -79,17 +79,17 @@ class vgl_fit_sphere_3d
   // returns the average distance from the points to the sphere
   // used as an initial condition for Levenberg Marquardt
   // error conditions are reported on outstream
-  T fit_linear(std::ostream* outstream=0);
+  T fit_linear(std::ostream* outstream=VXL_NULLPTR);
 
   //:fits a sphere to the stored points using a linear method
-  bool fit_linear(const T error_marg, std::ostream* outstream=0);
+  bool fit_linear(const T error_marg, std::ostream* outstream=VXL_NULLPTR);
 
   //:fits a sphere nonlinearly to the stored points using Levenberg Marquardt
   // returns the average distance from the points to the sphere
-  T fit(std::ostream* outstream=0, bool verbose = false);
+  T fit(std::ostream* outstream=VXL_NULLPTR, bool verbose = false);
 
   //:fits a sphere nonlinearly to the stored points using Levenberg Marquardt
-  bool fit_(const T error_marg, std::ostream* outstream=0, bool verbose = false);
+  bool fit_(const T error_marg, std::ostream* outstream=VXL_NULLPTR, bool verbose = false);
 
 // Data Access---------------------------------------------------------------
 

--- a/core/vgl/algo/vgl_p_matrix.h
+++ b/core/vgl/algo/vgl_p_matrix.h
@@ -64,10 +64,10 @@ class vgl_p_matrix
   explicit vgl_p_matrix(vnl_matrix_fixed<T, 3, 4> const& P);
   //: Construct from 3x3 matrix A and vector a. P = [A a].
   vgl_p_matrix(const vnl_matrix_fixed<T,3,3>& A, const vnl_vector_fixed<T,3>& a)
-  : svd_(0) { set(A,a); }
+  : svd_(VXL_NULLPTR) { set(A,a); }
   //: Deprecated; use the vnl_matrix_fixed variant instead
   vgl_p_matrix(const vnl_matrix<T>& A, const vnl_vector<T>& a)
-  : svd_(0) { set(A,a); }
+  : svd_(VXL_NULLPTR) { set(A,a); }
 
   vgl_p_matrix(const vgl_p_matrix& P);
  ~vgl_p_matrix();

--- a/core/vgl/algo/vgl_p_matrix.hxx
+++ b/core/vgl/algo/vgl_p_matrix.hxx
@@ -22,7 +22,7 @@
 //
 template <class T>
 vgl_p_matrix<T>::vgl_p_matrix() :
-  svd_(0)
+  svd_(VXL_NULLPTR)
 {
   for (int row_index = 0; row_index < 3; row_index++)
     for (int col_index = 0; col_index < 4; col_index++)
@@ -36,7 +36,7 @@ vgl_p_matrix<T>::vgl_p_matrix() :
 //
 template <class T>
 vgl_p_matrix<T>::vgl_p_matrix(std::istream& i) :
-  svd_(0)
+  svd_(VXL_NULLPTR)
 {
   read_ascii(i);
 }
@@ -45,7 +45,7 @@ vgl_p_matrix<T>::vgl_p_matrix(std::istream& i) :
 //
 template <class T>
 vgl_p_matrix<T>::vgl_p_matrix(vnl_matrix_fixed<T, 3, 4> const& pmatrix) :
-  p_matrix_(pmatrix), svd_(0)
+  p_matrix_(pmatrix), svd_(VXL_NULLPTR)
 {
 }
 
@@ -53,7 +53,7 @@ vgl_p_matrix<T>::vgl_p_matrix(vnl_matrix_fixed<T, 3, 4> const& pmatrix) :
 //
 template <class T>
 vgl_p_matrix<T>::vgl_p_matrix(const T *c_matrix) :
-  p_matrix_(c_matrix), svd_(0)
+  p_matrix_(c_matrix), svd_(VXL_NULLPTR)
 {
 }
 
@@ -62,7 +62,7 @@ vgl_p_matrix<T>::vgl_p_matrix(const T *c_matrix) :
 // - Copy ctor
 template <class T>
 vgl_p_matrix<T>::vgl_p_matrix(const vgl_p_matrix& that) :
-  p_matrix_(that.get_matrix()), svd_(0)
+  p_matrix_(that.get_matrix()), svd_(VXL_NULLPTR)
 {
 }
 
@@ -71,7 +71,7 @@ template <class T>
 vgl_p_matrix<T>& vgl_p_matrix<T>::operator=(const vgl_p_matrix& that)
 {
   p_matrix_ = that.get_matrix();
-  svd_ = 0;
+  svd_ = VXL_NULLPTR;
   return *this;
 }
 
@@ -81,7 +81,7 @@ vgl_p_matrix<T>& vgl_p_matrix<T>::operator=(const vgl_p_matrix& that)
 template <class T>
 vgl_p_matrix<T>::~vgl_p_matrix()
 {
-  delete svd_; svd_ = 0;
+  delete svd_; svd_ = VXL_NULLPTR;
 }
 
 // OPERATIONS
@@ -193,7 +193,7 @@ vgl_p_matrix<T> vgl_p_matrix<T>::read(std::istream& s)
 template <class T>
 vnl_svd<T>* vgl_p_matrix<T>::svd() const
 {
-  if (svd_ == 0) {
+  if (svd_ == VXL_NULLPTR) {
     svd_ = new vnl_svd<T>(p_matrix_.as_ref()); // size 3x4; mutable const
   }
   return svd_;
@@ -202,7 +202,7 @@ vnl_svd<T>* vgl_p_matrix<T>::svd() const
 template <class T>
 void vgl_p_matrix<T>::clear_svd() const
 {
-  delete svd_; svd_ = 0;
+  delete svd_; svd_ = VXL_NULLPTR;
 }
 
 //-----------------------------------------------------------------------------

--- a/core/vgl/algo/vgl_rtree.h
+++ b/core/vgl/algo/vgl_rtree.h
@@ -122,7 +122,7 @@ class vgl_rtree_iterator_base
   unsigned int i;
 
   vgl_rtree_iterator_base(node *root) : current(root), i(0) { }
-  vgl_rtree_iterator_base() : current(0), i(0) { }
+  vgl_rtree_iterator_base() : current(VXL_NULLPTR), i(0) { }
 
   void operator_pp();
   void operator_mm();
@@ -244,11 +244,11 @@ template <class V, class B, class C>
 class vgl_rtree
 {
  public:
-  vgl_rtree() : root(0) { }
+  vgl_rtree() : root(VXL_NULLPTR) { }
   ~vgl_rtree() {
     if (root)
       delete root;
-    root = 0;
+    root = VXL_NULLPTR;
   }
 
   //
@@ -269,7 +269,7 @@ class vgl_rtree
     if (root)
       root->add(v);
     else
-      root = new node(0/*parent*/, v);
+      root = new node(VXL_NULLPTR/*parent*/, v);
   }
 
   //: remove one element from the rtree.
@@ -284,7 +284,7 @@ class vgl_rtree
 
       if (root->total_vts == 0) {
         delete root;
-        root = 0;
+        root = VXL_NULLPTR;
       }
     }
   }
@@ -306,7 +306,7 @@ class vgl_rtree
     i.current->erase(i.i);
     if (root->total_vts == 0) {
       delete root;
-      root = 0;
+      root = VXL_NULLPTR;
     }
   }
 

--- a/core/vgl/algo/vgl_rtree.hxx
+++ b/core/vgl/algo/vgl_rtree.hxx
@@ -33,7 +33,7 @@ vgl_rtree_node<V, B, C>::vgl_rtree_node(node *parent_node, V const &v)
 template <class V, class B, class C>
 vgl_rtree_node<V, B, C>::~vgl_rtree_node()
 {
-  parent = 0;
+  parent = VXL_NULLPTR;
   for (unsigned int i=0; i<local_chs; ++i)
     delete chs[i];
 }
@@ -150,7 +150,7 @@ vgl_rtree_node<V, B, C> *vgl_rtree_node<V, B, C>::add(V const &v)
   }
 
   // all full up, so add the vertex to a suitable child.
-  node *child = 0;
+  node *child = VXL_NULLPTR;
 #if 0
   // get the smallest subtree :
   child = chs[0];
@@ -230,7 +230,7 @@ void vgl_rtree_node<V, B, C>::erase(unsigned int i)
         p->chs[j] = p->chs[p->local_chs];
 
       // delete the node.
-      delete n; n=0;
+      delete n; n=VXL_NULLPTR;
 
       // recompute the bounding boxes all the way up to the root.
       for (node *t = p; t; t=t->parent)
@@ -359,7 +359,7 @@ void vgl_rtree_iterator_base<V, B, C>::operator_pp()
   p = current->parent;
 
   if (!p) { // reached the end
-    current = 0;
+    current = VXL_NULLPTR;
     return;
   }
 

--- a/core/vgl/vgl_closest_point.h
+++ b/core/vgl/vgl_closest_point.h
@@ -265,7 +265,7 @@ template <class T>
 std::pair<vgl_point_3d<T>, vgl_point_3d<T> >
 vgl_closest_points(const vgl_line_3d_2_points<T>& l1,
                    const vgl_line_3d_2_points<T>& l2,
-                   bool* unique=0);
+                   bool* unique=VXL_NULLPTR);
 
 
 //: Return the points of closest approach on two infinite 3D lines.
@@ -279,7 +279,7 @@ template <class T>
 std::pair<vgl_point_3d<T>, vgl_point_3d<T> >
 vgl_closest_points(const vgl_infinite_line_3d<T>& l1,
                    const vgl_infinite_line_3d<T>& l2,
-                   bool* unique=0)
+                   bool* unique=VXL_NULLPTR)
 {
   vgl_line_3d_2_points<T> l21(l1.point(), l1.point_t(T(1)));
   vgl_line_3d_2_points<T> l22(l2.point(), l2.point_t(T(1)));
@@ -297,7 +297,7 @@ template <class T>
 std::pair<vgl_point_3d<T>, vgl_point_3d<T> >
 vgl_closest_points(const vgl_line_segment_3d<T>& l1,
                    const vgl_line_segment_3d<T>& l2,
-                   bool* unique=0);
+                   bool* unique=VXL_NULLPTR);
 
 //: Return the closest point on a line segment \a l to a point \a p in 2D
 // \relatesalso vgl_point_2d

--- a/core/vidl/vidl_convert.cxx
+++ b/core/vidl/vidl_convert.cxx
@@ -514,7 +514,7 @@ vidl_frame_sptr vidl_convert_frame(const vidl_frame_sptr& in_frame,
                                    vidl_pixel_format format)
 {
   if (format == VIDL_PIXEL_FORMAT_UNKNOWN)
-    return NULL;
+    return VXL_NULLPTR;
 
   unsigned ni = in_frame->ni();
   unsigned nj = in_frame->nj();
@@ -525,7 +525,7 @@ vidl_frame_sptr vidl_convert_frame(const vidl_frame_sptr& in_frame,
   if (vidl_convert_frame(*in_frame, *out_frame))
     return out_frame;
 
-  return NULL;
+  return VXL_NULLPTR;
 }
 
 
@@ -535,7 +535,7 @@ vidl_frame_sptr vidl_convert_frame(const vidl_frame_sptr& in_frame,
 vidl_frame_sptr vidl_convert_to_frame(const vil_image_view_base_sptr& image)
 {
   if (!image)
-    return NULL;
+    return VXL_NULLPTR;
   return vidl_convert_to_frame(*image);
 }
 
@@ -597,7 +597,7 @@ vidl_frame_sptr vidl_convert_to_frame(const vil_image_view_base& image)
   else if (num_channels == 4)
     format = VIDL_PIXEL_FORMAT_RGBA_32P;
   else
-    return NULL;
+    return VXL_NULLPTR;
 
   vil_image_view<vxl_byte> img;
   if (image.pixel_format() == VIL_PIXEL_FORMAT_BYTE)
@@ -607,7 +607,7 @@ vidl_frame_sptr vidl_convert_to_frame(const vil_image_view_base& image)
     vil_image_resource_sptr resrc = vil_new_image_resource_of_view(image);
     vil_image_view_base_sptr bimage = vil_convert_cast(vxl_byte(),resrc->get_view());
     if (!bimage)
-      return NULL;
+      return VXL_NULLPTR;
     img = *bimage;
   }
   return new vidl_memory_chunk_frame(ni, nj, format,
@@ -623,7 +623,7 @@ bool vidl_convert_to_view(vidl_frame const& frame,
                           vidl_pixel_color require_color)
 {
   if (frame.pixel_format() == VIDL_PIXEL_FORMAT_UNKNOWN ||
-      frame.data() == NULL)
+      frame.data() == VXL_NULLPTR)
     return false;
 
   vidl_pixel_color in_color = vidl_pixel_format_color(frame.pixel_format());
@@ -760,7 +760,7 @@ vidl_convert_wrap_in_view(vidl_frame const& frame)
   vidl_pixel_traits pt =  vidl_pixel_format_traits(format);
   if ( pt.chroma_shift_x != 0 || pt.chroma_shift_y != 0 ||
        pt.bits_per_pixel % pt.num_channels != 0)
-    return NULL;
+    return VXL_NULLPTR;
 
   unsigned ni = frame.ni(), nj = frame.nj();
   unsigned np = pt.num_channels;
@@ -778,7 +778,7 @@ vidl_convert_wrap_in_view(vidl_frame const& frame)
       break;
     default:
       // Cannot wrap other pixel arrangements
-      return NULL;
+      return VXL_NULLPTR;
   }
   std::ptrdiff_t top_left_offset = 0;
 

--- a/core/vidl/vidl_ffmpeg_ostream_stub.hxx
+++ b/core/vidl/vidl_ffmpeg_ostream_stub.hxx
@@ -21,7 +21,7 @@ struct vidl_ffmpeg_ostream::pimpl
 
 vidl_ffmpeg_ostream
 ::vidl_ffmpeg_ostream()
-  : os_( 0 )
+  : os_( VXL_NULLPTR )
 {
   std::cerr << "vidl_ffmpeg_ostream: warning: ffmpeg support is not compiled in\n";
 }
@@ -29,7 +29,7 @@ vidl_ffmpeg_ostream
 vidl_ffmpeg_ostream
 ::vidl_ffmpeg_ostream(const std::string&,
                       const vidl_ffmpeg_ostream_params&)
-  : os_( 0 )
+  : os_( VXL_NULLPTR )
 {
   std::cerr << "vidl_ffmpeg_ostream: warning: ffmpeg support is not compiled in\n";
 }

--- a/core/vidl/vidl_frame.cxx
+++ b/core/vidl/vidl_frame.cxx
@@ -34,7 +34,7 @@ vidl_frame::unref()
 vidl_memory_chunk_frame::
 vidl_memory_chunk_frame(const vil_image_view_base& image,
                         vidl_pixel_format fmt)
-  : vidl_frame(), memory_(NULL)
+  : vidl_frame(), memory_(VXL_NULLPTR)
 {
   ni_ = image.ni();
   nj_ = image.nj();
@@ -109,7 +109,7 @@ vidl_memory_chunk_frame(const vil_image_view_base& image,
     format_ = VIDL_PIXEL_FORMAT_UNKNOWN;
 
   if (format_ == VIDL_PIXEL_FORMAT_UNKNOWN)
-    memory_ = NULL;
+    memory_ = VXL_NULLPTR;
 }
 
 

--- a/core/vidl/vidl_frame.h
+++ b/core/vidl/vidl_frame.h
@@ -88,7 +88,7 @@ class vidl_shared_frame : public vidl_frame
   public:
     //: Constructor
     vidl_shared_frame():
-      vidl_frame(), buffer_(NULL) {}
+      vidl_frame(), buffer_(VXL_NULLPTR) {}
 
     //: Constructor
     vidl_shared_frame(void * buffer, unsigned ni, unsigned nj, vidl_pixel_format fmt):
@@ -98,7 +98,7 @@ class vidl_shared_frame : public vidl_frame
     virtual ~vidl_shared_frame() {}
 
     //: Make the buffer invalid (data()==0 and size()==0)
-    virtual void invalidate() { buffer_ = 0; vidl_frame::invalidate(); }
+    virtual void invalidate() { buffer_ = VXL_NULLPTR; vidl_frame::invalidate(); }
 
     //: Return a pointer to the first element of data
     virtual void * data() { return buffer_; }
@@ -118,7 +118,7 @@ class vidl_memory_chunk_frame : public vidl_frame
 {
   public:
     //: Constructor
-    vidl_memory_chunk_frame() : memory_(NULL) {}
+    vidl_memory_chunk_frame() : memory_(VXL_NULLPTR) {}
 
     //: Constructor - from a vil_memory_chunk_sptr
     vidl_memory_chunk_frame(unsigned ni, unsigned nj, vidl_pixel_format fmt,
@@ -139,11 +139,11 @@ class vidl_memory_chunk_frame : public vidl_frame
     virtual ~vidl_memory_chunk_frame() {}
 
     //: Make the buffer invalid (data()==0 and size()==0)
-    virtual void invalidate() { memory_ = NULL;  vidl_frame::invalidate(); }
+    virtual void invalidate() { memory_ = VXL_NULLPTR;  vidl_frame::invalidate(); }
 
     //: Return a pointer to the first element of data
-    virtual void * data () { return memory_?memory_->data():NULL; }
-    virtual const void * data () const { return memory_?memory_->data():NULL; }
+    virtual void * data () { return memory_?memory_->data():VXL_NULLPTR; }
+    virtual const void * data () const { return memory_?memory_->data():VXL_NULLPTR; }
 
     //: The size of the buffer in bytes
     virtual unsigned long size() const { return (unsigned long)(memory_?memory_->size():0L); }

--- a/core/vidl/vidl_image_list_istream.cxx
+++ b/core/vidl/vidl_image_list_istream.cxx
@@ -33,7 +33,7 @@ vidl_image_list_istream()
   : index_(INIT_INDEX),
     ni_(0), nj_(0),
     format_(VIDL_PIXEL_FORMAT_UNKNOWN),
-    current_frame_(NULL) {}
+    current_frame_(VXL_NULLPTR) {}
 
 
 //: Constructor
@@ -42,7 +42,7 @@ vidl_image_list_istream(const std::string& glob)
   : index_(INIT_INDEX),
     ni_(0), nj_(0),
     format_(VIDL_PIXEL_FORMAT_UNKNOWN),
-    current_frame_(NULL)
+    current_frame_(VXL_NULLPTR)
 {
   open(glob);
 }
@@ -53,7 +53,7 @@ vidl_image_list_istream(const std::vector<std::string>& paths)
   : index_(INIT_INDEX),
     ni_(0), nj_(0),
     format_(VIDL_PIXEL_FORMAT_UNKNOWN),
-    current_frame_(NULL)
+    current_frame_(VXL_NULLPTR)
 {
   open(paths);
 }
@@ -121,7 +121,7 @@ open(const std::vector<std::string>& paths)
     }
   }
   index_ = INIT_INDEX;
-  current_frame_ = NULL;
+  current_frame_ = VXL_NULLPTR;
   return !image_paths_.empty();
 }
 
@@ -133,7 +133,7 @@ close()
 {
   image_paths_.clear();
   index_ = INIT_INDEX;
-  current_frame_ = NULL;
+  current_frame_ = VXL_NULLPTR;
   ni_ = 0;
   nj_ = 0;
   format_ = VIDL_PIXEL_FORMAT_UNKNOWN;
@@ -145,7 +145,7 @@ bool
 vidl_image_list_istream::
 advance()
 {
-  current_frame_ = NULL;
+  current_frame_ = VXL_NULLPTR;
   if (index_ < image_paths_.size() || index_ == INIT_INDEX )
     return ++index_ < image_paths_.size();
 
@@ -173,7 +173,7 @@ vidl_image_list_istream::current_frame()
     }
     return current_frame_;
   }
-  return NULL;
+  return VXL_NULLPTR;
 }
 
 
@@ -196,7 +196,7 @@ seek_frame(unsigned int frame_nr)
 {
   if (is_open() && frame_nr < image_paths_.size()) {
     if (index_ != frame_nr)
-      current_frame_ = NULL;
+      current_frame_ = VXL_NULLPTR;
     index_ = frame_nr;
     return true;
   }

--- a/core/vidl/vidl_istream_image_resource.cxx
+++ b/core/vidl/vidl_istream_image_resource.cxx
@@ -118,10 +118,10 @@ vidl_istream_image_resource::get_copy_view(unsigned i0, unsigned ni,
                                            unsigned j0, unsigned nj) const
 {
   if (!istream_)
-    return NULL;
+    return VXL_NULLPTR;
 
   int curr_frame = istream_->frame_number();
-  vidl_frame_sptr frame = NULL;
+  vidl_frame_sptr frame = VXL_NULLPTR;
   if (curr_frame == frame_number_)
     frame = istream_->current_frame();
   if (curr_frame + 1 == frame_number_) {
@@ -134,7 +134,7 @@ vidl_istream_image_resource::get_copy_view(unsigned i0, unsigned ni,
   }
 
   if (!frame)
-    return NULL;
+    return VXL_NULLPTR;
 
   // try the wrap the frame in an image view
   vil_image_view_base_sptr view = vidl_convert_wrap_in_view(*frame);
@@ -145,12 +145,12 @@ vidl_istream_image_resource::get_copy_view(unsigned i0, unsigned ni,
     vidl_convert_to_view(*frame,*view);
   }
   if (!view)
-    return NULL;
+    return VXL_NULLPTR;
 
   if (i0 == 0 && j0 == 0 && ni == view->ni() && nj == view->nj())
     return view;
 
-  if (i0 + ni > view->ni() || j0 + nj > view->nj()) return NULL;
+  if (i0 + ni > view->ni() || j0 + nj > view->nj()) return VXL_NULLPTR;
 
   switch (view->pixel_format())
   {
@@ -180,7 +180,7 @@ vidl_istream_image_resource::get_copy_view(unsigned i0, unsigned ni,
     break;
   }
 
-  return NULL;
+  return VXL_NULLPTR;
 }
 
 
@@ -221,6 +221,6 @@ vidl_istream_image_resource::create_empty_view() const
    default:
     break;
   }
-  return NULL;
+  return VXL_NULLPTR;
 }
 

--- a/core/vidl/vidl_istream_image_resource.h
+++ b/core/vidl/vidl_istream_image_resource.h
@@ -59,7 +59,7 @@ class vidl_istream_image_resource : public vil_image_resource
   //: Put the data in this view back into the image source.
   virtual bool put_view(const vil_image_view_base& im, unsigned i0, unsigned j0);
 
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
  private:
   //: try to find the image format and size from the current frame

--- a/core/vidl/vidl_pixel_iterator.cxx
+++ b/core/vidl/vidl_pixel_iterator.cxx
@@ -60,7 +60,7 @@ struct make_pixel_iterator
     if (frame.pixel_format() == pix_type){
       if (vidl_pixel_iterator_valid<pix_type>::value)
         return new vidl_pixel_iterator_of<pix_type>(frame);
-      return (vidl_pixel_iterator*)0;
+      return (vidl_pixel_iterator*)VXL_NULLPTR;
     }
     return make_pixel_iterator<vidl_pixel_format(pix_type-1)>::apply(frame);
   }
@@ -72,7 +72,7 @@ struct make_pixel_iterator<VIDL_PIXEL_FORMAT_UNKNOWN>
 {
   static inline vidl_pixel_iterator* apply(vidl_frame const& /*frame*/)
   {
-    return (vidl_pixel_iterator*)0;
+    return (vidl_pixel_iterator*)VXL_NULLPTR;
   }
 };
 

--- a/core/vil/algo/vil_convolve_1d.h
+++ b/core/vil/algo/vil_convolve_1d.h
@@ -331,7 +331,7 @@ class vil_convolve_1d_resource : public vil_image_resource
   virtual vil_image_view_base_sptr get_copy_view(unsigned i0, unsigned n_i,
                                                  unsigned j0, unsigned n_j) const
   {
-    if (i0 + n_i > src_->ni() || j0 + n_j > src_->nj())  return 0;
+    if (i0 + n_i > src_->ni() || j0 + n_j > src_->nj())  return VXL_NULLPTR;
     const unsigned lsrc = (unsigned) std::max(0,(int)i0 + klo_); // lhs of input window
     const unsigned hsrc = std::min(src_->ni(),i0 + n_i - klo_ + khi_); // 1+rhs of input window.
     const unsigned lboundary = std::min((unsigned) -klo_, i0); // width of lhs boundary area.
@@ -359,7 +359,7 @@ class vil_convolve_1d_resource : public vil_image_resource
 // maybe need a better compiler, maybe there is a code fix - IMS
 #undef macro
      default:
-      return 0;
+      return VXL_NULLPTR;
     }
   }
 
@@ -380,7 +380,7 @@ class vil_convolve_1d_resource : public vil_image_resource
   }
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const
   {
     if (0==std::strcmp(tag, vil_property_read_only))
       return property_value ? (*static_cast<bool*>(property_value)) = true : true;

--- a/core/vil/algo/vil_correlate_1d.h
+++ b/core/vil/algo/vil_correlate_1d.h
@@ -142,7 +142,7 @@ class vil_correlate_1d_resource : public vil_image_resource
   virtual vil_image_view_base_sptr get_copy_view(unsigned i0, unsigned ni,
                                                  unsigned j0, unsigned nj) const
   {
-    if (i0 + ni > src_->ni() || j0 + nj > src_->nj())  return 0;
+    if (i0 + ni > src_->ni() || j0 + nj > src_->nj())  return VXL_NULLPTR;
     const unsigned lsrc = (unsigned)std::max(0,int(i0+klo_)); // lhs of input window
     const unsigned hsrc = std::min(src_->ni(),(unsigned int)(i0+ni-klo_+khi_)); // 1+rhs of input window.
     const unsigned lboundary = std::min((unsigned) -klo_, i0); // width of lhs boundary area.
@@ -170,7 +170,7 @@ class vil_correlate_1d_resource : public vil_image_resource
 // maybe need a better compiler, maybe there is a code fix - IMS
 #undef macro
       default:
-        return 0;
+        return VXL_NULLPTR;
     }
   }
 
@@ -191,7 +191,7 @@ class vil_correlate_1d_resource : public vil_image_resource
   }
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const
   {
     if (0==std::strcmp(tag, vil_property_read_only))
       return property_value ? (*static_cast<bool*>(property_value)) = true : true;

--- a/core/vil/file_formats/vil_geotiff_header.h
+++ b/core/vil/file_formats/vil_geotiff_header.h
@@ -61,7 +61,7 @@ class vil_geotiff_header
   bool get_key_value(geokey_t key, void** value,
                      int& size, int& length, tagtype_t& type);
 
-  void print_gtif(){ if (gtif_) GTIFPrint(gtif_, 0, 0); }
+  void print_gtif(){ if (gtif_) GTIFPrint(gtif_, VXL_NULLPTR, VXL_NULLPTR); }
 
  private:
 

--- a/core/vil/file_formats/vil_iris.h
+++ b/core/vil/file_formats/vil_iris.h
@@ -63,7 +63,7 @@ class vil_iris_generic_image : public vil_image_resource
   virtual bool put_view( vil_image_view_base const& buf, unsigned int x0, unsigned int y0);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
  protected:
   vil_stream* is_;

--- a/core/vil/file_formats/vil_jpeg_destination_mgr.cxx
+++ b/core/vil/file_formats/vil_jpeg_destination_mgr.cxx
@@ -140,7 +140,7 @@ vil_jpeg_stream_dst_rewind(j_compress_ptr cinfo, vil_stream *vs)
 {
   vil_jpeg_dstptr dst = ( vil_jpeg_dstptr )( cinfo->dest );
   { // verify
-    assert(dst != 0);
+    assert(dst != VXL_NULLPTR);
     assert(dst->stream == vs);
   }
 

--- a/core/vil/file_formats/vil_jpeg_source_mgr.cxx
+++ b/core/vil/file_formats/vil_jpeg_source_mgr.cxx
@@ -199,7 +199,7 @@ void
 vil_jpeg_stream_src_rewind(j_decompress_ptr cinfo, vil_stream *vs)
 {
   // verify
-  assert((vil_jpeg_srcptr)(cinfo->src) != 0);
+  assert((vil_jpeg_srcptr)(cinfo->src) != VXL_NULLPTR);
   assert(((vil_jpeg_srcptr)(cinfo->src))->stream == vs);
 
   cinfo->src->bytes_in_buffer = 0; // forces fill_input_buffer on first read

--- a/core/vil/file_formats/vil_nitf2_field_definition.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_definition.cxx
@@ -45,7 +45,7 @@ vil_nitf2_field_definition(std::string tag,
     description(description)
 {
   assert(!tag.empty() && "vil_nitf2_field_definition:: null tag");
-  assert(formatter != 0 && "vil_nitf2_field_definition:: null formatter");
+  assert(formatter != VXL_NULLPTR && "vil_nitf2_field_definition:: null formatter");
 }
 
 vil_nitf2_field_definition_node* vil_nitf2_field_definition::copy() const

--- a/core/vil/file_formats/vil_nitf2_field_definition.h
+++ b/core/vil/file_formats/vil_nitf2_field_definition.h
@@ -97,9 +97,9 @@ class vil_nitf2_field_definition : public vil_nitf2_field_definition_node
     // whether this field may be unspecified (all blanks)
     bool blanks_ok = false,
     // function, when specified, that overrides formatter's field width.
-    vil_nitf2_field_functor<int>* width_functor = 0,
+    vil_nitf2_field_functor<int>* width_functor = VXL_NULLPTR,
     // conditional field predicate; 0 for required fields
-    vil_nitf2_field_functor<bool>* condition_functor = 0,
+    vil_nitf2_field_functor<bool>* condition_functor = VXL_NULLPTR,
     // additional documentation fields
     std::string units = "",
     std::string description = "");
@@ -129,10 +129,10 @@ class vil_nitf2_field_definitions : public std::list<vil_nitf2_field_definition_
     // whether this field may be unspecified (all blank)
     bool blanks_ok = false,
     // function, when specified, that overrides formatter's field width
-    vil_nitf2_field_functor<int>* width_functor = 0,
+    vil_nitf2_field_functor<int>* width_functor = VXL_NULLPTR,
     // predicate that returns whether this conditional field is present;
     // 0 for required fields
-    vil_nitf2_field_functor<bool>* condition_functor = 0,
+    vil_nitf2_field_functor<bool>* condition_functor = VXL_NULLPTR,
     std::string units = "",
     std::string description = "");
 

--- a/core/vil/file_formats/vil_nitf2_image.h
+++ b/core/vil/file_formats/vil_nitf2_image.h
@@ -136,7 +136,7 @@ class vil_nitf2_image : public vil_blocked_image_resource
 
   virtual vil_image_view_base_sptr get_block( unsigned int blockIndexX, unsigned int blockIndexY ) const;
 
-  virtual bool get_property (char const *tag, void *property_value=0) const;
+  virtual bool get_property (char const *tag, void *property_value=VXL_NULLPTR) const;
 
   //const vil_nitf2_header& getFileHeader() const;
   const std::vector< vil_nitf2_image_subheader* >& get_image_headers() const

--- a/core/vil/file_formats/vil_nitf2_scalar_field.h
+++ b/core/vil/file_formats/vil_nitf2_scalar_field.h
@@ -48,7 +48,7 @@ class vil_nitf2_scalar_field : public vil_nitf2_field
   static vil_nitf2_scalar_field* read(vil_nitf2_istream& input,
                                       vil_nitf2_field_definition* definition,
                                       int variable_width = -1,
-                                      bool* error = 0);
+                                      bool* error = VXL_NULLPTR);
 
   virtual field_tree* get_tree() const;
 

--- a/core/vil/file_formats/vil_nitf2_tagged_record_definition.h
+++ b/core/vil/file_formats/vil_nitf2_tagged_record_definition.h
@@ -47,10 +47,10 @@ class vil_nitf2_tagged_record_definition
     // whether this field may be unspecified (all blank)
     bool blanks_ok = false,
     // function, when specified, that overrides formatter's width
-    vil_nitf2_field_functor<int>* width_functor = 0,
+    vil_nitf2_field_functor<int>* width_functor = VXL_NULLPTR,
     // predicate that returns whether this conditional field is present;
     // 0 for required fields
-    vil_nitf2_field_functor<bool>* condition_functor = 0,
+    vil_nitf2_field_functor<bool>* condition_functor = VXL_NULLPTR,
     std::string units = "",
     std::string description = "");
 
@@ -105,7 +105,7 @@ class vil_nitf2_tagged_record_definition
 
   // Constructor
   vil_nitf2_tagged_record_definition(std::string name, std::string pretty_name,
-                                     vil_nitf2_field_definitions* defs = 0);
+                                     vil_nitf2_field_definitions* defs = VXL_NULLPTR);
 
 #if 0
   // to implement

--- a/core/vil/file_formats/vil_nitf2_typed_field_formatter.h
+++ b/core/vil/file_formats/vil_nitf2_typed_field_formatter.h
@@ -81,9 +81,9 @@ vil_nitf2_scalar_field* vil_nitf2_typed_field_formatter<T>::read_field(
 {
   T value;
   if (read( input, value, out_blank )) {
-    return new vil_nitf2_typed_scalar_field<T>(value, 0);
+    return new vil_nitf2_typed_scalar_field<T>(value, VXL_NULLPTR);
   }
-  return 0;
+  return VXL_NULLPTR;
 }
 
 template<typename T>

--- a/core/vil/file_formats/vil_png.h
+++ b/core/vil/file_formats/vil_png.h
@@ -73,7 +73,7 @@ class vil_png_image : public vil_image_resource
   virtual bool put_view(const vil_image_view_base& im, unsigned i0, unsigned j0);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 };
 
 #endif // vil_png_file_format_h_

--- a/core/vil/file_formats/vil_pyramid_image_list.h
+++ b/core/vil/file_formats/vil_pyramid_image_list.h
@@ -32,7 +32,7 @@ class vil_pyramid_image_list_format : public vil_file_format
 
   //: should return 0 so that no attempt is made to create a single image resource
   virtual vil_image_resource_sptr make_input_image(vil_stream* /*vs*/)
-  { return 0; }
+  { return VXL_NULLPTR; }
 
   //: Read a pyramid resource. Image list files are stored in directory.
   virtual vil_pyramid_image_resource_sptr
@@ -59,7 +59,7 @@ class vil_pyramid_image_list_format : public vil_file_format
                                                     unsigned int /*nj*/,
                                                     unsigned int /*nplanes*/,
                                                     enum vil_pixel_format)
-  { return 0; }
+  { return VXL_NULLPTR; }
 
   virtual vil_pyramid_image_resource_sptr
     make_pyramid_output_image(char const* directory);
@@ -145,7 +145,7 @@ class vil_pyramid_image_list : public vil_pyramid_image_resource
     if (levels_.size()>0)
       return levels_[0]->image_->get_copy_view(i0, n_i, j0, n_j);
     else
-      return 0;
+      return VXL_NULLPTR;
   }
 
   //: Return a string describing the file format.
@@ -171,7 +171,7 @@ class vil_pyramid_image_list : public vil_pyramid_image_resource
 
   //: Get a level image resource of the pyramid
   inline vil_image_resource_sptr get_level(const unsigned int level) const
-  { if (level<levels_.size()) return levels_[level]->image_; else return 0; }
+  { if (level<levels_.size()) return levels_[level]->image_; else return VXL_NULLPTR; }
 
   //:Get a partial view from the image from a specified pyramid level
   virtual vil_image_view_base_sptr get_copy_view(unsigned int i0, unsigned int n_i,

--- a/core/vil/io/vil_io_smart_ptr.hxx
+++ b/core/vil/io/vil_io_smart_ptr.hxx
@@ -20,7 +20,7 @@ void vsl_b_write(vsl_b_ostream & os, const vil_smart_ptr<T> &p)
   const short io_version_no = 2;
   vsl_b_write(os, io_version_no);
 
-  if (p.ptr() == 0)  // Deal with Null pointers first.
+  if (p.ptr() == VXL_NULLPTR)  // Deal with Null pointers first.
   {
     vsl_b_write(os, true);
     vsl_b_write(os, 0ul); // Use 0 to indicate a null pointer.
@@ -82,12 +82,12 @@ void vsl_b_read(vsl_b_istream &is, vil_smart_ptr<T> &p)
 
     if (id == 0) // Deal with Null pointers first.
     {
-      p = 0;
+      p = VXL_NULLPTR;
       return;
     }
 
     T * pointer = static_cast<T *>( is.get_serialisation_pointer(id));
-    if (first_time != (pointer == 0))
+    if (first_time != (pointer == VXL_NULLPTR))
     {
       // This checks that the saving stream and reading stream
       // both agree on whether or not this is the first time they
@@ -98,7 +98,7 @@ void vsl_b_read(vsl_b_istream &is, vil_smart_ptr<T> &p)
       return;
     }
 
-    if (pointer == 0)
+    if (pointer == VXL_NULLPTR)
     {
       // If you get an error in the next line, it could be because your type T
       // has no vsl_b_read(vsl_b_ostream&,T*&)  defined on it.

--- a/core/vil/vil_cached_image_resource.h
+++ b/core/vil/vil_cached_image_resource.h
@@ -58,7 +58,7 @@ class vil_cached_image_resource : public vil_blocked_image_resource
 
 
   //: Extra property information
- inline virtual bool get_property(char const* tag, void* property_value = 0) const
+ inline virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const
     {return bir_->get_property(tag, property_value);}
 
  protected:

--- a/core/vil/vil_clamp.h
+++ b/core/vil/vil_clamp.h
@@ -68,7 +68,7 @@ class vil_clamp_image_resource : public vil_image_resource
   virtual bool put_view(const vil_image_view_base& /*im*/, unsigned /*i0*/, unsigned /*j0*/) { return false; }
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const;
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const;
 
  protected:
   //: Reference to underlying image source

--- a/core/vil/vil_convert.h
+++ b/core/vil/vil_convert.h
@@ -757,7 +757,7 @@ inline vil_image_view_base_sptr vil_convert_cast(outP /*dummy*/,
     default:
       vil_exception_warning(vil_exception_unsupported_pixel_format(
         src->pixel_format(), "vil_convert_cast") );
-      dest = 0;
+      dest = VXL_NULLPTR;
   }
   return dest;
 }
@@ -863,7 +863,7 @@ macro(VIL_PIXEL_FORMAT_DOUBLE , double )
   default:
     vil_exception_warning(vil_exception_unsupported_pixel_format(
       src->pixel_format(), "vil_convert_round") );
-    dest=0;
+    dest=VXL_NULLPTR;
   }
   return dest;
 }

--- a/core/vil/vil_copy.cxx
+++ b/core/vil/vil_copy.cxx
@@ -86,12 +86,12 @@ bool vil_copy_deep(const vil_image_resource_sptr &src, vil_image_resource_sptr &
 
 vil_image_resource_sptr vil_copy_deep( const vil_image_resource_sptr &src )
 {
-  if(src == NULL) return NULL;
+  if(src == VXL_NULLPTR) return VXL_NULLPTR;
   vil_image_resource_sptr result = vil_new_image_resource(src->ni(), src->nj(), src);
   bool copy_r = vil_copy_deep(src, result);
   if(!copy_r)
   {
-    return NULL;
+    return VXL_NULLPTR;
   }
   return result;
 }

--- a/core/vil/vil_crop.h
+++ b/core/vil/vil_crop.h
@@ -60,7 +60,7 @@ class vil_crop_image_resource : public vil_image_resource
   }
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const
   {
     return src_->get_property(tag, property_value);
   }

--- a/core/vil/vil_decimate.h
+++ b/core/vil/vil_decimate.h
@@ -67,7 +67,7 @@ class vil_decimate_image_resource : public vil_image_resource
   virtual bool put_view(const vil_image_view_base& im, unsigned i0, unsigned j0);
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const
   {
     return src_->get_property(tag, property_value);
   }

--- a/core/vil/vil_flip.h
+++ b/core/vil/vil_flip.h
@@ -70,7 +70,7 @@ class vil_flip_lr_image_resource : public vil_image_resource
                         unsigned j0);
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const {
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const {
     return src_->get_property(tag, property_value); }
 
 
@@ -111,7 +111,7 @@ class vil_flip_ud_image_resource : public vil_image_resource
                         unsigned j0);
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const {
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const {
     return src_->get_property(tag, property_value); }
 
  protected:

--- a/core/vil/vil_image_resource_plugin.h
+++ b/core/vil/vil_image_resource_plugin.h
@@ -41,9 +41,9 @@ class vil_image_resource_plugin : public vil_image_resource
   virtual unsigned nj() const { return 0; }
   virtual unsigned nplanes() const { return 0; }
 
-  virtual bool get_property(char const * /*tag*/, void * /*property_value*/=0) const { return false; }
+  virtual bool get_property(char const * /*tag*/, void * /*property_value*/=VXL_NULLPTR) const { return false; }
   virtual vil_image_view_base_sptr get_copy_view(unsigned /*i0*/, unsigned /*ni*/, unsigned /*j0*/, unsigned /*nj*/) const
-  { return vil_image_view_base_sptr(0); }
+  { return vil_image_view_base_sptr(VXL_NULLPTR); }
 
   virtual bool put_view(vil_image_view_base const& /*im*/, unsigned /*i0*/, unsigned /*j0*/) { return false; }
 

--- a/core/vil/vil_image_view.h
+++ b/core/vil/vil_image_view.h
@@ -61,7 +61,7 @@ class vil_image_view : public vil_image_view_base
  public:
   //: Dflt ctor
   //  Creates an empty one-plane image.
-  vil_image_view(): top_left_(0),istep_(0),jstep_(0),planestep_(0) {}
+  vil_image_view(): top_left_(VXL_NULLPTR),istep_(0),jstep_(0),planestep_(0) {}
 
   //: Create an image of ni x nj pixels in (n_planes * n_interleaved_planes) planes
   //  If n_interleaved_planes > 1, the planes are interleaved.

--- a/core/vil/vil_image_view.hxx
+++ b/core/vil/vil_image_view.hxx
@@ -36,7 +36,7 @@
 template<class T>
 vil_image_view<T>::vil_image_view(unsigned n_i, unsigned n_j, unsigned n_planes,
                                   unsigned n_interleaved_planes)
-: top_left_(0), istep_(n_interleaved_planes)
+: top_left_(VXL_NULLPTR), istep_(n_interleaved_planes)
 {
   assert(n_planes==1 || n_interleaved_planes==1);
   assert(vil_pixel_format_of(T()) == VIL_PIXEL_FORMAT_UNKNOWN ||
@@ -94,7 +94,7 @@ vil_image_view<T>::vil_image_view(vil_memory_chunk_sptr const& mem_chunk,
 template<class T>
 vil_image_view<T>::vil_image_view(const vil_image_view<T>& that)
 : vil_image_view_base(that.ni(),that.nj(),that.nplanes()),
-  top_left_(0), istep_(0), jstep_(0), planestep_(0), ptr_(0)
+  top_left_(VXL_NULLPTR), istep_(0), jstep_(0), planestep_(0), ptr_(VXL_NULLPTR)
 {
   operator=( static_cast<vil_image_view_base const&>(that) );
 }
@@ -104,7 +104,7 @@ vil_image_view<T>::vil_image_view(const vil_image_view<T>& that)
 // types are incompatible) it will set itself to empty.
 template<class T>
 vil_image_view<T>::vil_image_view(const vil_image_view_base& that):
-top_left_(0), istep_(0), jstep_(0), planestep_(0), ptr_(0)
+top_left_(VXL_NULLPTR), istep_(0), jstep_(0), planestep_(0), ptr_(VXL_NULLPTR)
 {
   operator=(that);
 }
@@ -114,7 +114,7 @@ top_left_(0), istep_(0), jstep_(0), planestep_(0), ptr_(0)
 // types are incompatible) it will set itself to empty.
 template <class T>
 vil_image_view<T>::vil_image_view(const vil_image_view_base_sptr& that):
-top_left_(0), istep_(0), jstep_(0), planestep_(0), ptr_(0)
+top_left_(VXL_NULLPTR), istep_(0), jstep_(0), planestep_(0), ptr_(VXL_NULLPTR)
 {
   operator=(that);
 }
@@ -585,7 +585,7 @@ const vil_image_view<T> & vil_image_view<T>::operator= (const vil_image_view_bas
 
   vil_exception_warning(vil_exception_pixel_formats_incompatible(
     rhs.pixel_format(), this->pixel_format(), "vil_image_view::operator =") );
-  set_to_memory(0, 0, 0, 0, 0, 0, 0);
+  set_to_memory(VXL_NULLPTR, 0, 0, 0, 0, 0, 0);
   return *this;
 }
 
@@ -878,7 +878,7 @@ template <class T> std::string vil_image_view_type_name(T*);
 template <class T>
 std::string vil_image_view<T>::is_a() const
 {
-  return vil_image_view_type_name(static_cast<T*>(0));
+  return vil_image_view_type_name(static_cast<T*>(VXL_NULLPTR));
 }
 
 #define VIL_IMAGE_VIEW_INSTANTIATE(T) \

--- a/core/vil/vil_math.h
+++ b/core/vil/vil_math.h
@@ -378,7 +378,7 @@ template< class sumT >
 inline bool vil_math_mean_and_variance(sumT& mean, sumT& var, const vil_image_resource_sptr im,
                                        const vil_image_view<bool> & mask, unsigned p)
 {
-  if(im == NULL || im->get_view() == NULL)
+  if(im == VXL_NULLPTR || im->get_view() == VXL_NULLPTR)
   {
     return false;
   }

--- a/core/vil/vil_memory_image.h
+++ b/core/vil/vil_memory_image.h
@@ -78,7 +78,7 @@ class vil_memory_image : public vil_image_resource
   virtual bool put_view(const vil_image_view_base& im, unsigned i0, unsigned j0);
 
   //: Declare that this is an in-memory image which is not read-only
-  bool get_property(char const * tag, void * prop = 0) const
+  bool get_property(char const * tag, void * prop = VXL_NULLPTR) const
   {
     if (0==std::strcmp(tag, vil_property_memory))
       return prop ? (*static_cast<bool*>(prop)) = true : true;

--- a/core/vil/vil_new.h
+++ b/core/vil/vil_new.h
@@ -76,7 +76,7 @@ vil_image_resource_sptr vil_new_image_resource(char const* filename,
                                                unsigned ni, unsigned nj,
                                                unsigned nplanes,
                                                vil_pixel_format format,
-                                               char const* file_format = 0);
+                                               char const* file_format = VXL_NULLPTR);
 
 //: Make a new vil_image_resource, writing to file "filename", size ni x nj, copying pixel format etc from "prototype".
 // \relatesalso vil_image_resource
@@ -84,7 +84,7 @@ vil_image_resource_sptr vil_new_image_resource(char const* filename,
                                                unsigned ni, unsigned nj,
                                                unsigned nplanes,
                                                vil_image_resource_sptr const &prototype,
-                                               char const* format = 0);
+                                               char const* format = VXL_NULLPTR);
 
 //: Make a new vil_image_resource, writing to stream "os", size ni x nj, copying pixel format etc from "prototype".
 // \relatesalso vil_image_resource
@@ -92,20 +92,20 @@ vil_image_resource_sptr vil_new_image_resource(vil_stream* os,
                                                unsigned ni, unsigned nj,
                                                unsigned nplanes,
                                                vil_image_resource_sptr const& prototype,
-                                               char const* file_format = 0);
+                                               char const* file_format = VXL_NULLPTR);
 //: Make a new blocked resource file
 vil_blocked_image_resource_sptr
 vil_new_blocked_image_resource(vil_stream* os, unsigned ni, unsigned nj,
                                unsigned nplanes, vil_pixel_format format,
                                unsigned size_block_i, unsigned size_block_j,
-                               char const* file_format = 0);
+                               char const* file_format = VXL_NULLPTR);
 
 //: Make a new blocked resource file
 vil_blocked_image_resource_sptr
 vil_new_blocked_image_resource(char const* filename, unsigned ni, unsigned nj,
                                unsigned nplanes, vil_pixel_format format,
                                unsigned size_block_i, unsigned size_block_j,
-                               char const* file_format = 0);
+                               char const* file_format = VXL_NULLPTR);
 
 //: create a blocked interface around any image resource
 // For zero size blocks, appropriate default blocking is created

--- a/core/vil/vil_plane.h
+++ b/core/vil/vil_plane.h
@@ -77,7 +77,7 @@ class vil_plane_image_resource : public vil_image_resource
                         unsigned j0);
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const {
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const {
     return src_->get_property(tag, property_value); }
 
  protected:

--- a/core/vil/vil_pyramid_image_view.hxx
+++ b/core/vil/vil_pyramid_image_view.hxx
@@ -45,7 +45,7 @@ vil_pyramid_image_view<T>::vil_pyramid_image_view(vil_image_view_base_sptr image
     // scale down the image
     scale/=2.0;
     img = static_cast<vil_image_view<T>*>(images_[l-1].ptr());
-    vil_image_view_base_sptr new_img=0;
+    vil_image_view_base_sptr new_img=VXL_NULLPTR;
     scale_down(*img, new_img);
     images_[l] = new_img;
     scales_[l] = scale;

--- a/core/vil/vil_stream_section.cxx
+++ b/core/vil/vil_stream_section.cxx
@@ -22,7 +22,7 @@ vil_stream_section::vil_stream_section(vil_stream *underlying, int begin)
   , end_((vil_streampos)(-1L))
   , current_(begin)
 {
-  assert(underlying != 0);
+  assert(underlying != VXL_NULLPTR);
   assert(begin >= 0);
   underlying_->ref();
 }
@@ -33,7 +33,7 @@ vil_stream_section::vil_stream_section(vil_stream *underlying, int begin, int en
   , end_(end)
   , current_(begin)
 {
-  assert(underlying != 0);
+  assert(underlying != VXL_NULLPTR);
   assert(begin >= 0);
   assert(begin <= end);
   underlying->ref();

--- a/core/vil/vil_transpose.h
+++ b/core/vil/vil_transpose.h
@@ -56,7 +56,7 @@ class vil_transpose_image_resource : public vil_image_resource
   virtual bool put_view(const vil_image_view_base& im, unsigned i0, unsigned j0);
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const {
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const {
     return src_->get_property(tag, property_value); }
 };
 

--- a/core/vil1/file_formats/vil1_bmp.cxx
+++ b/core/vil1/file_formats/vil1_bmp.cxx
@@ -300,7 +300,7 @@ bool vil1_bmp_generic_image::write_header()
 
 bool vil1_bmp_generic_image::get_section(void* ib, int x0, int y0, int w, int h) const
 {
-  assert(ib != 0);
+  assert(ib != VXL_NULLPTR);
   char *bp = static_cast<char*>(ib);
 
   //
@@ -329,7 +329,7 @@ bool vil1_bmp_generic_image::get_section(void* ib, int x0, int y0, int w, int h)
 
 bool vil1_bmp_generic_image::put_section(void const *ib, int x0, int y0, int xs, int ys)
 {
-  assert(ib != 0);
+  assert(ib != VXL_NULLPTR);
   int bypp = (components() * bits_per_component() +7) / 8;
   int rowlen = width() * bypp;
   rowlen += (3-(rowlen-1)%4); // round up to a multiple of 4

--- a/core/vil1/file_formats/vil1_bmp.h
+++ b/core/vil1/file_formats/vil1_bmp.h
@@ -78,7 +78,7 @@ class vil1_bmp_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
  private:
   vil1_stream* is_;

--- a/core/vil1/file_formats/vil1_gen.h
+++ b/core/vil1/file_formats/vil1_gen.h
@@ -34,7 +34,7 @@ class vil1_gen_file_format : public vil1_file_format
                                              int /*height*/,
                                              int /*components*/,
                                              int /*bits_per_component*/,
-                                             vil1_component_format /*format*/) { return 0; }
+                                             vil1_component_format /*format*/) { return VXL_NULLPTR; }
 };
 
 enum vil1_gen_type
@@ -82,7 +82,7 @@ class vil1_gen_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
 };
 

--- a/core/vil1/file_formats/vil1_gif.h
+++ b/core/vil1/file_formats/vil1_gif.h
@@ -37,7 +37,7 @@ struct vil1_gif_color_map
   int size;
   char *cmap;
   vil1_gif_color_map(int sz) : size(sz), cmap(new char [3*size]) { }
-  ~vil1_gif_color_map() { delete [] cmap; cmap = 0; }
+  ~vil1_gif_color_map() { delete [] cmap; cmap = VXL_NULLPTR; }
 };
 
 struct vil1_gif_image_record
@@ -79,7 +79,7 @@ struct vil1_gif_loader_saver : public vil1_image_impl
   bool put_section(int, void const *, int, int, int, int) { return false; }
 
   char const *file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
  private:
   vil1_stream *s;

--- a/core/vil1/file_formats/vil1_iris.h
+++ b/core/vil1/file_formats/vil1_iris.h
@@ -73,7 +73,7 @@ class vil1_iris_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
 //protected:
   vil1_stream* is_;

--- a/core/vil1/file_formats/vil1_jpeg.h
+++ b/core/vil1/file_formats/vil1_jpeg.h
@@ -63,7 +63,7 @@ class vil1_jpeg_generic_image : public vil1_image_impl
   int bits_per_component() const;
   vil1_component_format component_format() const;
   char const *file_format() const; // returns "jpeg"
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
   bool get_section(void       *buf, int x0, int y0, int w, int h) const;
   bool put_section(void const *buf, int x0, int y0, int w, int h);

--- a/core/vil1/file_formats/vil1_jpeg_destination_mgr.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_destination_mgr.cxx
@@ -136,7 +136,7 @@ vil1_jpeg_stream_dst_rewind(j_compress_ptr cinfo, vil1_stream *vs)
 {
   vil1_jpeg_dstptr dst = ( vil1_jpeg_dstptr )( cinfo->dest );
   { // verify
-    assert(dst != 0);
+    assert(dst != VXL_NULLPTR);
     assert(dst->stream == vs);
   }
 

--- a/core/vil1/file_formats/vil1_jpeg_source_mgr.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_source_mgr.cxx
@@ -193,7 +193,7 @@ vil1_jpeg_stream_src_rewind(j_decompress_ptr cinfo, vil1_stream *vs)
 {
   { // verify
     vil1_jpeg_srcptr src = ( vil1_jpeg_srcptr )( cinfo->src );
-    assert(src != 0);
+    assert(src != VXL_NULLPTR);
     assert(src->stream == vs);
     if (!src) return;
   }

--- a/core/vil1/file_formats/vil1_mit.cxx
+++ b/core/vil1/file_formats/vil1_mit.cxx
@@ -199,7 +199,7 @@ bool vil1_mit_generic_image::write_header()
 
 bool vil1_mit_generic_image::get_section(void* buf, int x0, int y0, int xs, int ys) const
 {
-  assert(buf != 0);
+  assert(buf != VXL_NULLPTR);
 
   vil1_streampos offset = 8; // fsm: was 4
 
@@ -223,7 +223,7 @@ bool vil1_mit_generic_image::get_section(void* buf, int x0, int y0, int xs, int 
 
 bool vil1_mit_generic_image::put_section(void const* buf, int x0, int y0, int xs, int ys)
 {
-  assert(buf != 0);
+  assert(buf != VXL_NULLPTR);
 
   int skip = bytes_per_pixel() * (width_ - xs);
 

--- a/core/vil1/file_formats/vil1_mit.h
+++ b/core/vil1/file_formats/vil1_mit.h
@@ -111,7 +111,7 @@ class vil1_mit_generic_image : public vil1_image_impl
   //virtual bool get_section_byte(void* buf, int x0, int y0, int width, int height) const;
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
 };
 

--- a/core/vil1/file_formats/vil1_png.cxx
+++ b/core/vil1/file_formats/vil1_png.cxx
@@ -228,7 +228,7 @@ struct vil1_png_structures
       }
     }
     else {
-      assert(rows != 0);
+      assert(rows != VXL_NULLPTR);
     }
 
     return rows;

--- a/core/vil1/file_formats/vil1_png.h
+++ b/core/vil1/file_formats/vil1_png.h
@@ -79,7 +79,7 @@ class vil1_png_generic_image : public vil1_image_impl
   //virtual bool get_section_byte(void* buf, int x0, int y0, int width, int height) const;
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
 };
 

--- a/core/vil1/file_formats/vil1_pnm.h
+++ b/core/vil1/file_formats/vil1_pnm.h
@@ -75,7 +75,7 @@ class vil1_pnm_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
 };
 

--- a/core/vil1/file_formats/vil1_ras.h
+++ b/core/vil1/file_formats/vil1_ras.h
@@ -76,7 +76,7 @@ class vil1_ras_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
   vil1_image get_plane(unsigned int p) const;
 };
 

--- a/core/vil1/file_formats/vil1_tiff.h
+++ b/core/vil1/file_formats/vil1_tiff.h
@@ -77,8 +77,8 @@ class vil1_tiff_generic_image : public vil1_image_impl
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
-  bool set_property(char const *tag, const void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
+  bool set_property(char const *tag, const void *prop = VXL_NULLPTR) const;
 
   vil1_image get_plane(unsigned int p) const;
 };

--- a/core/vil1/file_formats/vil1_viff.h
+++ b/core/vil1/file_formats/vil1_viff.h
@@ -95,7 +95,7 @@ class vil1_viff_generic_image : public vil1_image_impl
   virtual bool get_section_byte(void* buf, int x0, int y0, int width, int height) const;
 
   char const* file_format() const;
-  bool get_property(char const *tag, void *prop = 0) const;
+  bool get_property(char const *tag, void *prop = VXL_NULLPTR) const;
 
   //: User defined spare values in header
   vxl_uint_32 ispare1() const { return header_.ispare1;}

--- a/core/vil1/vil1_block_cache_image_impl.h
+++ b/core/vil1/vil1_block_cache_image_impl.h
@@ -52,7 +52,7 @@ class vil1_block_cache_image_impl : public vil1_image_impl
   bool put_section(void const *buf, int x0, int y0, int w, int h); // write-through
 
   //: Get info about block-characteristics
-  bool get_property(char const *tag, void *property_value_out = 0) const;
+  bool get_property(char const *tag, void *property_value_out = VXL_NULLPTR) const;
 
   //: Return the name of the class;
   virtual std::string is_a() const;

--- a/core/vil1/vil1_convolve.hxx
+++ b/core/vil1/vil1_convolve.hxx
@@ -22,14 +22,14 @@ void vil1_convolve_separable(I1 const kernel[], unsigned N,
   std::cerr << "convolve x..." << std::flush;
   vil1_convolve_1d_x(K,
                      vil1_convolve_signal_2d<I2 const>(bufc.row_array(), 0, 0, w,  0, 0, h),
-                     (AC*)0,
+                     (AC*)VXL_NULLPTR,
                      vil1_convolve_signal_2d<AC     >(tmp.row_array(), 0, 0, w,  0, 0, h),
                      vil1_convolve_trim, vil1_convolve_trim);
   std::cerr << "done\n"
            << "convolve y...";
   vil1_convolve_1d_y(K,
                      vil1_convolve_signal_2d<AC const>(tmpc.row_array(), 0, 0, w,  0, 0, h),
-                     (AC*)0,
+                     (AC*)VXL_NULLPTR,
                      vil1_convolve_signal_2d<O       >(out.row_array(), 0, 0, w,  0, 0, h),
                      vil1_convolve_trim, vil1_convolve_trim);
   std::cerr << "done\n";

--- a/core/vil1/vil1_convolve_simple.hxx
+++ b/core/vil1/vil1_convolve_simple.hxx
@@ -124,12 +124,12 @@ void vil1_convolve_simple(vil1_memory_image_of<I1> const &input1,    // input 1
   static void (*f)(I1 const * const *, unsigned, unsigned,
                    I2 const * const *, unsigned, unsigned,
                    AC *,
-                   O        * const *) = 0;
+                   O        * const *) = VXL_NULLPTR;
   if (!f)
     f = vil1_convolve_simple;
   (*f)(const_cast<I1 const * const *>(/* xxx */&in1[0]), w1, h1,
        const_cast<I2 const * const *>(/* xxx */&in2[0]), w2, h2,
-       (AC*)0,
+       (AC*)VXL_NULLPTR,
        const_cast<O        * const *>(/* xxx */&out[0]));
 }
 
@@ -155,12 +155,12 @@ void vil1_convolve_simple(vil1_memory_image_of<I1> const &in1,
   static void (*f)(I1 const * const *, unsigned, unsigned,
                    I2 const * const *, unsigned, unsigned,
                    AC *,
-                   O        * const *) = 0;
+                   O        * const *) = VXL_NULLPTR;
   if (!f)
     f = vil1_convolve_simple;
   (*f)(in1.row_array(), in1.width(), in1.height(),
        in2.row_array(), in2.width(), in2.height(),
-       (AC*)0,
+       (AC*)VXL_NULLPTR,
        out.row_array());
 }
 

--- a/core/vil1/vil1_image.h
+++ b/core/vil1/vil1_image.h
@@ -64,11 +64,11 @@ class vil1_image
   { vil1_image_delegate(put_section, (buf, x0, y0, wd, ht), false); }
 
   //: Getting property information
-  bool get_property(char const *tag, void *property_value = 0) const
+  bool get_property(char const *tag, void *property_value = VXL_NULLPTR) const
   { vil1_image_delegate(get_property, (tag, property_value), false); }
 
   //: Setting property information
-  bool set_property(char const *tag, void const *property_value = 0)
+  bool set_property(char const *tag, void const *property_value = VXL_NULLPTR)
   { vil1_image_delegate(set_property, (tag, property_value), false); }
 
   //: Return a string describing the file format.
@@ -91,7 +91,7 @@ class vil1_image
 
   //------------ smart-pointer logic --------
 
-  vil1_image(vil1_image_impl *p = 0) : ptr(p)
+  vil1_image(vil1_image_impl *p = VXL_NULLPTR) : ptr(p)
   {
     if (ptr)
       ptr->up_ref();
@@ -106,7 +106,7 @@ class vil1_image
   ~vil1_image() {
     if (ptr)
       ptr->down_ref();
-    ptr = 0; // don't dangle
+    ptr = VXL_NULLPTR; // don't dangle
   }
 
   vil1_image& operator=(vil1_image const &that) {
@@ -141,11 +141,11 @@ class vil1_image
 
   //: conversion to bool
   operator safe_bool () const
-    { return (ptr != 0)? VCL_SAFE_BOOL_TRUE : 0; }
+    { return (ptr != VXL_NULLPTR)? VCL_SAFE_BOOL_TRUE : VXL_NULLPTR; }
 
   //: inverse conversion to bool
   bool operator!() const
-    { return (ptr != 0)? false : true; }
+    { return (ptr != VXL_NULLPTR)? false : true; }
 
   //: use "sptr.impl()" to get a pointer to the impl object.
   vil1_image_impl *impl() const {

--- a/core/vil1/vil1_image_impl.h
+++ b/core/vil1/vil1_image_impl.h
@@ -133,11 +133,11 @@ class vil1_image_impl
 
   //: Return a string describing the file format.
   // Only file images have a format, others return 0
-  virtual char const* file_format() const { return 0; }
+  virtual char const* file_format() const { return VXL_NULLPTR; }
 
   //: Extra property information
-  virtual bool get_property(char const* tag, void* property_value = 0) const;
-  virtual bool set_property(char const* tag, void const* property_value = 0) const;
+  virtual bool get_property(char const* tag, void* property_value = VXL_NULLPTR) const;
+  virtual bool set_property(char const* tag, void const* property_value = VXL_NULLPTR) const;
 
   //: Return the name of the class;
   virtual std::string is_a() const { return "vil1_image_impl"; }

--- a/core/vil1/vil1_memory_image.cxx
+++ b/core/vil1/vil1_memory_image.cxx
@@ -121,7 +121,7 @@ vil1_memory_image& vil1_memory_image::operator= (vil1_memory_image const& that)
 
 void vil1_memory_image::resize(int width, int height)
 {
-  assert(ptr!=0);
+  assert(ptr!=VXL_NULLPTR);
   vil1_memory_image_impl* mi = (vil1_memory_image_impl*)ptr;
   mi->resize(1, width, height);
   cache_from_impl;
@@ -129,7 +129,7 @@ void vil1_memory_image::resize(int width, int height)
 
 void vil1_memory_image::resize(int planes, int width, int height)
 {
-  assert(ptr!=0);
+  assert(ptr!=VXL_NULLPTR);
   vil1_memory_image_impl* mi = (vil1_memory_image_impl*)ptr;
   mi->resize(planes, width, height);
   cache_from_impl;

--- a/core/vil1/vil1_memory_image_impl.h
+++ b/core/vil1/vil1_memory_image_impl.h
@@ -50,7 +50,7 @@ class vil1_memory_image_impl : public vil1_image_impl
   virtual bool get_section(void* buf, int x0, int y0, int width, int height) const;
   virtual bool put_section(void const* buf, int x0, int y0, int width, int height);
 
-  virtual bool get_property(char const *tag, void *property_value = 0) const;
+  virtual bool get_property(char const *tag, void *property_value = VXL_NULLPTR) const;
 
   void resize(int planes, int width, int height);
   void resize(int planes, int width, int height, int components, int bits_per_component,

--- a/core/vil1/vil1_new.h
+++ b/core/vil1/vil1_new.h
@@ -34,17 +34,17 @@ vil1_image vil1_new(vil1_stream* os,
                     int components,
                     int bits_per_component,
                     vil1_component_format format,
-                    char const* file_format = 0);
+                    char const* file_format = VXL_NULLPTR);
 
 //: Make a new image.
 vil1_image vil1_new(char const* filename,
                     int width, int height,
                     vil1_image const &prototype,
-                    char const* format = 0);
+                    char const* format = VXL_NULLPTR);
 
 vil1_image vil1_new(vil1_stream* os,
                     int width, int height,
                     vil1_image const& prototype,
-                    char const* file_format = 0);
+                    char const* file_format = VXL_NULLPTR);
 
 #endif // vil1_new_h_

--- a/core/vil1/vil1_resample_image_impl.cxx
+++ b/core/vil1/vil1_resample_image_impl.cxx
@@ -48,7 +48,7 @@ bool vil1_resample_image_impl::get_property(char const *, void *) const
 
 bool vil1_resample_image_impl::get_section(void *buf, int x0, int y0, int w, int h) const
 {
-  assert(buf!=0);
+  assert(buf!=VXL_NULLPTR);
 #ifdef DEBUG
   std::cerr << "get_section() x0 y0 w h = " << x0 << ' ' << y0 << ' ' << w << ' ' << h << '\n';
 #endif

--- a/core/vil1/vil1_resample_image_impl.h
+++ b/core/vil1/vil1_resample_image_impl.h
@@ -36,7 +36,7 @@ class vil1_resample_image_impl : public vil1_image_impl
   bool get_section(void *buf, int x0, int y0, int w, int h) const;
   bool put_section(void const *buf, int x0, int y0, int w, int h); // <- will fail
 
-  bool get_property(char const *tag, void *property_value_out = 0) const;
+  bool get_property(char const *tag, void *property_value_out = VXL_NULLPTR) const;
 
   //: Return the name of the class
   virtual std::string is_a() const { return "vil1_resample_image_impl"; }

--- a/core/vil1/vil1_skip_image_impl.h
+++ b/core/vil1/vil1_skip_image_impl.h
@@ -34,7 +34,7 @@ class vil1_skip_image_impl : public vil1_image_impl
   bool get_section(void *buf, int x0, int y0, int w, int h) const;
   bool put_section(void const *buf, int x0, int y0, int w, int h); // <- will fail
 
-  bool get_property(char const *tag, void *property_value_out = 0) const;
+  bool get_property(char const *tag, void *property_value_out = VXL_NULLPTR) const;
 
   //: Return the name of the class
   virtual std::string is_a() const { return "vil1_skip_image_impl"; }

--- a/core/vil1/vil1_stream_section.cxx
+++ b/core/vil1/vil1_stream_section.cxx
@@ -22,7 +22,7 @@ vil1_stream_section::vil1_stream_section(vil1_stream *underlying, int begin)
   , end_((vil1_streampos)(-1L))
   , current_(begin)
 {
-  assert(underlying != 0);
+  assert(underlying != VXL_NULLPTR);
   assert(begin >= 0);
   underlying_->ref();
 }
@@ -33,7 +33,7 @@ vil1_stream_section::vil1_stream_section(vil1_stream *underlying, int begin, int
   , end_(end)
   , current_(begin)
 {
-  assert(underlying != 0);
+  assert(underlying != VXL_NULLPTR);
   assert(begin >= 0);
   assert(begin <= end);
   underlying->ref();

--- a/core/vil1/vil1_vil.h
+++ b/core/vil1/vil1_vil.h
@@ -108,7 +108,7 @@ class vil1_vil_image_resource: public vil_image_resource
   virtual unsigned nj() const { if (src_) return src_.height(); else return 0; }
   virtual unsigned nplanes() const { if (!src_) return 0; else return src_.components(); }
 
-  virtual bool get_property(char const *tag, void *property_value=0) const
+  virtual bool get_property(char const *tag, void *property_value=VXL_NULLPTR) const
   {
     if (src_)
       return src_.get_property(tag, property_value);
@@ -119,7 +119,7 @@ class vil1_vil_image_resource: public vil_image_resource
   virtual vil_image_view_base_sptr get_copy_view(unsigned i0, unsigned ni, unsigned j0, unsigned nj) const
   {
     if (!src_)
-      return 0;
+      return VXL_NULLPTR;
 
     switch (pixel_format())
     {
@@ -140,7 +140,7 @@ class vil1_vil_image_resource: public vil_image_resource
         macro(VIL_PIXEL_FORMAT_FLOAT , float )
         macro(VIL_PIXEL_FORMAT_DOUBLE , double )
 #undef macro
-    default: return 0;
+    default: return VXL_NULLPTR;
     }
   }
 
@@ -174,7 +174,7 @@ class vil1_vil_image_resource: public vil_image_resource
 
 inline vil_image_resource_sptr vil1_to_vil_image_resource(const vil1_image &vil1_im)
 {
-  if (!vil1_im) return 0;
+  if (!vil1_im) return VXL_NULLPTR;
   return new vil1_vil_image_resource(vil1_im);
 }
 

--- a/core/vnl/algo/vnl_brent.cxx
+++ b/core/vnl/algo/vnl_brent.cxx
@@ -23,7 +23,7 @@ double vnl_brent::minimize_given_bounds(double ax, double bx, double cx,
                                         double tol,
                                         double *xmin)
 {
-  assert( xmin != NULL );
+  assert( xmin != VXL_NULLPTR );
   this->set_x_tolerance( tol );
   *xmin = vnl_brent_minimizer::minimize_given_bounds( ax, bx, cx );
   return vnl_brent_minimizer::f_at_last_minimum();
@@ -33,7 +33,7 @@ double vnl_brent::minimize_given_bounds_and_1st_f(double ax, double bx,
                                                   double fb, double cx,
                                                   double tol, double *xmin)
 {
-  assert( xmin != NULL );
+  assert( xmin != VXL_NULLPTR );
   this->set_x_tolerance( tol );
   *xmin = vnl_brent_minimizer::minimize_given_bounds_and_one_f( ax, bx, cx, fb );
   return vnl_brent_minimizer::f_at_last_minimum();

--- a/core/vnl/algo/vnl_complex_generalized_schur.cxx
+++ b/core/vnl/algo/vnl_complex_generalized_schur.cxx
@@ -30,10 +30,10 @@ bool vnl_generalized_schur(vnl_matrix<std::complex<double> > *A,
   assert(B->rows() == B->cols());
 
   long n = A->rows();
-  assert(alpha!=0); alpha->set_size(n);    alpha->fill(0);
-  assert(beta!=0);  beta ->set_size(n);    beta ->fill(0);
-  assert(L!=0);     L    ->set_size(n, n); L    ->fill(0);
-  assert(R!=0);     R    ->set_size(n, n); R    ->fill(0);
+  assert(alpha!=VXL_NULLPTR); alpha->set_size(n);    alpha->fill(0);
+  assert(beta!=VXL_NULLPTR);  beta ->set_size(n);    beta ->fill(0);
+  assert(L!=VXL_NULLPTR);     L    ->set_size(n, n); L    ->fill(0);
+  assert(R!=VXL_NULLPTR);     R    ->set_size(n, n); R    ->fill(0);
 
   long sdim = 0;
   long lwork = 1000 + (8*n + 16);

--- a/core/vnl/algo/vnl_convolve.hxx
+++ b/core/vnl/algo/vnl_convolve.hxx
@@ -47,7 +47,7 @@ vnl_vector<U> vnl_convolve_cyclic(vnl_vector<T1> const& v1, vnl_vector<T2> const
   if (n == 1) return vnl_vector<U>(1, U(v1[0]*v2[0]));
 
   if (use_fft)
-    return vnl_convolve_cyclic_using_fft(v1, v2, (U*)0);
+    return vnl_convolve_cyclic_using_fft(v1, v2, (U*)VXL_NULLPTR);
 
   vnl_vector<U> ret(n, (U)0); // all elements already initialized to zero
   for (unsigned int k=0; k<n; ++k)
@@ -83,7 +83,7 @@ vnl_vector<U> vnl_convolve_using_fft(vnl_vector<T1> const& v1, vnl_vector<T2> co
   vnl_vector<U> w1(n, U(0)); for (unsigned i=0; i<v1.size(); ++i) w1[i]=U(v1[i]);
   vnl_vector<U> w2(n, U(0)); for (unsigned i=0; i<v2.size(); ++i) w2[i]=U(v2[i]);
   // convolve, using n-points FFT:
-  w1 = vnl_convolve_cyclic_using_fft(w1, w2, (U*)0);
+  w1 = vnl_convolve_cyclic_using_fft(w1, w2, (U*)VXL_NULLPTR);
   // return w1, but possibly drop the last few (zero) entries:
   return vnl_vector<U>(v1.size()+v2.size()-1, v1.size()+v2.size()-1, w1.data_block());
 }
@@ -98,7 +98,7 @@ vnl_vector<T> vnl_convolve(vnl_vector<T> const& v1, vnl_vector<T> const& v2, int
   if (v2.size() == 1) return v1*v2[0];
 
   if (use_fft != 0)
-    return vnl_convolve_using_fft(v1, v2, (T*)0, use_fft);
+    return vnl_convolve_using_fft(v1, v2, (T*)VXL_NULLPTR, use_fft);
 
   unsigned int n = v1.size() + v2.size() - 1;
   vnl_vector<T> ret(n, (T)0); // all elements already initialized to zero
@@ -120,7 +120,7 @@ vnl_vector<U> vnl_convolve(vnl_vector<T1> const& v1, vnl_vector<T2> const& v2, U
     return vnl_vector<U>(0);
 
   if (use_fft != 0)
-    return vnl_convolve_using_fft(v1, v2, (U*)0, use_fft);
+    return vnl_convolve_using_fft(v1, v2, (U*)VXL_NULLPTR, use_fft);
 
   unsigned int n = v1.size() + v2.size() - 1;
   vnl_vector<U> ret(n, (U)0); // all elements already initialized to zero

--- a/core/vnl/algo/vnl_fft_prime_factors.hxx
+++ b/core/vnl/algo/vnl_fft_prime_factors.hxx
@@ -9,7 +9,7 @@
 
 template <class T>
 vnl_fft_prime_factors<T>::vnl_fft_prime_factors()
-  : trigs_(0)
+  : trigs_(VXL_NULLPTR)
   , number_(0)
 {
 }

--- a/core/vnl/algo/vnl_generalized_schur.cxx
+++ b/core/vnl/algo/vnl_generalized_schur.cxx
@@ -30,11 +30,11 @@ bool vnl_generalized_schur(vnl_matrix<double> *A,
   assert(A->cols() == B->cols());
 
   long n = A->rows();
-  assert(alphar!=0); alphar->set_size(n);    alphar->fill(0);
-  assert(alphai!=0); alphai->set_size(n);    alphai->fill(0);
-  assert(beta!=0);   beta  ->set_size(n);    beta  ->fill(0);
-  assert(L!=0);      L     ->set_size(n, n); L     ->fill(0);
-  assert(R!=0);      R     ->set_size(n, n); R     ->fill(0);
+  assert(alphar!=VXL_NULLPTR); alphar->set_size(n);    alphar->fill(0);
+  assert(alphai!=VXL_NULLPTR); alphai->set_size(n);    alphai->fill(0);
+  assert(beta!=VXL_NULLPTR);   beta  ->set_size(n);    beta  ->fill(0);
+  assert(L!=VXL_NULLPTR);      L     ->set_size(n, n); L     ->fill(0);
+  assert(R!=VXL_NULLPTR);      R     ->set_size(n, n); R     ->fill(0);
 
   long sdim = 0;
   long lwork = 1000 + (8*n + 16);

--- a/core/vnl/algo/vnl_lsqr.cxx
+++ b/core/vnl/algo/vnl_lsqr.cxx
@@ -24,7 +24,7 @@ public:
 
   lsqrVNL()
     {
-    this->ls_ = NULL;
+    this->ls_ = VXL_NULLPTR;
     }
 
   virtual ~lsqrVNL()
@@ -123,7 +123,7 @@ int vnl_lsqr::minimize(vnl_vector<double>& result)
   long n = ls_->get_number_of_unknowns();
   double damp = 0;
   long leniw = 1;
-  long* iw = 0;
+  long* iw = VXL_NULLPTR;
   long lenrw = m;
 #ifdef __GNUC__
   double rw[m];

--- a/core/vnl/algo/vnl_qr.hxx
+++ b/core/vnl/algo/vnl_qr.hxx
@@ -199,10 +199,10 @@ vnl_vector<T> vnl_qr<T>::solve(const vnl_vector<T>& b) const
   vnl_linpack_qrsl(qrdc_out_.data_block(),
                    &n, &n, &p,
                    qraux_.data_block(),
-                   b_data, (T*)0, Qt_B.data_block(),
+                   b_data, (T*)VXL_NULLPTR, Qt_B.data_block(),
                    x.data_block(),
-                   (T*)0/*residual*/,
-                   (T*)0/*Ax*/,
+                   (T*)VXL_NULLPTR/*residual*/,
+                   (T*)VXL_NULLPTR/*Ax*/,
                    &JOB,
                    &info);
 
@@ -230,11 +230,11 @@ vnl_vector<T> vnl_qr<T>::QtB(const vnl_vector<T>& b) const
                    &n, &n, &p,
                    qraux_.data_block(),
                    b_data,
-                   (T*)0,               // A: Qb
+                   (T*)VXL_NULLPTR,               // A: Qb
                    Qt_B.data_block(),   // B: Q'b
-                   (T*)0,               // C: x
-                   (T*)0,               // D: residual
-                   (T*)0,               // E: Ax
+                   (T*)VXL_NULLPTR,               // C: x
+                   (T*)VXL_NULLPTR,               // D: residual
+                   (T*)VXL_NULLPTR,               // E: Ax
                    &JOB,
                    &info);
 

--- a/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
+++ b/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
@@ -29,7 +29,7 @@ void sse_op_callback(const long* n,
                      const double* p,
                      double* q)
 {
-  assert(current_system != 0);
+  assert(current_system != VXL_NULLPTR);
 
   current_system->CalculateProduct(*n,*m,p,q);
 }
@@ -46,7 +46,7 @@ void sse_iovect_callback(const long* n,
                          const long* j,
                          const long* k)
 {
-  assert(current_system != 0);
+  assert(current_system != VXL_NULLPTR);
 
   if (*k==0)
     current_system->SaveVectors(*n,*m,q,*j-*m);

--- a/core/vnl/algo/vnl_svd_economy.hxx
+++ b/core/vnl/algo/vnl_svd_economy.hxx
@@ -45,7 +45,7 @@ vnl_svd_economy<real_t>::vnl_svd_economy( vnl_matrix<real_t> const& M ) :
   vnl_linpack_svdc_economy((real_t*)X, &m_, &m_, &n_,
                            wspace.data_block(),
                            espace.data_block(),
-                           0, &ldu,
+                           VXL_NULLPTR, &ldu,
                            vspace.data_block(), &n_,
                            work.data_block(),
                            &job, &info);

--- a/core/vnl/vnl_file_matrix.h
+++ b/core/vnl/vnl_file_matrix.h
@@ -30,7 +30,7 @@ class VNL_TEMPLATE_EXPORT vnl_file_matrix : public vnl_matrix<T>
   vnl_file_matrix(char const* filename);
 
   operator safe_bool () const
-    { return (ok_)? VCL_SAFE_BOOL_TRUE : 0; }
+    { return (ok_)? VCL_SAFE_BOOL_TRUE : VXL_NULLPTR; }
   bool operator!() const
     { return !ok_; }
 

--- a/core/vnl/vnl_file_vector.h
+++ b/core/vnl/vnl_file_vector.h
@@ -31,7 +31,7 @@ class VNL_TEMPLATE_EXPORT vnl_file_vector : public vnl_vector<T>
   vnl_file_vector(char const* filename);
 
   operator safe_bool () const
-    { return (ok_)? VCL_SAFE_BOOL_TRUE : 0; }
+    { return (ok_)? VCL_SAFE_BOOL_TRUE : VXL_NULLPTR; }
   bool operator!() const
     { return !ok_; }
 

--- a/core/vnl/vnl_matlab_print.h
+++ b/core/vnl/vnl_matlab_print.h
@@ -46,7 +46,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_diag_matrix<T> const&,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 //: print a vnl_matrix<T>.
@@ -54,7 +54,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_matrix<T> const&,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 //: print a vnl_matrix_fixed<T>.
@@ -62,7 +62,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T, unsigned int n, unsigned int m> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_matrix_fixed<T,n,m> const&,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 //: print a vnl_matrix_ref<T>.
@@ -70,7 +70,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_matrix_ref<T> const &,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 //: print a vnl_vector<T>.
@@ -78,7 +78,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_vector<T> const &,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 //: print a vnl_vector_fixed<T>.
@@ -86,7 +86,7 @@ std::ostream &vnl_matlab_print(std::ostream &,
 template <class T, unsigned int n> VNL_TEMPLATE_EXPORT
 std::ostream &vnl_matlab_print(std::ostream &,
                               vnl_vector_fixed<T,n> const &,
-                              char const *variable_name =0,
+                              char const *variable_name =VXL_NULLPTR,
                               vnl_matlab_print_format =vnl_matlab_print_format_default);
 
 

--- a/core/vnl/vnl_matlab_print2.h
+++ b/core/vnl/vnl_matlab_print2.h
@@ -61,7 +61,7 @@ template <class T>
 inline
 vnl_matlab_print_proxy<T>
 vnl_matlab_print(T const &obj,
-                 char const *name = 0,
+                 char const *name = VXL_NULLPTR,
                  vnl_matlab_print_format format = vnl_matlab_print_format_default)
 {
   return vnl_matlab_print_proxy<T>(obj, name, format);

--- a/core/vnl/vnl_matlab_read.h
+++ b/core/vnl/vnl_matlab_read.h
@@ -33,8 +33,8 @@ template <class T> class vnl_matrix;
 // If the data in the file cannot reasonably be read into the destination, abort().
 //
 // The vector/matrix will be resized if necessary.
-template <class T> VNL_TEMPLATE_EXPORT bool vnl_matlab_read_or_die(std::istream &, vnl_vector<T> &, char const *name =0);
-template <class T> VNL_TEMPLATE_EXPORT bool vnl_matlab_read_or_die(std::istream &, vnl_matrix<T> &, char const *name =0);
+template <class T> VNL_TEMPLATE_EXPORT bool vnl_matlab_read_or_die(std::istream &, vnl_vector<T> &, char const *name =VXL_NULLPTR);
+template <class T> VNL_TEMPLATE_EXPORT bool vnl_matlab_read_or_die(std::istream &, vnl_matrix<T> &, char const *name =VXL_NULLPTR);
 
 // ------------------------------ less easy ------------------------------
 

--- a/core/vnl/vnl_sym_matrix.h
+++ b/core/vnl/vnl_sym_matrix.h
@@ -29,7 +29,7 @@ class VNL_TEMPLATE_EXPORT vnl_sym_matrix
 {
  public:
   //: Construct an empty symmetric matrix.
-  vnl_sym_matrix(): data_(0), index_(0), nn_(0) {}
+  vnl_sym_matrix(): data_(VXL_NULLPTR), index_(VXL_NULLPTR), nn_(0) {}
 
   //: Construct a symmetric matrix of size nn by nn.
   explicit vnl_sym_matrix(unsigned nn):
@@ -222,7 +222,7 @@ inline vnl_sym_matrix<T>::vnl_sym_matrix(vnl_matrix<T> const& that):
 
 template <class T>
 inline vnl_sym_matrix<T>::vnl_sym_matrix(vnl_sym_matrix<T> const& that):
-  data_(0), index_(0), nn_(0)
+  data_(VXL_NULLPTR), index_(VXL_NULLPTR), nn_(0)
 {
   set_size(that.rows());
   update(that);

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -134,7 +134,7 @@ class VNL_TEMPLATE_EXPORT vnl_vector
   vnl_vector(vnl_vector<T> const &, vnl_matrix<T> const &, vnl_tag_mul); // v * M
   vnl_vector(vnl_vector<T> &that, vnl_tag_grab)
     : num_elmts(that.num_elmts), data(that.data)
-  { that.num_elmts=0; that.data=0; } // "*this" now uses "that"'s data.
+  { that.num_elmts=0; that.data=VXL_NULLPTR; } // "*this" now uses "that"'s data.
 // </internal>
 #endif
 

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -288,7 +288,7 @@ void vnl_vector<T>::clear()
   if (data) {
     destroy();
     num_elmts = 0;
-    data = 0;
+    data = VXL_NULLPTR;
   }
 }
 

--- a/core/vpgl/vpgl_fundamental_matrix.h
+++ b/core/vpgl/vpgl_fundamental_matrix.h
@@ -48,11 +48,11 @@ class vpgl_fundamental_matrix
   //: Main constructor takes two projective cameras.
   //  The RHS of the fundamental matrix will correspond to cr and the LHS to cl.
   vpgl_fundamental_matrix( const vpgl_proj_camera<T>& cr,
-                           const vpgl_proj_camera<T>& cl ) : cached_svd_(NULL)
+                           const vpgl_proj_camera<T>& cl ) : cached_svd_(VXL_NULLPTR)
   { set_matrix( cr, cl ); }
 
   //: Construct from a fundamental matrix in vnl form.
-  vpgl_fundamental_matrix( const vnl_matrix_fixed<T,3,3>& F ) : cached_svd_(NULL)
+  vpgl_fundamental_matrix( const vnl_matrix_fixed<T,3,3>& F ) : cached_svd_(VXL_NULLPTR)
   { set_matrix( F ); }
 
   //: Copy Constructor

--- a/core/vpgl/vpgl_fundamental_matrix.hxx
+++ b/core/vpgl/vpgl_fundamental_matrix.hxx
@@ -29,7 +29,7 @@
 //---------------------------------
 template <class T>
 vpgl_fundamental_matrix<T>::vpgl_fundamental_matrix()
-  : cached_svd_(NULL)
+  : cached_svd_(VXL_NULLPTR)
 {
   vnl_matrix_fixed<T,3,3> default_matrix( (T)0 );
   default_matrix(0,0) = default_matrix(1,1) = (T)1;
@@ -41,7 +41,7 @@ vpgl_fundamental_matrix<T>::vpgl_fundamental_matrix()
 template <class T>
 vpgl_fundamental_matrix<T>::vpgl_fundamental_matrix(
   const vpgl_fundamental_matrix<T>& other)
-  : cached_svd_(NULL)
+  : cached_svd_(VXL_NULLPTR)
 {
   set_matrix( other.F_ );
 }
@@ -54,7 +54,7 @@ vpgl_fundamental_matrix<T>::vpgl_fundamental_matrix(
     const vpgl_calibration_matrix<T> &kr,
     const vpgl_calibration_matrix<T> &kl,
     const vpgl_essential_matrix<T>   &em)
-  : cached_svd_(NULL)
+  : cached_svd_(VXL_NULLPTR)
 {
   vnl_matrix_fixed<T, 3, 3> kl_tinv = vnl_inverse(kl.get_matrix().transpose());
   vnl_matrix_fixed<T, 3, 3> kr_inv = vnl_inverse(kr.get_matrix());
@@ -248,7 +248,7 @@ template <class T>
 void vpgl_fundamental_matrix<T>::set_matrix( const vnl_matrix_fixed<T,3,3>& F )
 {
   F_ = vnl_svd<T>( F.as_ref() ).recompose(2);
-  if ( cached_svd_ != NULL ) delete cached_svd_;
+  if ( cached_svd_ != VXL_NULLPTR ) delete cached_svd_;
   cached_svd_ = new vnl_svd<T>( F_.as_ref() );
 }
 

--- a/core/vpgl/vpgl_lens_distortion.h
+++ b/core/vpgl/vpgl_lens_distortion.h
@@ -16,6 +16,7 @@
 
 //: forward declare vgl_homg_point_2d<T> and vgl_vector_2d<T>
 #include <vgl/vgl_fwd.h>
+#include "vcl_compiler_detection.h"
 
 //: A base class for lens distortions
 template <class T>
@@ -32,7 +33,7 @@ class vpgl_lens_distortion
   // \param init is an initial guess at the solution for the iterative solver
   // if \p init is NULL then \p point is used as the initial guess
   virtual vgl_homg_point_2d<T> undistort( const vgl_homg_point_2d<T>& point,
-                                          const vgl_homg_point_2d<T>* init=0) const;
+                                          const vgl_homg_point_2d<T>* init=VXL_NULLPTR) const;
 
   //: Set a translation to apply before of after distortion
   // This is needed when distorting an image to translate the resulting image

--- a/core/vpgl/vpgl_local_rational_camera.hxx
+++ b/core/vpgl/vpgl_local_rational_camera.hxx
@@ -183,7 +183,7 @@ vpgl_local_rational_camera<T>* read_local_rational_camera(std::string cam_path)
   file_inp.open(cam_path.c_str());
   if (!file_inp.good()) {
     std::cout << "error: bad filename: " << cam_path << std::endl;
-    return 0;
+    return VXL_NULLPTR;
   }
   return read_local_rational_camera<T>(file_inp);
 }
@@ -193,7 +193,7 @@ vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr)
 {
   vpgl_rational_camera<T>* rcam = read_rational_camera<T>(istr);
   if (!rcam)
-    return 0;
+    return VXL_NULLPTR;
   std::string input;
   bool good = false;
   vpgl_lvcs lvcs;
@@ -211,7 +211,7 @@ vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr)
   if  (!good)
   {
     //std::cout << "error: not a composite rational camera file\n";
-    return 0;
+    return VXL_NULLPTR;
   }
   return new vpgl_local_rational_camera<T>(lvcs, *rcam);
 }

--- a/core/vpgl/vpgl_poly_radial_distortion.h
+++ b/core/vpgl/vpgl_poly_radial_distortion.h
@@ -66,7 +66,7 @@ class vpgl_poly_radial_distortion : public vpgl_radial_distortion<T>
 
   void set_coefficients(const T* k)
   {
-    if ( k == NULL ) return;
+    if ( k == VXL_NULLPTR ) return;
     const T* kptr = k;
     T* coptr = coefficients_;
     for (unsigned int i=0; i<n; ++i, ++kptr, ++coptr)

--- a/core/vpgl/vpgl_proj_camera.hxx
+++ b/core/vpgl/vpgl_proj_camera.hxx
@@ -20,7 +20,7 @@
 //------------------------------------
 template <class T>
 vpgl_proj_camera<T>::vpgl_proj_camera() :
-  cached_svd_(NULL)
+  cached_svd_(VXL_NULLPTR)
 {
   P_ = vnl_matrix_fixed<T,3,4>( (T)0 );
   P_(0,0) = P_(1,1) = P_(2,2) = (T)1;
@@ -30,7 +30,7 @@ vpgl_proj_camera<T>::vpgl_proj_camera() :
 template <class T>
 vpgl_proj_camera<T>::vpgl_proj_camera( const vnl_matrix_fixed<T,3,4>& camera_matrix ) :
   P_( camera_matrix ),
-  cached_svd_(NULL)
+  cached_svd_(VXL_NULLPTR)
 {
 }
 
@@ -38,7 +38,7 @@ vpgl_proj_camera<T>::vpgl_proj_camera( const vnl_matrix_fixed<T,3,4>& camera_mat
 template <class T>
 vpgl_proj_camera<T>::vpgl_proj_camera( const T* camera_matrix ) :
   P_( camera_matrix ),
-  cached_svd_(NULL)
+  cached_svd_(VXL_NULLPTR)
 {
 }
 
@@ -47,7 +47,7 @@ template <class T>
 vpgl_proj_camera<T>::vpgl_proj_camera( const vpgl_proj_camera& cam ) :
   vpgl_camera<T>(),
   P_( cam.get_matrix() ),
-  cached_svd_(NULL)
+  cached_svd_(VXL_NULLPTR)
 {
 }
 
@@ -56,8 +56,8 @@ template <class T>
 const vpgl_proj_camera<T>& vpgl_proj_camera<T>::operator=( const vpgl_proj_camera& cam )
 {
   P_ = cam.get_matrix();
-  if ( cached_svd_ != NULL ) delete cached_svd_;
-  cached_svd_ = NULL;
+  if ( cached_svd_ != VXL_NULLPTR ) delete cached_svd_;
+  cached_svd_ = VXL_NULLPTR;
   return *this;
 }
 
@@ -65,8 +65,8 @@ const vpgl_proj_camera<T>& vpgl_proj_camera<T>::operator=( const vpgl_proj_camer
 template <class T>
 vpgl_proj_camera<T>::~vpgl_proj_camera()
 {
-  if ( cached_svd_ != NULL ) delete cached_svd_;
-  cached_svd_ = NULL;
+  if ( cached_svd_ != VXL_NULLPTR ) delete cached_svd_;
+  cached_svd_ = VXL_NULLPTR;
 }
 
 template <class T>
@@ -201,7 +201,7 @@ template <class T>
 vnl_svd<T>* vpgl_proj_camera<T>::svd() const
 {
   // Check if the cached copy is valid, if not recompute it.
-  if ( cached_svd_ == NULL )
+  if ( cached_svd_ == VXL_NULLPTR )
   {
     cached_svd_ = new vnl_svd<T>(P_.as_ref());
 
@@ -218,8 +218,8 @@ template <class T>
 bool vpgl_proj_camera<T>::set_matrix( const vnl_matrix_fixed<T,3,4>& new_camera_matrix )
 {
   P_ = new_camera_matrix;
-  if ( cached_svd_ != NULL ) delete cached_svd_;
-  cached_svd_ = NULL;
+  if ( cached_svd_ != VXL_NULLPTR ) delete cached_svd_;
+  cached_svd_ = VXL_NULLPTR;
   return true;
 }
 
@@ -228,8 +228,8 @@ template <class T>
 bool vpgl_proj_camera<T>::set_matrix( const T* new_camera_matrix )
 {
   P_ = vnl_matrix_fixed<T,3,4>( new_camera_matrix );
-    if ( cached_svd_ != NULL ) delete cached_svd_;
-    cached_svd_ = NULL;
+    if ( cached_svd_ != VXL_NULLPTR ) delete cached_svd_;
+    cached_svd_ = VXL_NULLPTR;
   return true;
 }
 

--- a/core/vpgl/vpgl_radial_distortion.h
+++ b/core/vpgl/vpgl_radial_distortion.h
@@ -40,7 +40,7 @@ class vpgl_radial_distortion : public vpgl_lens_distortion<T>
   // if \p init is NULL then \p point is used as the initial guess
   // calls the radial undistortion function
   virtual vgl_homg_point_2d<T> undistort( const vgl_homg_point_2d<T>& point,
-                                          const vgl_homg_point_2d<T>* init=0) const;
+                                          const vgl_homg_point_2d<T>* init=VXL_NULLPTR) const;
 
   //: Distort a radial length
   // \retval a scale factor such that
@@ -52,7 +52,7 @@ class vpgl_radial_distortion : public vpgl_lens_distortion<T>
   //: Return the inverse of distort function
   // \param init is an initial guess at the solution for the iterative solver
   // if \p init is NULL then \p radius is used as the initial guess
-  virtual T undistort_radius( T radius, const T* init=0) const;
+  virtual T undistort_radius( T radius, const T* init=VXL_NULLPTR) const;
 
   //: Compute the derivative of the distort_radius function
   // \note implementing this function is optional but it may improve the convergence

--- a/core/vpgl/vpgl_rational_camera.hxx
+++ b/core/vpgl/vpgl_rational_camera.hxx
@@ -437,7 +437,7 @@ vpgl_rational_camera<T>* read_rational_camera(std::string cam_path)
   file_inp.open(cam_path.c_str());
   if (!file_inp.good()) {
     std::cout << "error: bad filename: " << cam_path << std::endl;
-    return 0;
+    return VXL_NULLPTR;
   }
   vpgl_rational_camera<T>* rcam = read_rational_camera<T>(file_inp);
   file_inp.close();
@@ -548,16 +548,16 @@ vpgl_rational_camera<T>* read_rational_camera(std::istream& istr)
   }
   istr >> input;
   if (input!="END_GROUP")
-    return 0;
+    return VXL_NULLPTR;
   istr >> input;
   if (input!="=")
-    return 0;
+    return VXL_NULLPTR;
   istr >> input;
   if (input!="IMAGE")
-    return 0;
+    return VXL_NULLPTR;
   istr >> input;
   if (input!="END;")
-    return 0;
+    return VXL_NULLPTR;
   int map[20];
   map[0]=19;
   map[1]=9;
@@ -582,7 +582,7 @@ vpgl_rational_camera<T>* read_rational_camera(std::istream& istr)
 
   if ((neu_u.size() != 20) || (den_u.size() != 20)) {
     std::cerr << "the input is not a valid rational camera\n";
-    return 0;
+    return VXL_NULLPTR;
   }
 
   T temp_vector[20];
@@ -626,7 +626,7 @@ vpgl_rational_camera<T>* read_rational_camera_from_txt(std::string cam_path)
   istr.open(cam_path.c_str());
   if (!istr.good()) {
     std::cout << "error: bad filename: " << cam_path << std::endl;
-    return 0;
+    return VXL_NULLPTR;
   }
 
   std::vector<T> neu_u;
@@ -765,7 +765,7 @@ vpgl_rational_camera<T>* read_rational_camera_from_txt(std::string cam_path)
 
   if ((neu_u.size() != 20) || (den_u.size() != 20)) {
     std::cerr << "the input is not a valid rational camera\n";
-    return 0;
+    return VXL_NULLPTR;
   }
 
   T temp_vector[20];

--- a/core/vsl/vsl_binary_io.cxx
+++ b/core/vsl/vsl_binary_io.cxx
@@ -207,7 +207,7 @@ static const unsigned short vsl_magic_number_part_2=0x472b;
 // User is responsible for deleting os after deleting the adaptor
 vsl_b_ostream::vsl_b_ostream(std::ostream *o_s): os_(o_s)
 {
-  assert(os_ != 0);
+  assert(os_ != VXL_NULLPTR);
   vsl_b_write_uint_16(*this, version_no_);
   vsl_b_write_uint_16(*this, vsl_magic_number_part_1);
   vsl_b_write_uint_16(*this, vsl_magic_number_part_2);
@@ -216,7 +216,7 @@ vsl_b_ostream::vsl_b_ostream(std::ostream *o_s): os_(o_s)
 //: A reference to the adaptor's stream
 std::ostream& vsl_b_ostream::os() const
 {
-  assert(os_ != 0);
+  assert(os_ != VXL_NULLPTR);
   return *os_;
 }
 
@@ -247,7 +247,7 @@ void vsl_b_ostream::clear_serialisation_records()
 unsigned long vsl_b_ostream::add_serialisation_record
                     (void *pointer, int other_data /*= 0*/)
 {
-  assert(pointer != 0);
+  assert(pointer != VXL_NULLPTR);
   assert(serialisation_records_.find(pointer) == serialisation_records_.end());
   unsigned long id = (unsigned long)serialisation_records_.size() + 1;
   serialisation_records_[pointer] = std::make_pair(id, other_data);
@@ -316,7 +316,7 @@ vsl_b_ofstream::~vsl_b_ofstream()
 //: Close the stream
 void vsl_b_ofstream::close()
 {
-  assert(os_ != 0);
+  assert(os_ != VXL_NULLPTR);
   ((std::ofstream *)os_)->close();
   clear_serialisation_records();
 }
@@ -327,7 +327,7 @@ void vsl_b_ofstream::close()
 // User is responsible for deleting is after deleting the adaptor
 vsl_b_istream::vsl_b_istream(std::istream *i_s): is_(i_s)
 {
-  assert(is_ != 0);
+  assert(is_ != VXL_NULLPTR);
   if (!(*is_)) return;
   unsigned long v=0, m1=0, m2=0;
   vsl_b_read_uint_16(*this, v);
@@ -357,7 +357,7 @@ vsl_b_istream::vsl_b_istream(std::istream *i_s): is_(i_s)
 //: A reference to the adaptor's stream
 std::istream & vsl_b_istream::is() const
 {
-  assert(is_ != 0);
+  assert(is_ != VXL_NULLPTR);
   return *is_;
 }
 
@@ -394,7 +394,7 @@ void vsl_b_istream::clear_serialisation_records()
 void vsl_b_istream::add_serialisation_record(unsigned long serial_number,
                                              void *pointer, int other_data /*= 0*/)
 {
-  assert(pointer != 0);
+  assert(pointer != VXL_NULLPTR);
   assert(serialisation_records_.find(serial_number) == serialisation_records_.end());
   serialisation_records_[serial_number] = std::make_pair(pointer, other_data);
 }
@@ -458,7 +458,7 @@ vsl_b_ifstream::~vsl_b_ifstream()
 //: Close the stream
 void vsl_b_ifstream::close()
 {
-  assert(is_ != 0);
+  assert(is_ != VXL_NULLPTR);
   ((std::ifstream *)is_)->close();
   clear_serialisation_records();
 }

--- a/core/vsl/vsl_binary_loader.hxx
+++ b/core/vsl/vsl_binary_loader.hxx
@@ -12,7 +12,7 @@
 template<class BaseClass>
 vsl_binary_loader<BaseClass>& vsl_binary_loader<BaseClass>::instance()
 {
-  if (instance_ == 0)
+  if (instance_ == VXL_NULLPTR)
   {
     instance_ = new vsl_binary_loader<BaseClass>;
 
@@ -34,7 +34,7 @@ template<class BaseClass>
 vsl_binary_loader<BaseClass>::~vsl_binary_loader()
 {
   make_empty();
-  instance_=0;
+  instance_=VXL_NULLPTR;
 }
 
 // IO for  pointers to BaseClass:
@@ -55,7 +55,7 @@ void vsl_binary_loader<BaseClass>::load_object( vsl_b_istream& is, BaseClass*& b
   if (name=="VSL_NULL_PTR")
   {
     // Zero pointer
-    b=0;
+    b=VXL_NULLPTR;
     return;
   }
 
@@ -93,7 +93,7 @@ void vsl_b_write(vsl_b_ostream& bfs, const BaseClass* b)
 }
 
 template <class BaseClass>
-vsl_binary_loader<BaseClass>* vsl_binary_loader<BaseClass>::instance_ = 0;
+vsl_binary_loader<BaseClass>* vsl_binary_loader<BaseClass>::instance_ = VXL_NULLPTR;
 
 
 #undef VSL_BINARY_LOADER_INSTANTIATE

--- a/core/vsl/vsl_clipon_binary_loader.hxx
+++ b/core/vsl/vsl_clipon_binary_loader.hxx
@@ -13,7 +13,7 @@
 template<class BaseClass, class BaseClassIO>
 vsl_clipon_binary_loader<BaseClass,BaseClassIO>& vsl_clipon_binary_loader<BaseClass,BaseClassIO>::instance()
 {
-  if (instance_ == 0)
+  if (instance_ == VXL_NULLPTR)
   {
     instance_ = new vsl_clipon_binary_loader<BaseClass,BaseClassIO>;
 
@@ -107,7 +107,7 @@ void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::read_object( vsl_b_istream
   if (name=="VSL_NULL_PTR")
   {
     // Zero pointer
-    b=0;
+    b=VXL_NULLPTR;
     return;
   }
 
@@ -120,7 +120,7 @@ void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::read_object( vsl_b_istream
 template<class BaseClass, class BaseClassIO>
 void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::write_object( vsl_b_ostream& os, const BaseClass* b)
 {
-  if (b==0)
+  if (b==VXL_NULLPTR)
   {
     vsl_b_write(os,std::string("VSL_NULL_PTR"));
     return;
@@ -135,7 +135,7 @@ void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::write_object( vsl_b_ostrea
 template<class BaseClass, class BaseClassIO>
 void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::print_object_summary( std::ostream& os, const BaseClass* b)
 {
-  if (b==0)
+  if (b==VXL_NULLPTR)
   {
     os<<"No object defined.";
     return;
@@ -146,7 +146,7 @@ void vsl_clipon_binary_loader<BaseClass,BaseClassIO>::print_object_summary( std:
 }
 
 template <class B, class IO>
-vsl_clipon_binary_loader<B, IO>* vsl_clipon_binary_loader<B, IO>::instance_ = 0;
+vsl_clipon_binary_loader<B, IO>* vsl_clipon_binary_loader<B, IO>::instance_ = VXL_NULLPTR;
 
 #define VSL_CLIPON_BINARY_LOADER_INSTANTIATE(B,IO) \
 template class vsl_clipon_binary_loader<B, IO >;

--- a/core/vul/vul_reg_exp.h
+++ b/core/vul/vul_reg_exp.h
@@ -142,7 +142,7 @@ class vul_reg_exp
 
  private:
   //: private function to clear startp[] and endp[]
-  void clear_bufs() { for (int n=0; n<vul_reg_exp_nsubexp; ++n) startp[n]=endp[n]=0; }
+  void clear_bufs() { for (int n=0; n<vul_reg_exp_nsubexp; ++n) startp[n]=endp[n]=VXL_NULLPTR; }
 };
 
 #endif // vul_reg_exph

--- a/v3p/clipper/clipper.cpp
+++ b/v3p/clipper/clipper.cpp
@@ -48,6 +48,8 @@
 #include <ostream>
 #include <functional>
 
+#include "vcl_compiler_detection.h"
+
 namespace ClipperLib {
 
 static double const pi = 3.141592653589793238;
@@ -162,7 +164,7 @@ PolyNode* PolyTree::GetFirst() const
   if (!Childs.empty())
       return Childs[0];
   else
-      return 0;
+      return VXL_NULLPTR;
 }
 //------------------------------------------------------------------------------
 
@@ -178,7 +180,7 @@ int PolyTree::Total() const
 // PolyNode methods ...
 //------------------------------------------------------------------------------
 
-PolyNode::PolyNode(): Childs(), Parent(0), Index(0), m_IsOpen(false)
+PolyNode::PolyNode(): Childs(), Parent(VXL_NULLPTR), Index(0), m_IsOpen(false)
 {
 }
 //------------------------------------------------------------------------------
@@ -210,7 +212,7 @@ PolyNode* PolyNode::GetNext() const
 PolyNode* PolyNode::GetNextSiblingUp() const
 {
   if (!Parent) //protects against PolyTree.GetNextSiblingUp()
-      return 0;
+      return VXL_NULLPTR;
   else if (Index == Parent->Childs.size() - 1)
       return Parent->GetNextSiblingUp();
   else
@@ -705,8 +707,8 @@ void ReversePolyPtLinks(OutPt *pp)
 
 void DisposeOutPts(OutPt*& pp)
 {
-  if (pp == 0) return;
-    pp->Prev->Next = 0;
+  if (pp == VXL_NULLPTR) return;
+    pp->Prev->Next = VXL_NULLPTR;
   while( pp )
   {
     OutPt *tmpPp = pp;
@@ -748,7 +750,7 @@ TEdge* RemoveEdge(TEdge* e)
   e->Prev->Next = e->Next;
   e->Next->Prev = e->Prev;
   TEdge* result = e->Next;
-  e->Prev = 0; //flag as removed (see ClipperBase.Clear)
+  e->Prev = VXL_NULLPTR; //flag as removed (see ClipperBase.Clear)
   return result;
 }
 //------------------------------------------------------------------------------
@@ -816,20 +818,20 @@ bool FirstIsBottomPt(const OutPt* btmPt1, const OutPt* btmPt2)
 
 OutPt* GetBottomPt(OutPt *pp)
 {
-  OutPt* dups = 0;
+  OutPt* dups = VXL_NULLPTR;
   OutPt* p = pp->Next;
   while (p != pp)
   {
     if (p->Pt.Y > pp->Pt.Y)
     {
       pp = p;
-      dups = 0;
+      dups = VXL_NULLPTR;
     }
     else if (p->Pt.Y == pp->Pt.Y && p->Pt.X <= pp->Pt.X)
     {
       if (p->Pt.X < pp->Pt.X)
       {
-        dups = 0;
+        dups = VXL_NULLPTR;
         pp = p;
       } else
       {
@@ -923,7 +925,7 @@ TEdge* FindNextLocMin(TEdge* E)
 TEdge* ClipperBase::ProcessBound(TEdge* E, bool NextIsForward)
 {
   TEdge *Result = E;
-  TEdge *Horz = 0;
+  TEdge *Horz = VXL_NULLPTR;
 
   if (E->OutIdx == Skip)
   {
@@ -956,7 +958,7 @@ TEdge* ClipperBase::ProcessBound(TEdge* E, bool NextIsForward)
         E = Result->Prev;
       MinimaList::value_type locMin;
       locMin.Y = E->Bot.Y;
-      locMin.LeftBound = 0;
+      locMin.LeftBound = VXL_NULLPTR;
       locMin.RightBound = E;
       E->WindDelta = 0;
       Result = ProcessBound(E, NextIsForward);
@@ -1158,7 +1160,7 @@ bool ClipperBase::AddPath(const Path &pg, PolyType PolyTyp, bool Closed)
     if (E->Prev->Bot.X < E->Prev->Top.X) ReverseHorizontal(*E->Prev);
     MinimaList::value_type locMin;
     locMin.Y = E->Bot.Y;
-    locMin.LeftBound = 0;
+    locMin.LeftBound = VXL_NULLPTR;
     locMin.RightBound = E;
     locMin.RightBound->Side = esRight;
     locMin.RightBound->WindDelta = 0;
@@ -1175,7 +1177,7 @@ bool ClipperBase::AddPath(const Path &pg, PolyType PolyTyp, bool Closed)
 
   m_edges.push_back(edges);
   bool leftBoundIsForward;
-  TEdge* EMin = 0;
+  TEdge* EMin = VXL_NULLPTR;
 
   //workaround to avoid an endless loop in the while loop below when
   //open paths have matching start and end points ...
@@ -1218,9 +1220,9 @@ bool ClipperBase::AddPath(const Path &pg, PolyType PolyTyp, bool Closed)
     if (E2->OutIdx == Skip) E2 = ProcessBound(E2, !leftBoundIsForward);
 
     if (locMin.LeftBound->OutIdx == Skip)
-      locMin.LeftBound = 0;
+      locMin.LeftBound = VXL_NULLPTR;
     else if (locMin.RightBound->OutIdx == Skip)
-      locMin.RightBound = 0;
+      locMin.RightBound = VXL_NULLPTR;
     m_MinimaList.push_back(locMin);
     if (!leftBoundIsForward) E = E2;
   }
@@ -1339,8 +1341,8 @@ IntRect ClipperBase::GetBounds()
 
 Clipper::Clipper(int initOptions) : ClipperBase() //constructor
 {
-  m_ActiveEdges = 0;
-  m_SortedEdges = 0;
+  m_ActiveEdges = VXL_NULLPTR;
+  m_SortedEdges = VXL_NULLPTR;
   m_ExecuteLocked = false;
   m_UseFullRange = false;
   m_ReverseOutput = ((initOptions & ioReverseSolution) != 0);
@@ -1371,8 +1373,8 @@ void Clipper::Reset()
 {
   ClipperBase::Reset();
   m_Scanbeam = ScanbeamList();
-  m_ActiveEdges = 0;
-  m_SortedEdges = 0;
+  m_ActiveEdges = VXL_NULLPTR;
+  m_SortedEdges = VXL_NULLPTR;
   for (MinimaList::iterator lm = m_MinimaList.begin(); lm != m_MinimaList.end(); ++lm)
     InsertScanbeam(lm->Y);
 }
@@ -1512,7 +1514,7 @@ void Clipper::DisposeOutRec(PolyOutList::size_type index)
   OutRec *outRec = m_PolyOuts[index];
   if (outRec->Pts) DisposeOutPts(outRec->Pts);
   delete outRec;
-  m_PolyOuts[index] = 0;
+  m_PolyOuts[index] = VXL_NULLPTR;
 }
 //------------------------------------------------------------------------------
 
@@ -1790,13 +1792,13 @@ void Clipper::AddEdgeToSEL(TEdge *edge)
   if( !m_SortedEdges )
   {
     m_SortedEdges = edge;
-    edge->PrevInSEL = 0;
-    edge->NextInSEL = 0;
+    edge->PrevInSEL = VXL_NULLPTR;
+    edge->NextInSEL = VXL_NULLPTR;
   }
   else
   {
     edge->NextInSEL = m_SortedEdges;
-    edge->PrevInSEL = 0;
+    edge->PrevInSEL = VXL_NULLPTR;
     m_SortedEdges->PrevInSEL = edge;
     m_SortedEdges = edge;
   }
@@ -1846,7 +1848,7 @@ void Clipper::AddGhostJoin(OutPt *op, const IntPoint OffPt)
 {
   Join* j = new Join;
   j->OutPt1 = op;
-  j->OutPt2 = 0;
+  j->OutPt2 = VXL_NULLPTR;
   j->OffPt = OffPt;
   m_GhostJoins.push_back(j);
 }
@@ -1859,18 +1861,18 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
     TEdge* lb = m_CurrentLM->LeftBound;
     TEdge* rb = m_CurrentLM->RightBound;
     PopLocalMinima();
-    OutPt *Op1 = 0;
+    OutPt *Op1 = VXL_NULLPTR;
     if (!lb)
     {
       //nb: don't insert LB into either AEL or SEL
-      InsertEdgeIntoAEL(rb, 0);
+      InsertEdgeIntoAEL(rb, VXL_NULLPTR);
       SetWindingCount(*rb);
       if (IsContributing(*rb))
         Op1 = AddOutPt(rb, rb->Bot);
     }
     else if (!rb)
     {
-      InsertEdgeIntoAEL(lb, 0);
+      InsertEdgeIntoAEL(lb, VXL_NULLPTR);
       SetWindingCount(*lb);
       if (IsContributing(*lb))
         Op1 = AddOutPt(lb, lb->Bot);
@@ -1878,7 +1880,7 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
     }
     else
     {
-      InsertEdgeIntoAEL(lb, 0);
+      InsertEdgeIntoAEL(lb, VXL_NULLPTR);
       InsertEdgeIntoAEL(rb, lb);
       SetWindingCount( *lb );
       rb->WindCnt = lb->WindCnt;
@@ -1956,8 +1958,8 @@ void Clipper::DeleteFromAEL(TEdge *e)
   if( AelPrev ) AelPrev->NextInAEL = AelNext;
   else m_ActiveEdges = AelNext;
   if( AelNext ) AelNext->PrevInAEL = AelPrev;
-  e->NextInAEL = 0;
-  e->PrevInAEL = 0;
+  e->NextInAEL = VXL_NULLPTR;
+  e->PrevInAEL = VXL_NULLPTR;
 }
 //------------------------------------------------------------------------------
 
@@ -1969,8 +1971,8 @@ void Clipper::DeleteFromSEL(TEdge *e)
   if( SelPrev ) SelPrev->NextInSEL = SelNext;
   else m_SortedEdges = SelNext;
   if( SelNext ) SelNext->PrevInSEL = SelPrev;
-  e->NextInSEL = 0;
-  e->PrevInSEL = 0;
+  e->NextInSEL = VXL_NULLPTR;
+  e->PrevInSEL = VXL_NULLPTR;
 }
 //------------------------------------------------------------------------------
 
@@ -2306,15 +2308,15 @@ void Clipper::AppendPolygon(TEdge *e1, TEdge *e2)
     Side = esRight;
   }
 
-  outRec1->BottomPt = 0;
+  outRec1->BottomPt = VXL_NULLPTR;
   if (holeStateRec == outRec2)
   {
     if (outRec2->FirstLeft != outRec1)
       outRec1->FirstLeft = outRec2->FirstLeft;
     outRec1->IsHole = outRec2->IsHole;
   }
-  outRec2->Pts = 0;
-  outRec2->BottomPt = 0;
+  outRec2->Pts = VXL_NULLPTR;
+  outRec2->BottomPt = VXL_NULLPTR;
   outRec2->FirstLeft = outRec1;
 
   int OKIdx = e1->OutIdx;
@@ -2344,10 +2346,10 @@ OutRec* Clipper::CreateOutRec()
   OutRec* result = new OutRec;
   result->IsHole = false;
   result->IsOpen = false;
-  result->FirstLeft = 0;
-  result->Pts = 0;
-  result->BottomPt = 0;
-  result->PolyNd = 0;
+  result->FirstLeft = VXL_NULLPTR;
+  result->Pts = VXL_NULLPTR;
+  result->BottomPt = VXL_NULLPTR;
+  result->PolyNd = VXL_NULLPTR;
   m_PolyOuts.push_back(result);
   result->Idx = (int)m_PolyOuts.size()-1;
   return result;
@@ -2425,7 +2427,7 @@ inline bool IsIntermediate(TEdge *e, const cInt Y)
 
 TEdge *GetMaximaPair(TEdge *e)
 {
-  TEdge* result = 0;
+  TEdge* result = VXL_NULLPTR;
   if ((e->Next->Top == e->Top) && !e->Next->NextInLML)
     result = e->Next;
   else if ((e->Prev->Top == e->Top) && !e->Prev->NextInLML)
@@ -2434,7 +2436,7 @@ TEdge *GetMaximaPair(TEdge *e)
   if (result && (result->OutIdx == Skip ||
     //result is false if both NextInAEL & PrevInAEL are nil & not horizontal ...
     (result->NextInAEL == result->PrevInAEL && !IsHorizontal(*result))))
-      return 0;
+      return VXL_NULLPTR;
   return result;
 }
 //------------------------------------------------------------------------------
@@ -2571,7 +2573,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge, bool isTopOfScanbeam)
 
   GetHorzDirection(*horzEdge, dir, horzLeft, horzRight);
 
-  TEdge* eLastHorz = horzEdge, *eMaxPair = 0;
+  TEdge* eLastHorz = horzEdge, *eMaxPair = VXL_NULLPTR;
   while (eLastHorz->NextInLML && IsHorizontal(*eLastHorz->NextInLML))
     eLastHorz = eLastHorz->NextInLML;
   if (!eLastHorz->NextInLML)
@@ -2720,11 +2722,11 @@ bool Clipper::ProcessIntersections(const cInt topY)
   }
   catch(...)
   {
-    m_SortedEdges = 0;
+    m_SortedEdges = VXL_NULLPTR;
     DisposeIntersectNodes();
     throw clipperException("ProcessIntersections error");
   }
-  m_SortedEdges = 0;
+  m_SortedEdges = VXL_NULLPTR;
   return true;
 }
 //------------------------------------------------------------------------------
@@ -2777,11 +2779,11 @@ void Clipper::BuildIntersectList(const cInt topY)
       else
         e = eNext;
     }
-    if( e->PrevInSEL ) e->PrevInSEL->NextInSEL = 0;
+    if( e->PrevInSEL ) e->PrevInSEL->NextInSEL = VXL_NULLPTR;
     else break;
   }
   while ( isModified );
-  m_SortedEdges = 0; //important
+  m_SortedEdges = VXL_NULLPTR; //important
 }
 //------------------------------------------------------------------------------
 
@@ -2956,7 +2958,7 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
   {
     if(IsIntermediate(e, topY))
     {
-      OutPt* op = 0;
+      OutPt* op = VXL_NULLPTR;
       if( e->OutIdx >= 0 )
         op = AddOutPt(e, e->Top);
       UpdateEdgeIntoAEL(e);
@@ -2992,8 +2994,8 @@ void Clipper::FixupOutPolygon(OutRec &outrec)
 {
   //FixupOutPolygon() - removes duplicate points and simplifies consecutive
   //parallel edges by removing the middle vertex.
-  OutPt *lastOK = 0;
-  outrec.BottomPt = 0;
+  OutPt *lastOK = VXL_NULLPTR;
+  outrec.BottomPt = VXL_NULLPTR;
   OutPt *pp = outrec.Pts;
 
   for (;;)
@@ -3001,7 +3003,7 @@ void Clipper::FixupOutPolygon(OutRec &outrec)
     if (pp->Prev == pp || pp->Prev == pp->Next )
     {
       DisposeOutPts(pp);
-      outrec.Pts = 0;
+      outrec.Pts = VXL_NULLPTR;
       return;
     }
 
@@ -3011,7 +3013,7 @@ void Clipper::FixupOutPolygon(OutRec &outrec)
       (!m_PreserveCollinear ||
       !Pt2IsBetweenPt1AndPt3(pp->Prev->Pt, pp->Pt, pp->Next->Pt))))
     {
-      lastOK = 0;
+      lastOK = VXL_NULLPTR;
       OutPt *tmp = pp;
       pp->Prev->Next = pp->Next;
       pp->Next->Prev = pp->Prev;
@@ -3080,7 +3082,7 @@ void Clipper::BuildResult2(PolyTree& polytree)
         //nb: polytree takes ownership of all the PolyNodes
         polytree.AllNodes.push_back(pn);
         outRec->PolyNd = pn;
-        pn->Parent = 0;
+        pn->Parent = VXL_NULLPTR;
         pn->Index = 0;
         pn->Contour.reserve(cnt);
         OutPt *op = outRec->Pts->Prev;
@@ -3168,13 +3170,13 @@ void Clipper::InsertEdgeIntoAEL(TEdge *edge, TEdge* startEdge)
 {
   if(!m_ActiveEdges)
   {
-    edge->PrevInAEL = 0;
-    edge->NextInAEL = 0;
+    edge->PrevInAEL = VXL_NULLPTR;
+    edge->NextInAEL = VXL_NULLPTR;
     m_ActiveEdges = edge;
   }
   else if(!startEdge && E2InsertsBeforeE1(*m_ActiveEdges, *edge))
   {
-      edge->PrevInAEL = 0;
+      edge->PrevInAEL = VXL_NULLPTR;
       edge->NextInAEL = m_ActiveEdges;
       m_ActiveEdges->PrevInAEL = edge;
       m_ActiveEdges = edge;
@@ -3524,7 +3526,7 @@ void Clipper::JoinCommonEdges()
       //instead of joining two polygons, we've just created a new one by
       //splitting one polygon into two.
       outRec1->Pts = join->OutPt1;
-      outRec1->BottomPt = 0;
+      outRec1->BottomPt = VXL_NULLPTR;
       outRec2 = CreateOutRec();
       outRec2->Pts = join->OutPt2;
 
@@ -3583,8 +3585,8 @@ void Clipper::JoinCommonEdges()
     {
       //joined 2 polygons together ...
 
-      outRec2->Pts = 0;
-      outRec2->BottomPt = 0;
+      outRec2->Pts = VXL_NULLPTR;
+      outRec2->BottomPt = VXL_NULLPTR;
       outRec2->Idx = outRec1->Idx;
 
       outRec1->IsHole = holeStateRec->IsHole;

--- a/v3p/netlib/linalg/lsmrBase.cxx
+++ b/v3p/netlib/linalg/lsmrBase.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "lsmrBase.h"
+#include "vcl_compiler_detection.h"
 
 #include <algorithm>
 #include <cmath>
@@ -40,7 +41,7 @@ lsmrBase::lsmrBase()
   this->btol = 1e-6;
   this->conlim = 1.0 / ( 10 * sqrt( this->eps ) );
   this->itnlim = 10;
-  this->nout = NULL;
+  this->nout = VXL_NULLPTR;
   this->istop = 0;
   this->itn = 0;
   this->normA = 0.0;

--- a/v3p/netlib/linalg/lsmrDense.cxx
+++ b/v3p/netlib/linalg/lsmrDense.cxx
@@ -16,10 +16,11 @@
  *
  *=========================================================================*/
 #include "lsmrDense.h"
+#include "vcl_compiler_detection.h"
 
 lsmrDense::lsmrDense()
 {
-  this->A = 0;
+  this->A = VXL_NULLPTR;
 }
 
 

--- a/v3p/netlib/linalg/lsqrDense.cxx
+++ b/v3p/netlib/linalg/lsqrDense.cxx
@@ -17,10 +17,11 @@
  *=========================================================================*/
 
 #include "lsqrDense.h"
+#include "vcl_compiler_detection.h"
 
 lsqrDense::lsqrDense()
 {
-  this->A = 0;
+  this->A = VXL_NULLPTR;
 }
 
 


### PR DESCRIPTION
STYLE: Use VTK_NULLPTR to utilize c++11 features
    
    Where available, use c++11 features to identify
    potential nullptr usage errors.
