### PR TITLE
Move the c++ headers out of the extern C block

### DIFF
--- a/core/vpl/os_unix/vpl.cxx
+++ b/core/vpl/os_unix/vpl.cxx
@@ -8,9 +8,9 @@ extern "C" {
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+}
 #include <cstdlib>
 #include <cstring>  // for strdup
-}
 #include <vxl_config.h> // for VXL_UNISTD_*
 
 char *


### PR DESCRIPTION
Keeping the C++ headers in the extern C block causes build failures with duplicate definitions of various functions.