### PR TITLE
COMP: Use C++ headers over C headers

### DIFF
--- a/contrib/brl/b3p/expatpp/expatpp.cpp
+++ b/contrib/brl/b3p/expatpp/expatpp.cpp
@@ -8,7 +8,7 @@
   #include <cstring> // for std::strlen() & strcmp()
   #include <string>
   using namespace std;
-  #include <assert.h>
+  #include <cassert>
 #endif
 #include "expatpp.h"
 

--- a/contrib/brl/bbas/volm/volm_utils.cxx
+++ b/contrib/brl/bbas/volm/volm_utils.cxx
@@ -1,6 +1,6 @@
 #include <iostream>
 #include "volm_utils.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <vcl_compiler.h>
 #include <vcl_where_root_dir.h>
 

--- a/contrib/brl/bseg/boxm2/boxm2_scene.cxx
+++ b/contrib/brl/bseg/boxm2/boxm2_scene.cxx
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <cmath>
-#include <stddef.h>
+#include <cstddef>
 #include "boxm2_scene.h"
 //:
 // \file

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_refine_block_function_with_labels.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_refine_block_function_with_labels.cxx
@@ -1,5 +1,5 @@
 #include "boxm2_refine_block_function_with_labels.h"
-#include <stdlib.h>
+#include <cstdlib>
 //:
 // \file
 

--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.h
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.h
@@ -4,7 +4,7 @@
 #include <boxm2/boxm2_scene.h>
 #include <vcl_compiler.h>
 #include <vector>
-#include <stddef.h>
+#include <cstddef>
 #include <boxm2/boxm2_block.h>
 #include <boxm2/basic/boxm2_block_id.h>
 #include <boxm2/boxm2_data.h>

--- a/contrib/mul/msm/tools/msm_reset_shape_modes.cxx
+++ b/contrib/mul/msm/tools/msm_reset_shape_modes.cxx
@@ -19,7 +19,7 @@
 #include <vsl/vsl_quick_file.h>
 #include <msm/msm_shape_instance.h>
 #include <msm/msm_add_all_loaders.h>
-#include <limits.h>
+#include <climits>
 
 /*
 Parameter file format:

--- a/core/vgl/vgl_affine_coordinates.hxx
+++ b/core/vgl/vgl_affine_coordinates.hxx
@@ -9,7 +9,7 @@
 #include <vgl/vgl_vector_3d.h>
 #include <vgl/vgl_tolerance.h>
 #include <cassert>
-#include <math.h>
+#include <cmath>
 // Points are all coplanar. The first three points in pts are the basis, pts[0] is the origin
 template <class T>
 void vgl_affine_coordinates_2d(std::vector<vgl_point_2d<T> > const& pts, std::vector<vgl_point_2d<T> >& affine_pts)

--- a/core/vil/file_formats/vil_viffheader.cxx
+++ b/core/vil/file_formats/vil_viffheader.cxx
@@ -2,7 +2,7 @@
 // \file
 #include "vil_viffheader.h"
 #include "vcl_compiler.h"
-#include <string.h>
+#include <cstring>
 
 
 //: Construct an image header

--- a/core/vnl/vnl_math.cxx
+++ b/core/vnl/vnl_math.cxx
@@ -26,7 +26,7 @@
 #endif
 
 #elif VXL_HAS_STD_ISFINITE || VXL_HAS_STD_ISNAN ||  VXL_HAS_STD_ISNORMAL
-# include<math.h>
+# include<cmath>
 # if VXL_HAS_STD_ISFINITE
 #    define finite  std::isfinite
 #    define finitef std::isfinite

--- a/core/vnl/vnl_sample.cxx
+++ b/core/vnl/vnl_sample.cxx
@@ -11,7 +11,7 @@
 #include <vcl_compiler.h>
 #include <vxl_config.h>
 
-#include <stdlib.h> // dont_vxl_filter
+#include <cstdlib> // dont_vxl_filter
 
 #if !VXL_STDLIB_HAS_DRAND48
 // rand() is not always a good random number generator,

--- a/core/vpl/os_unix/vpl.cxx
+++ b/core/vpl/os_unix/vpl.cxx
@@ -8,8 +8,8 @@ extern "C" {
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>  // for strdup
+#include <cstdlib>
+#include <cstring>  // for strdup
 }
 #include <vxl_config.h> // for VXL_UNISTD_*
 

--- a/core/vul/vul_temp_filename.cxx
+++ b/core/vul/vul_temp_filename.cxx
@@ -16,7 +16,7 @@
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
   // Helper functions for Unix
 
-  #include <stdio.h>  // for P_tmpdir
+  #include <cstdio>  // for P_tmpdir
   #include <unistd.h> // for unlink
   #include <fcntl.h>  // for O_CREATE,...
 


### PR DESCRIPTION
Some headers from C library were deprecated in C++ and are no longer
welcome in C++ codebases. Some have no effect in C++. For more details
refer to the C++ 14 Standard [depr.c.headers] section.

This patch replaces C standard library headers with their C++
alternatives and removes redundant ones.