### PR TITLE
STYLE: macro definition with () protected arguments

### DIFF
--- a/core/vbl/vbl_array_3d.h
+++ b/core/vbl/vbl_array_3d.h
@@ -29,8 +29,8 @@
 # define RANGECHECK(i,j,k) ((void)0)
 #else
 # include <vcl_cassert.h>
-# define RANGECHECK(i,j,k) assert(((size_type)i < row1_count_) && \
-                   ((size_type)j < row2_count_) && ((size_type)k < row3_count_))
+# define RANGECHECK(i,j,k) assert(((size_type)(i) < row1_count_) && \
+                   ((size_type)(j) < row2_count_) && ((size_type)(k) < row3_count_))
 #endif
 
 //: Templated 3-dimensional array

--- a/core/vbl/vbl_qsort.h
+++ b/core/vbl/vbl_qsort.h
@@ -112,8 +112,8 @@ void vbl_qsort(std::vector<T>& v, int (*compare)(T const& a, T const& b))
 }
 
 #define VBL_QSORT_INSTANTIATE(T) \
-VCL_INSTANTIATE_INLINE(void vbl_qsort_ascending(T*,int));\
-VCL_INSTANTIATE_INLINE(void vbl_qsort_descending(T*,int))
+VCL_INSTANTIATE_INLINE(void vbl_qsort_ascending((T)*,int));\
+VCL_INSTANTIATE_INLINE(void vbl_qsort_descending((T)*,int))
 
 #define VBL_QSORT_INSTANTIATE_vector(T) \
 VCL_INSTANTIATE_INLINE(void vbl_qsort(std::vector<T >& v, \

--- a/core/vgl/algo/tests/test_conic.cxx
+++ b/core/vgl/algo/tests/test_conic.cxx
@@ -63,7 +63,7 @@ conic_distance(vgl_conic<double> const& c1, vgl_conic<double> const& c2)
   else if ( c1.f() != 0 && c2.f() != 0 )  k = c1.f() / c2.f();
   else                                    k = 1.0;
 
-#define DO_MAX(x,a) if ((a)>(x)) x=a
+#define DO_MAX(x,a) if ((a)>(x)) (x)=a
   double expr = std::abs( c1.a() - c2.a() * k );
   DO_MAX(expr,  std::abs( c1.b() - c2.b() * k ));
   DO_MAX(expr,  std::abs( c1.c() - c2.c() * k ));

--- a/core/vgl/algo/tests/test_rotation_3d.cxx
+++ b/core/vgl/algo/tests/test_rotation_3d.cxx
@@ -186,7 +186,7 @@ void test_rotation_3d()
   TEST_NEAR("constructor from two vgl vectors", errorf, 0.0f, 1e-6f);
   vnl_vector_fixed<vnl_rational,3> ai(1L, 1L, 0L), bi(1L, -1L, 0L);
   vgl_rotation_3d<vnl_rational> r_abi(ai, bi);
-#define sqr(x) (x)*(x)
+#define sqr(x) ((x)*(x))
   error1 = sqr(double(r_abi.as_quaternion()[0]))
          + sqr(double(r_abi.as_quaternion()[1]))
          + sqr(double(r_abi.as_quaternion()[2]) + vnl_math::sqrt1_2)

--- a/core/vgl/algo/vgl_convex_hull_2d.hxx
+++ b/core/vgl/algo/vgl_convex_hull_2d.hxx
@@ -52,7 +52,7 @@ static int ccw(double **P, int i, int j, int k)
 
 
 #define CMPM(c,A,B) \
-  v = (*(double*const*)A)[c] - (*(double*const*)B)[c];\
+  v = (*(double*const*)(A))[c] - (*(double*const*)(B))[c];\
   if (v>0) return 1;\
   if (v<0) return -1
 

--- a/core/vgl/algo/vgl_homg_operators_3d.hxx
+++ b/core/vgl/algo/vgl_homg_operators_3d.hxx
@@ -477,7 +477,7 @@ vgl_homg_operators_3d<T>::perp_dist_squared(const vgl_homg_point_3d<T>& point,
     return 1e38;
   }
 
-#define dot(p,q) p.a()*q.x()+p.b()*q.y()+p.c()*q.z()+p.d()*q.w()
+#define dot(p,q) ((p).a()*(q).x()+(p).b()*(q).y()+(p).c()*(q).z()+(p).d()*(q).w())
   double numerator = dot(plane,point) / point.w();
 #undef dot
   if (numerator == 0) return 0.0;

--- a/core/vgl/vgl_homg_line_2d.h
+++ b/core/vgl/vgl_homg_line_2d.h
@@ -102,7 +102,7 @@ class vgl_homg_line_2d
   //  This version checks (max(|a|,|b|) <= tol * |c|
   inline bool ideal(T tol = (T)0) const
   {
-#define vgl_Abs(x) (x<0?-x:x) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
+#define vgl_Abs(x) ((x)<0?-(x):(x)) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
     return vgl_Abs(a()) <= tol*vgl_Abs(c()) && vgl_Abs(b()) <= tol*vgl_Abs(c());
 #undef vgl_Abs
   }

--- a/core/vgl/vgl_homg_line_2d.hxx
+++ b/core/vgl/vgl_homg_line_2d.hxx
@@ -47,11 +47,11 @@ vgl_homg_line_2d<Type>::vgl_homg_line_2d (vgl_homg_point_2d<Type> const& p1,
   assert(a_||b_||c_); // given points should be different
 }
 
-#define vp(os,v,s) { os<<' '; if ((v)>0) os<<'+';\
-                     if ((v)&&!s[0]) os<<(v); else { \
-                       if ((v)==-1) os<<'-';\
-                       else if ((v)!=0&&(v)!=1) os<<(v);\
-                       if ((v)!=0) os<<' '<<s; } }
+#define vp(os,v,s) { (os)<<' '; if ((v)>0) (os)<<'+';\
+                     if ((v)&&!(s)[0]) (os)<<(v); else { \
+                       if ((v)==-1) (os)<<'-';\
+                       else if ((v)!=0&&(v)!=1) (os)<<(v);\
+                       if ((v)!=0) (os)<<' '<<(s); } }
 
 //: Print line equation to stream
 template <class Type>

