### PR TITLE
add large penalty for negative focal length in camera optimization

### DIFF
--- a/core/vpgl/algo/vpgl_optimize_camera.cxx
+++ b/core/vpgl/algo/vpgl_optimize_camera.cxx
@@ -176,6 +176,15 @@ vpgl_orientation_position_focal_lsqr::f(vnl_vector<double> const& x, vnl_vector<
   vgl_rotation_3d<double> R(q);
   vgl_vector_3d<double> t(x[4], x[5], x[6]);
 
+  // Check that it is a valid focal length
+  if (x[7]<=0) {
+    for (unsigned int i=0; i<world_points_.size(); ++i) {
+      fx[2*i]   = 100000000;
+      fx[2*i+1] = 100000000;
+    }
+    return;
+  }
+
   vpgl_calibration_matrix<double> K(K_init_);
   K.set_focal_length(x[7]);
   vpgl_perspective_camera<double> cam(K, R, t);


### PR DESCRIPTION
This fixes a bug in which vpgl_optimize_camera::opt_orient_pos_f() would occasionally return a camera with a negative focal length.

There was already a similar check within the cost function used by vpgl_optimize_camera::opt_orient_pos_cal, but not in the position and focal length only variant.