### PR TITLE
ENH: Update travis for flexible cmake versioning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,35 @@ sudo: false
 
 language: cpp
 compiler:
-  - gcc
   - clang
+  - gcc
 
 # https://docs.travis-ci.com/user/customizing-the-build/
 git:
   depth: 3
+before_install:
+  - TOOLS_DIR=$(pwd)
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then CMAKE_URL="http://www.cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then mkdir -p cmake && travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then export PATH=${TOOLS_DIR}/cmake/bin:${PATH} ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "need cmake 3.9.5"; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew install ccache cmake; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/cmake/bin:$PATH"; fi
 
 script:
   - export HERE=$(pwd)
-  - cmake --version
+  - ${TOOLS_DIR}/cmake/bin/cmake --version
   - mkdir -p ${HERE}/build
   - mkdir -p ${HERE}/install
   - cd ${HERE}/build
-  - cmake
+  - ${TOOLS_DIR}/cmake/bin/cmake
           -DCMAKE_INSTALL_PREFIX:PATH=${HERE}/install
           -DCMAKE_CXX_STANDARD:STRING=98
           -DBUILD_BRL:BOOL=OFF
           ../
-  - ctest -D ExperimentalStart
-  - ctest -D ExperimentalConfigure
-  - ctest -D ExperimentalBuild -j2
-  - ctest -D ExperimentalTest --schedule-random -j2
-  - ctest -D ExperimentalSubmit
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalStart
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalConfigure
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalBuild -j2
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalTest --schedule-random -j2
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalSubmit
   - make install


### PR DESCRIPTION
Add an infrastructure to easily download and
use different versions of cmake.