--- a/core/vgl/vgl_homg_plane_3d.h
+++ b/core/vgl/vgl_homg_plane_3d.h
@@ -87,7 +87,7 @@ class vgl_homg_plane_3d
   // If called without an argument, tol=0, i.e., a, b and c must be 0.
   inline bool ideal(Type tol = (Type)0) const
   {
-#define vgl_Abs(x) (x<0?-x:x) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
+#define vgl_Abs(x) ((x)<0?-(x):(x)) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
     return vgl_Abs(a()) <= tol * vgl_Abs(d()) &&
            vgl_Abs(b()) <= tol * vgl_Abs(d()) &&
            vgl_Abs(c()) <= tol * vgl_Abs(d());

--- a/core/vgl/vgl_homg_point_1d.h
+++ b/core/vgl/vgl_homg_point_1d.h
@@ -66,7 +66,7 @@ class vgl_homg_point_1d
   //: Return true iff the point is at infinity (an ideal point).
   // The method checks whether |w| <= tol * |x|
   inline bool ideal(T tol = T(0)) const {
-#define vgl_Abs(x) (x<0?-x:x) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
+#define vgl_Abs(x) ((x)<0?-(x):(x)) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
     return vgl_Abs(w()) <= tol * vgl_Abs(x());
 #undef vgl_Abs
   }

--- a/core/vgl/vgl_homg_point_2d.h
+++ b/core/vgl/vgl_homg_point_2d.h
@@ -99,7 +99,7 @@ class vgl_homg_point_2d
   // The method checks whether |w| <= tol * max(|x|,|y|)
   inline bool ideal(T tol = (T)0) const
   {
-#define vgl_Abs(x) (x<0?-x:x) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
+#define vgl_Abs(x) ((x)<0?-(x):(x)) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
     return vgl_Abs(w()) <= tol * vgl_Abs(x()) ||
            vgl_Abs(w()) <= tol * vgl_Abs(y());
 #undef vgl_Abs

--- a/core/vgl/vgl_homg_point_3d.h
+++ b/core/vgl/vgl_homg_point_3d.h
@@ -96,7 +96,7 @@ class vgl_homg_point_3d
   // The method checks whether |w| <= tol * max(|x|,|y|,|z|)
   inline bool ideal(Type tol = (Type)0) const
   {
-#define vgl_Abs(x) (x<0?-x:x) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
+#define vgl_Abs(x) ((x)<0?-(x):(x)) // avoid #include of vcl_cmath.h AND vcl_cstdlib.h
     return vgl_Abs(w()) <= tol * vgl_Abs(x()) ||
            vgl_Abs(w()) <= tol * vgl_Abs(y()) ||
            vgl_Abs(w()) <= tol * vgl_Abs(z());

--- a/core/vgl/vgl_line_2d.hxx
+++ b/core/vgl/vgl_line_2d.hxx
@@ -88,10 +88,10 @@ bool vgl_line_2d<Type>::normalize()
   return mag>0.99 && mag<1.01;
 }
 
-#define vp(os,v,s) { os<<' '; if ((v)>0) os<<'+'; if ((v)&&!s[0]) os<<(v); else { \
-                     if ((v)==-1) os<<'-';\
-                     else if ((v)!=0&&(v)!=1) os<<(v);\
-                     if ((v)!=0) os<<' '<<s; } }
+#define vp(os,v,s) { (os)<<' '; if ((v)>0) (os)<<'+'; if ((v)&&!(s)[0]) (os)<<(v); else { \
+                     if ((v)==-1) (os)<<'-';\
+                     else if ((v)!=0&&(v)!=1) (os)<<(v);\
+                     if ((v)!=0) (os)<<' '<<(s); } }
 
 //: Write line description to stream: "<vgl_line_2d ax+by+c=0>"
 template <class Type>

