### PR TITLE
COMP: Remove inheritance from std::<un|bin>ary_function

### DIFF
--- a/contrib/brl/bbas/bvgl/bvgl_point_3d_cmp.h
+++ b/contrib/brl/bbas/bvgl/bvgl_point_3d_cmp.h
@@ -19,7 +19,7 @@
 
 //: A comparison functor for vgl_point_3d's. Needed to create a std::set of vgl_point_3d<int>'s.
 template <class T>
-class bvgl_point_3d_cmp : public std::binary_function<vgl_point_3d<T>, vgl_point_3d<T>, bool>
+class bvgl_point_3d_cmp
 {
  public:
   bvgl_point_3d_cmp() {}

--- a/contrib/brl/bseg/boxm/basic/boxm_block_vis_graph_node.h
+++ b/contrib/brl/bseg/boxm/basic/boxm_block_vis_graph_node.h
@@ -10,7 +10,7 @@
 
 //: A comparison functor for vgl_point_3d's. Needed to create a std::set of vgl_point_3d<int>'s.
 template <class T>
-class vgl_point_3d_cmp : public std::binary_function<vgl_point_3d<T>, vgl_point_3d<T>, bool>
+class vgl_point_3d_cmp
 {
  public:
   vgl_point_3d_cmp() {}

--- a/contrib/mul/mbl/mbl_index_sort.h
+++ b/contrib/mul/mbl/mbl_index_sort.h
@@ -105,7 +105,7 @@ void mbl_index_sort(const std::vector<T>& data, std::vector<unsigned>& index)
 // \endcode
 template <class T, class INDEX=unsigned, class CONT = std::vector<T>,
   class CMP=std::less<T> >
-  struct mbl_index_sort_cmp: public std::binary_function<INDEX, INDEX, bool>
+  struct mbl_index_sort_cmp
 {
   explicit mbl_index_sort_cmp(const CONT &data, const CMP &c = CMP()):
     data_(data), cmp_(c) {}

--- a/contrib/mul/mbl/mbl_stl.h
+++ b/contrib/mul/mbl/mbl_stl.h
@@ -109,7 +109,7 @@ template<typename InputIterator,
 //NB something like this is in the SGI extension to the STL but is not included in the standard VCL
 //However this is very useful with map iterators so include it here
 template <class Pair>
-struct mbl_stl_select1st : public std::unary_function<Pair, typename Pair::first_type>
+struct mbl_stl_select1st
 {
   inline typename Pair::first_type const & operator()(Pair const & pair) const
   {
@@ -121,7 +121,7 @@ struct mbl_stl_select1st : public std::unary_function<Pair, typename Pair::first
 //NB something like this is in the SGI extension to the STL but is not included in the standard VCL
 //However this is very useful with map iterators so include it here
 template <class Pair>
-struct mbl_stl_select2nd : public std::unary_function<Pair, typename Pair::second_type>
+struct mbl_stl_select2nd
 {
   inline typename Pair::second_type const & operator()(Pair const & pair) const
   {
@@ -131,7 +131,7 @@ struct mbl_stl_select2nd : public std::unary_function<Pair, typename Pair::secon
 
 //Accumulate the second elements of a pair (e.g. for accumulating values through a map)
 template <class Pair>
-struct mbl_stl_add2nd : public std::binary_function<typename Pair::second_type, Pair, typename Pair::second_type>
+struct mbl_stl_add2nd
 {
   inline typename Pair::second_type  operator()(typename Pair::second_type partSum, Pair const & x2 ) const
   {

--- a/contrib/mul/mbl/mbl_stl_pred.h
+++ b/contrib/mul/mbl/mbl_stl_pred.h
@@ -19,7 +19,7 @@
 
 //: Return true if a string contains a substring
 // Note without this you'd need bind2nd mem_fun which can cause reference to reference compile errors
-class mbl_stl_pred_str_contains : public std::unary_function<std::string, bool>
+class mbl_stl_pred_str_contains
 {
   //: The sought substring
   const std::string& substr_;
@@ -35,7 +35,7 @@ class mbl_stl_pred_str_contains : public std::unary_function<std::string, bool>
 //: Adapt a predicate over a vector to the operation specified on an index into that vector
 // T is type of the vector, and Pred the boolean predicate to really be applied
 template <class T, class Pred>
-class mbl_stl_pred_index_adapter : public std::unary_function<unsigned, bool>
+class mbl_stl_pred_index_adapter
 {
   //:const reference to vector used to store the objects indexed
   const std::vector<T >& vec_;
@@ -51,7 +51,7 @@ class mbl_stl_pred_index_adapter : public std::unary_function<unsigned, bool>
 };
 
 template <class T, class Pred>
-class mbl_stl_pred_index_adapter_n : public std::unary_function<unsigned, bool>
+class mbl_stl_pred_index_adapter_n
 {
   //:const reference to vector used to store the objects indexed
   const vnl_vector<T >& vec_;
@@ -88,7 +88,7 @@ inline mbl_stl_pred_index_adapter_n<T,Pred> mbl_stl_pred_create_index_adapter(co
 //: Adapt a predicate over a vector to the operation specified on an index into that vector
 // T is type of the vector, and Pred the boolean predicate to really be applied
 template <class T, class Pred>
-class mbl_stl_pred_binary_index_adapter : public std::binary_function<unsigned, unsigned, bool>
+class mbl_stl_pred_binary_index_adapter
 {
   //:const reference to vector used to store the objects indexed
   const std::vector<T >& vec_;
@@ -119,7 +119,7 @@ inline mbl_stl_pred_binary_index_adapter<T,Pred> mbl_stl_pred_create_binary_inde
 //Can also be used for collections of pointers or objects supporting
 //dereferencing operator like *p.
 template <class Iter>
-struct mbl_stl_pred_iter_deref_order : public std::binary_function<Iter,Iter, bool>
+struct mbl_stl_pred_iter_deref_order
 {
   inline bool  operator()(const Iter& iter1, const Iter& iter2 ) const
   {
@@ -131,7 +131,7 @@ struct mbl_stl_pred_iter_deref_order : public std::binary_function<Iter,Iter, bo
 //Order a collection of pair iterators according to their dereferenced keys
 //NB assumes the key type supports operator<
 template <class PairIter>
-struct mbl_stl_pred_pair_iter_key_order : public std::binary_function<PairIter,PairIter, bool>
+struct mbl_stl_pred_pair_iter_key_order
 {
   inline bool  operator()(const PairIter& iter1, const PairIter& iter2 ) const
   {
@@ -142,7 +142,7 @@ struct mbl_stl_pred_pair_iter_key_order : public std::binary_function<PairIter,P
 //Order a collection of pair iterators according to their dereferenced values
 //NB assumes the key type supports operator<
 template <class PairIter>
-struct mbl_stl_pred_pair_iter_value_order : public std::binary_function<PairIter,PairIter, bool>
+struct mbl_stl_pred_pair_iter_value_order
 {
   inline bool  operator()(const PairIter& iter1, const PairIter& iter2 ) const
   {
@@ -154,7 +154,7 @@ struct mbl_stl_pred_pair_iter_value_order : public std::binary_function<PairIter
 //Order a collection of pairs according to their first elements
 //NB assumes the key type supports operator<
 template <class Pair>
-struct mbl_stl_pred_pair_key_order : public std::binary_function<Pair,Pair, bool>
+struct mbl_stl_pred_pair_key_order
 {
   inline bool  operator()(const Pair& pair1, const Pair& pair2 ) const
   {
@@ -165,7 +165,7 @@ struct mbl_stl_pred_pair_key_order : public std::binary_function<Pair,Pair, bool
 //Order a collection of pairs according to their second elements
 //NB assumes the key type supports operator<
 template <class Pair>
-struct mbl_stl_pred_pair_value_order : public std::binary_function<Pair,Pair, bool>
+struct mbl_stl_pred_pair_value_order
 {
   inline bool  operator()(const Pair& pair1, const Pair& pair2 ) const
   {
@@ -180,7 +180,7 @@ struct mbl_stl_pred_pair_value_order : public std::binary_function<Pair,Pair, bo
 //First is the primary key, second is the secondary key
 //NB assumes both the pair types supports operator<
 template <class T1, class T2>
-struct mbl_stl_pred_pair_order : public std::binary_function<std::pair<T1,T2>,std::pair<T1,T2>, bool>
+struct mbl_stl_pred_pair_order
 {
   inline bool  operator()(const std::pair<T1,T2>& pair1, const std::pair<T1,T2>& pair2 ) const
   {
@@ -199,7 +199,7 @@ struct mbl_stl_pred_pair_order : public std::binary_function<std::pair<T1,T2>,st
 //(e.g. auto_ptr mbl_cloneable_ptr etc)
 template <class T>
 //NB assumes templated class provides is_a to return its typename
-class mbl_stl_pred_is_a : public std::unary_function<T, bool>
+class mbl_stl_pred_is_a
 {
   //:const reference to name of required class type
   const std::string& ctype_;
@@ -212,7 +212,7 @@ class mbl_stl_pred_is_a : public std::unary_function<T, bool>
   }
 };
 
-class mbl_stl_pred_is_near : public std::unary_function<double, bool>
+class mbl_stl_pred_is_near
 {
   double epsilon_;
   double xtarget_;

--- a/core/vbl/vbl_batch_compact_multimap.h
+++ b/core/vbl/vbl_batch_compact_multimap.h
@@ -45,7 +45,6 @@ class vbl_batch_compact_multimap
  public:
   //: A comparator to sort input data, by ignoring the value in pair<key, value>
   class input_compare
-  : public std::binary_function<input_type, input_type, bool>
   {
    public:
     friend class vbl_batch_compact_multimap<key_type, value_type, key_compare>;

--- a/core/vbl/vbl_batch_multimap.h
+++ b/core/vbl/vbl_batch_multimap.h
@@ -41,7 +41,6 @@ public:
 
 
   class value_compare_t
-  : public std::binary_function<value_type, value_type, bool>
   {
   //  friend class vbl_batch_multimap<key_type, mapped_type, key_compare>;
   // protected:

--- a/core/vnl/vnl_sparse_matrix.h
+++ b/core/vnl/vnl_sparse_matrix.h
@@ -94,7 +94,7 @@ class VNL_TEMPLATE_EXPORT vnl_sparse_matrix_pair
     return *this;
   }
 
-  struct less : public std::binary_function<vnl_sparse_matrix_pair, vnl_sparse_matrix_pair, bool>
+  struct less
   {
     bool operator() (vnl_sparse_matrix_pair const& p1, vnl_sparse_matrix_pair const& p2) {
       return p1.first < p2.first;


### PR DESCRIPTION
Both std::unary_function and std::binary_function are
deprecated since C++11 and removed without any replacement
from C++17. These base classes only contained typedefs that
were used solely by std::not2 (strictly superseeded by
std::not_fn in C++17).

As std::not2 is not used anywhere in VXL, this commit does
not break backward compatibility. In fact, the whole
purpose of this commit is C++17 forward compatibility,
which is important for projects written in C++17 that use
VXL and need to pass according compiler flags for binary
compatibility.

This will not make VXL fully compatible to C++17 but it is
enough regarding the components of VXL used by ITK.