--- a/core/vgl/vgl_plane_3d.hxx
+++ b/core/vgl/vgl_plane_3d.hxx
@@ -108,10 +108,10 @@ bool vgl_plane_3d<T>::operator==(vgl_plane_3d<T> const& p) const
           && (c()*p.d()==p.c()*d()) );
 }
 
-#define vp(os,v,s) { os<<' '; if ((v)>0) os<<'+'; if ((v)&&!s[0]) os<<(v); else { \
-                     if ((v)==-1) os<<'-';\
-                     else if ((v)!=0&&(v)!=1) os<<(v);\
-                     if ((v)!=0) os<<' '<<s; } }
+#define vp(os,v,s) { (os)<<' '; if ((v)>0) (os)<<'+'; if ((v)&&!(s)[0]) (os)<<(v); else { \
+                     if ((v)==-1) (os)<<'-';\
+                     else if ((v)!=0&&(v)!=1) (os)<<(v);\
+                     if ((v)!=0) (os)<<' '<<(s); } }
 
 template <class T>
 std::ostream& operator<<(std::ostream& os, const vgl_plane_3d<T>& p)

--- a/core/vidl/vidl_color.cxx
+++ b/core/vidl/vidl_color.cxx
@@ -28,7 +28,7 @@ struct type_index;
 template <> \
 struct type_index<T> \
 {\
-enum { index = NUM };\
+enum { index = (NUM) };\
 }
 
 vidl_type_index_mac(vxl_byte, 0);

--- a/core/vidl/vidl_pixel_format.h
+++ b/core/vidl/vidl_pixel_format.h
@@ -200,7 +200,7 @@ template <vidl_pixel_color color_type>
 template <> \
 struct vidl_color_traits_of<VIDL_PIXEL_COLOR_##COL> \
 {\
-  enum { num_channels = NC }; \
+  enum { num_channels = (NC) }; \
 }
 
 vidl_ct_mac( UNKNOWN,  0 );
@@ -226,14 +226,14 @@ struct vidl_pixel_traits_of<VIDL_PIXEL_FORMAT_##FMT> \
 {\
   static inline std::string name() { return NAME; }\
   typedef T type;\
-  enum { bits_per_pixel = BPP };\
+  enum { bits_per_pixel = (BPP) };\
   enum { num_channels = vidl_color_traits_of<VIDL_PIXEL_COLOR_##CLR>::num_channels };\
   static inline vidl_pixel_color color() { return VIDL_PIXEL_COLOR_##CLR; }\
   enum { color_idx = VIDL_PIXEL_COLOR_##CLR };\
   static inline vidl_pixel_arrangement arrangement() { return VIDL_PIXEL_ARRANGE_##ARNG; }\
   enum { arrangement_idx = VIDL_PIXEL_ARRANGE_##ARNG };\
-  enum { chroma_shift_x = XCS };\
-  enum { chroma_shift_y = YCS };\
+  enum { chroma_shift_x = (XCS) };\
+  enum { chroma_shift_y = (YCS) };\
 }
 
 //            format    name             type         bpp  color    arrange  xcs  ycs

--- a/core/vil/tests/test_na.cxx
+++ b/core/vil/tests/test_na.cxx
@@ -15,9 +15,9 @@ void test_na()
   float na_f = vil_na(float());
 
 #define print_hex(p) \
-  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&p)[sizeof(p)-1]; \
+  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&(p))[sizeof(p)-1]; \
   for (unsigned int i=2; i<=sizeof(p); ++i) \
-    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&p))[sizeof(p)-i]; \
+    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&(p)))[sizeof(p)-i]; \
   std::cout<<std::dec
 
   std::cout << "qnan_d = " << qnan_d << " = " << print_hex(qnan_d) << std::endl

--- a/core/vil1/vil1_clamp_image.cxx
+++ b/core/vil1/vil1_clamp_image.cxx
@@ -10,8 +10,8 @@
 
 #undef VIL1_CLAMP_IMAGE_THRESHOLD
 #define VIL1_CLAMP_IMAGE_THRESHOLD(V, L, H) \
-  if (V > H) V = H; \
-  else if (V < L) V = L
+  if ((V) > (H)) (V) = H; \
+  else if ((V) < (L)) (V) = L
 
 template <class T>
 bool vil1_clamp_image(vil1_image const& base, double low, double high,

--- a/core/vil1/vil1_image_impl.h
+++ b/core/vil1/vil1_image_impl.h
@@ -159,7 +159,7 @@ class vil1_image_impl
 };
 
 #define VIL1_DISPATCH_AUX(VTYPE, uchar, Template, Args) \
-case VTYPE: Template<uchar > Args; break;
+case VTYPE: (Template)<uchar > (Args); break;
 
 #define VIL1_DISPATCH_IMAGE_OP(f, Template, Args) \
 switch (f) {\

--- a/core/vnl/algo/vnl_lbfgs.cxx
+++ b/core/vnl/algo/vnl_lbfgs.cxx
@@ -105,8 +105,8 @@ bool vnl_lbfgs::minimize(vnl_vector<double>& x)
       best_f = f;
     }
 
-#define print_(i,a,b,c,d) std::cerr<<std::setw(6)<<i<<' '<<std::setw(20)<<a<<' '\
-           <<std::setw(20)<<b<<' '<<std::setw(20)<<c<<' '<<std::setw(20)<<d<<'\n'
+#define print_(i,a,b,c,d) std::cerr<<std::setw(6)<<(i)<<' '<<std::setw(20)<<(a)<<' '\
+           <<std::setw(20)<<(b)<<' '<<std::setw(20)<<(c)<<' '<<std::setw(20)<<(d)<<'\n'
 
     if (check_derivatives_)
     {

--- a/core/vnl/tests/test_arithmetic.cxx
+++ b/core/vnl/tests/test_arithmetic.cxx
@@ -15,10 +15,10 @@
 // --- dynamic ------------------------------
 
 #define NewMat(mat, r,c,data) \
-   assert( sizeof(data) >= r*c*sizeof(double) ); \
+   assert( sizeof(data) >= (r)*(c)*sizeof(double) ); \
    vnl_matrix<double> mat( data, r, c )
 #define NewVec(vec, n,data) \
-   assert( sizeof(data) >= n*sizeof(double) ); \
+   assert( sizeof(data) >= (n)*sizeof(double) ); \
    vnl_vector<double> vec( data, n )
 
 static
@@ -35,10 +35,10 @@ test_arithmetic_dynamic()
 // --- ref ----------------------------------
 
 #define NewMat(mat, r,c,data) \
-   assert( sizeof(data) >= r*c*sizeof(double) ); \
+   assert( sizeof(data) >= (r)*(c)*sizeof(double) ); \
    vnl_matrix_ref<double> mat( r, c, data )
 #define NewVec(vec, n,data) \
-   assert( sizeof(data) >= n*sizeof(double) ); \
+   assert( sizeof(data) >= (n)*sizeof(double) ); \
    vnl_vector_ref<double> vec( n, data )
 
 static
@@ -55,10 +55,10 @@ test_arithmetic_ref()
 #undef NewVec
 
 #define NewMat(mat, r,c,data) \
-   assert( sizeof(data) >= r*c*sizeof(double) ); \
+   assert( sizeof(data) >= (r)*(c)*sizeof(double) ); \
    vnl_matrix_fixed<double,r,c> mat( data )
 #define NewVec(vec, n,data) \
-   assert( sizeof(data) >= n*sizeof(double) ); \
+   assert( sizeof(data) >= (n)*sizeof(double) ); \
    vnl_vector_fixed<double,n> vec( data )
 
 void

--- a/core/vnl/tests/test_na.cxx
+++ b/core/vnl/tests/test_na.cxx
@@ -9,9 +9,9 @@
 
 
 #define print_hex(p) \
-  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&p)[sizeof(p)-1]; \
+  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&(p))[sizeof(p)-1]; \
   for (unsigned int i=2; i<=sizeof(p); ++i) \
-    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&p))[sizeof(p)-i]; \
+    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&(p)))[sizeof(p)-i]; \
   std::cout<<std::dec
 
 
@@ -156,9 +156,9 @@ void test_na()
   float na_f = vnl_na(float());
 
 #define print_hex(p) \
-  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&p)[sizeof(p)-1]; \
+  std::hex<<std::setfill('0')<<std::setw(2)<<(short)reinterpret_cast<unsigned char*>(&(p))[sizeof(p)-1]; \
   for (unsigned int i=2; i<=sizeof(p); ++i) \
-    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&p))[sizeof(p)-i]; \
+    std::cout<<std::setfill('0')<<std::setw(2)<<(short)(reinterpret_cast<unsigned char*>(&(p)))[sizeof(p)-i]; \
   std::cout<<std::dec
 
   std::cout << "qnan_d = " << qnan_d << " = " << print_hex(qnan_d) << '\n'

--- a/core/vnl/vnl_sse.h
+++ b/core/vnl/vnl_sse.h
@@ -77,8 +77,8 @@
 # define VNL_SSE_HEAP_STORE(pf) _mm_storeu_##pf
 # define VNL_SSE_HEAP_LOAD(pf) _mm_loadu_##pf
 # if VNL_CONFIG_THREAD_SAFE
-#   define VNL_SSE_ALLOC(n,s,a) new char[n*s]
-#   define VNL_SSE_FREE(v,n,s) delete [] static_cast<char*>(v)
+#   define VNL_SSE_ALLOC(n,s,a) new char[(n)*(s)]
+#   define VNL_SSE_FREE(v,n,s) (delete [] static_cast<char*>(v))
 # else
 #   define VNL_SSE_ALLOC(n,s,a) vnl_alloc::allocate((n == 0) ? 8 : (n * s));
 #   define VNL_SSE_FREE(v,n,s) if (v) vnl_alloc::deallocate(v, (n == 0) ? 8 : (n * s));

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -65,7 +65,7 @@
 #define vnl_vector_alloc_blah(size) \
 do { \
   this->num_elmts = (size); \
-  this->data = size ? vnl_c_vector<T>::allocate_T(size) : 0; \
+  this->data = (size) ? vnl_c_vector<T>::allocate_T(size) : 0; \
 } while (false)
 
 // This macro deallocates the dynamic storage used by a vnl_vector.

--- a/core/vsl/vsl_binary_explicit_io.h
+++ b/core/vsl/vsl_binary_explicit_io.h
@@ -159,7 +159,7 @@ macro(std::size_t);
 // If you are converting several integers at once, multiply the value by
 // the number of integers.
 #define VSL_MAX_ARBITRARY_INT_BUFFER_LENGTH(size_of_type) \
-  (((size_of_type * 8)/7) + ((((size_of_type * 8) % 7) == 0) ? 0: 1))
+  ((((size_of_type) * 8)/7) + (((((size_of_type) * 8) % 7) == 0) ? 0: 1))
 
 
 //: Implement arbitrary length conversion for unsigned integers.

--- a/core/vsl/vsl_binary_loader.hxx
+++ b/core/vsl/vsl_binary_loader.hxx
@@ -103,7 +103,7 @@ template <> std::string vsl_binary_loader<T >::is_a() const \
 template class vsl_binary_loader<T >
 #define VSL_BINARY_LOADER_INSTANTIATE(T) \
 VSL_BINARY_LOADER_WITH_SPECIALIZATION_INSTANTIATE(T); \
-VCL_INSTANTIATE_INLINE(void vsl_b_read( vsl_b_istream& bfs, T*& b)); \
+VCL_INSTANTIATE_INLINE(void vsl_b_read( vsl_b_istream& bfs, (T)*& b)); \
 template void vsl_b_write(vsl_b_ostream& bfs, const T* b)
 
 #endif // vsl_binary_loader_hxx_

--- a/core/vul/vul_psfile.cxx
+++ b/core/vul/vul_psfile.cxx
@@ -10,9 +10,9 @@
 #include <vcl_compiler.h>
 #include <vcl_cassert.h>
 
-#define RANGE(a,b,c) { if (a < b) a = b;  if (a > c) a = c; }
-#define in_range(a) (a < 0x100)
-#define Hex4bit(a) ((char)((a<=9) ? (a+'0') : (a - 10 + 'a')))
+#define RANGE(a,b,c) { if ((a) < (b)) (a) = b;  if ((a) > (c)) (a) = c; }
+#define in_range(a) ((a) < 0x100)
+#define Hex4bit(a) ((char)(((a)<=9) ? ((a)+'0') : ((a) - 10 + 'a')))
 
 static const float PIX2INCH = 72.0f;
 static bool debug = true;

--- a/v3p/netlib/sparse/spMatrix.h
+++ b/v3p/netlib/sparse/spMatrix.h
@@ -175,15 +175,15 @@
  * Macro function that adds data to a imaginary element in the matrix by
  * a pointer.
  */
-#define  spADD_IMAG_ELEMENT(element,imag)       *(element+1) += imag
+#define  spADD_IMAG_ELEMENT(element,imag)       *((element)+1) += imag
 
 /*!
  * Macro function that adds data to a complex element in the matrix by
  * a pointer.
  */
 #define  spADD_COMPLEX_ELEMENT(element,real,imag)       \
-{   *(element) += real;                                 \
-    *(element+1) += imag;                               \
+{   *(element) += (real);                                 \
+    *((element)+1) += (imag);                               \
 }
 
 /*!
@@ -191,10 +191,10 @@
  * specified by the given template.
  */
 #define  spADD_REAL_QUAD(template,real)         \
-{   *((template).Element1) += real;             \
-    *((template).Element2) += real;             \
-    *((template).Element3Negated) -= real;      \
-    *((template).Element4Negated) -= real;      \
+{   *((template).Element1) += (real);             \
+    *((template).Element2) += (real);             \
+    *((template).Element3Negated) -= (real);      \
+    *((template).Element4Negated) -= (real);      \
 }
 
 /*!
@@ -202,10 +202,10 @@
  * elements specified by the given template.
  */
 #define  spADD_IMAG_QUAD(template,imag)         \
-{   *((template).Element1+1) += imag;           \
-    *((template).Element2+1) += imag;           \
-    *((template).Element3Negated+1) -= imag;    \
-    *((template).Element4Negated+1) -= imag;    \
+{   *((template).Element1+1) += (imag);           \
+    *((template).Element2+1) += (imag);           \
+    *((template).Element3Negated+1) -= (imag);    \
+    *((template).Element4Negated+1) -= (imag);    \
 }
 
 /*!
@@ -213,14 +213,14 @@
  * elements specified by the given template.
  */
 #define  spADD_COMPLEX_QUAD(template,real,imag) \
-{   *((template).Element1) += real;             \
-    *((template).Element2) += real;             \
-    *((template).Element3Negated) -= real;      \
-    *((template).Element4Negated) -= real;      \
-    *((template).Element1+1) += imag;           \
-    *((template).Element2+1) += imag;           \
-    *((template).Element3Negated+1) -= imag;    \
-    *((template).Element4Negated+1) -= imag;    \
+{   *((template).Element1) += (real);             \
+    *((template).Element2) += (real);             \
+    *((template).Element3Negated) -= (real);      \
+    *((template).Element4Negated) -= (real);      \
+    *((template).Element1+1) += (imag);           \
+    *((template).Element2+1) += (imag);           \
+    *((template).Element3Negated+1) -= (imag);    \
+    *((template).Element4Negated+1) -= (imag);    \
 }
 
 /*

--- a/vcl/tests/test_atomic_count.cxx
+++ b/vcl/tests/test_atomic_count.cxx
@@ -1,7 +1,7 @@
 #include <vcl_atomic_count.h>
 #include <vcl_cstdio.h>
 
-#define TEST(str,x,y) vcl_printf(str ":   "); if (x!=y) { vcl_printf("FAILED\n"); status = 1; } else { vcl_printf("PASSED\n"); }
+#define TEST(str,x,y) vcl_printf(str ":   "); if ((x)!=(y)) { vcl_printf("FAILED\n"); status = 1; } else { vcl_printf("PASSED\n"); }
 
 int test_atomic_count_main(int /*argc*/,char* /*argv*/[])
 {

--- a/vcl/tests/test_cmath.cxx
+++ b/vcl/tests/test_cmath.cxx
@@ -24,7 +24,7 @@ int test_cmath_main(int /*argc*/,char* /*argv*/[])
 
 #define macro(var, type) \
 do { \
-  if (vcl_abs(var) == var && vcl_abs(- var) == var) \
+  if (vcl_abs(var) == (var) && vcl_abs(- (var)) == (var)) \
     vcl_cout << "vcl_abs(" #type ") PASSED" << vcl_endl; \
   else \
     vcl_cerr << "vcl_abs(" #type ") *** FAILED *** " << vcl_endl; \
@@ -58,7 +58,7 @@ do { \
   do { \
     T x = 2; \
     T y = vcl_sqrt(x); \
-    if (vcl_abs(x - y*y) < eps) \
+    if (vcl_abs(x - y*y) < (eps)) \
       vcl_cout << "vcl_sqrt(" #T ") PASSED" << vcl_endl; \
     else \
       vcl_cout << "vcl_sqrt(" #T ") *** FAILED *** " << vcl_endl; \

--- a/vcl/tests/test_limits.cxx
+++ b/vcl/tests/test_limits.cxx
@@ -49,8 +49,8 @@ void test_static_const_definition()
 #undef TEST_TYPE
 }
 
-#define TEST(m,x,y)    if ((x)!=(y)) { vcl_cout<< "FAIL: " << m << '\n'; fail=true; } \
-                       else { vcl_cout<< "PASS: " << m << '\n'; }
+#define TEST(m,x,y)    if ((x)!=(y)) { vcl_cout<< "FAIL: " << (m) << '\n'; fail=true; } \
+                       else { vcl_cout<< "PASS: " << (m) << '\n'; }
 
 int test_limits_main(int /*argc*/, char* /*argv*/[])
 {

--- a/vcl/tests/test_sstream.cxx
+++ b/vcl/tests/test_sstream.cxx
@@ -2,7 +2,7 @@
 #include <vcl_iostream.h>
 #include <vcl_sstream.h>
 
-#define AssertEq(x,y) {status+=((x)==(y))?0:1;vcl_cout<<"TEST ["<<x<<"] == ["<<y<<"] : "<<((x)==(y)?"PASSED":"FAILED")<<vcl_endl;}
+#define AssertEq(x,y) {status+=((x)==(y))?0:1;vcl_cout<<"TEST ["<<(x)<<"] == ["<<(y)<<"] : "<<((x)==(y)?"PASSED":"FAILED")<<vcl_endl;}
 
 int test_sstream_main(int /*argc*/,char* /*argv*/[])
 {

--- a/vcl/tests/test_string.cxx
+++ b/vcl/tests/test_string.cxx
@@ -3,7 +3,7 @@
 
 #define Assert(x) {vcl_cout << "TEST " #x " : "; vcl_cout << ((x)?"PASSED":"FAILED")}
 
-#define AssertEq(x) {vcl_cout<<"TEST ["<<fred<<"] == ["<<x<<"] : ";vcl_cout<<(fred==(x)?"PASSED":"FAILED")<<vcl_endl;}
+#define AssertEq(x) {vcl_cout<<"TEST ["<<fred<<"] == ["<<(x)<<"] : ";vcl_cout<<(fred==(x)?"PASSED":"FAILED")<<vcl_endl;}
 
 int test_string_main(int /*argc*/,char* /*argv*/[])
 {


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/misc-macro-parentheses.html

Finds macros that can have unexpected behaviour due to missing
parentheses.  Macros are expanded by the preprocessor as-is. As a
result, there can be unexpected behaviour; operators may be evaluated in
unexpected order and unary operators may become binary operators, etc.
When the replacement list has an expression, it is recommended to
surround it with parentheses. This ensures that the macro result is
evaluated completely before it is used.

It is also recommended to surround macro arguments in the replacement
list with parentheses. This ensures that the argument value is
calculated properly.