### PR TITLE
COMP: Fix numerous compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@ contrib/brl/bseg/bvxm/pyscripts/*pyc
 *.swp
 ## Ignore files that are used for auto_completion with clang
 *.clang_complete
+
 ## YouCompleteMe vim plugin configuration file
 .ycm_extra_conf.py
+compile_commands.json
 
 
 # KWStyle hook output
@@ -40,6 +42,7 @@ CMakeLists.txt.user*
 
 # Clion editor internal project information
 .idea
+cmake-build-*/
 
 # Exclude to keep j2k implementation separate from vxl
 v3p/j2k/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ project(vxl)
 
 include(CMakeDependentOption)
 
+#Disable overzealous compiler warning.  If the definition is truely missing a link error will be created.
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-Wno-undefined-var-template HAS_NO_UNDEFINED_VAR_TEMPLATE)
+if( HAS_NO_UNDEFINED_VAR_TEMPLATE )
+  add_definitions( -Wno-undefined-var-template )
+endif()
 
 find_program( MEMORYCHECK_COMMAND valgrind )
 if(MEMORYCHECK_COMMAND)

--- a/core/vgl/tests/test_pointset.cxx
+++ b/core/vgl/tests/test_pointset.cxx
@@ -78,7 +78,7 @@ static void test_pointset()
   scostr.close();
   std::ifstream scistr(path.c_str());
   scistr >> ptset_sc_in;
-  good == good && (ptset_sc_in == ptset_sc);
+  good = good && (ptset_sc_in == ptset_sc);
   TEST("pointset with scalars", good, true);
   scistr.close();
   vpl_unlink(path.c_str());
@@ -90,7 +90,7 @@ static void test_pointset()
   nscostr.close();
   std::ifstream nscistr(path.c_str());
   nscistr >> ptset_nsc_in;
-  good == good && (ptset_nsc_in == ptset_nsc);
+  good = good && (ptset_nsc_in == ptset_nsc);
   nscistr.close();
   TEST("pointset with scalars and normals", good, true);
   vpl_unlink(path.c_str());

--- a/core/vgl/vgl_oriented_box_2d.hxx
+++ b/core/vgl/vgl_oriented_box_2d.hxx
@@ -139,7 +139,7 @@ std::ostream&  operator<<(std::ostream& os, const vgl_oriented_box_2d<T>& obox){
 }
 template <class T>
 std::istream&  operator>>(std::istream& is,  vgl_oriented_box_2d<T>& obox){
-  is.skipws;
+  //is.skipws;
   vgl_line_segment_2d<T> maj;
   T half_height = T(0);
   std::string temp;
@@ -181,9 +181,9 @@ bool vgl_oriented_box_2d<T>::near_equal(vgl_oriented_box_2d<T> const& ob, T tol)
     return false;
   const vgl_line_segment_2d<T>& ma = ob.major_axis();
   const vgl_point_2d<T>& obp1 = ma.point1();
-  const vgl_point_2d<T>& obp2 = ma.point2(); 
+  const vgl_point_2d<T>& obp2 = ma.point2();
   const vgl_point_2d<T>& tp1 = major_axis_.point1();
-  const vgl_point_2d<T>& tp2 = major_axis_.point2(); 
+  const vgl_point_2d<T>& tp2 = major_axis_.point2();
   vgl_vector_2d<T> p1p1 = obp1-tp1;
   vgl_vector_2d<T> p2p2 = obp2-tp2;
   if(p1p1.length()<tol && p2p2.length()<tol)

--- a/core/vgl/vgl_pointset_3d.h
+++ b/core/vgl/vgl_pointset_3d.h
@@ -47,7 +47,7 @@ class vgl_pointset_3d
                  std::vector<vgl_vector_3d<Type> > const& normals,
                  std::vector< Type > const& scalars):
   has_normals_(true), has_scalars_(true), points_(points), normals_(normals), scalars_(scalars){}
-  
+
   //: incrementally grow points, duplicate points are allowed
   void add_point(vgl_point_3d<Type> const& p){
     points_.push_back(p); has_normals_=false; has_scalars_ = false;

--- a/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx
+++ b/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx
@@ -1,6 +1,6 @@
 #include <vil/io/vil_io_smart_ptr.hxx>
 #include <vil/io/vil_io_image_view_base.h>
 #ifdef VCL_GCC
-VIL_IO_SMART_PTR_INSTANTIATE(vil_image_view_base);
-VIL_IO_SMART_PTR_INSTANTIATE(vil_image_resource);
+//VIL_IO_SMART_PTR_INSTANTIATE(vil_image_view_base);
+//VIL_IO_SMART_PTR_INSTANTIATE(vil_image_resource);
 #endif

--- a/core/vil/tests/test_image_view_maths.cxx
+++ b/core/vil/tests/test_image_view_maths.cxx
@@ -376,16 +376,16 @@ static void test_image_view_maths_byte()
 static void test_image_view_maths_float()
 {
   // dim > nxblock_size, n > 1
-  test_image_abs_diff<vxl_byte>(11, 13, 100.0f, 113.0f, 1e-8);
+  test_image_abs_diff<vxl_byte>(11, 13, 100.0f, 113.0f, 0);
 
   // dim = nxblock_size, n > 1
-  test_image_abs_diff<vxl_byte>(8, 12, 100.0f, 113.0f, 1e-8);
+  test_image_abs_diff<vxl_byte>(8, 12, 100.0f, 113.0f, 0);
 
   // dim = nxblock_size, n = 1
-  test_image_abs_diff<vxl_byte>(4, 4, 100.0f, 113.0f, 1e-8);
+  test_image_abs_diff<vxl_byte>(4, 4, 100.0f, 113.0f, 0);
 
   // dim r< nxblock_size, n = 1
-  test_image_abs_diff<vxl_byte>(2, 3, 100.0f, 113.0f, 1e-8);
+  test_image_abs_diff<vxl_byte>(2, 3, 100.0f, 113.0f, 0);
 }
 
 static void test_image_view_maths()


### PR DESCRIPTION
vxl/core/vgl/algo/vgl_homg_operators_1d.hxx:100:59: warning: instantiation of variable 'vgl_homg<double>::infinity' required here, but no definition is available [-Wundefined-var-template]
vxl/core/vgl/algo/vgl_homg_operators_1d.hxx:100:59: warning: instantiation of variable 'vgl_homg<float>::infinity' required here, but no definition is available [-Wundefined-var-template]
vxl/core/vgl/algo/vgl_homg_operators_2d.hxx:138:25: warning: instantiation of variable 'vgl_homg<double>::infinity' required here, but no definition is available [-Wundefined-var-template]
vxl/core/vgl/algo/vgl_homg_operators_2d.hxx:138:25: warning: instantiation of variable 'vgl_homg<float>::infinity' required here, but no definition is available [-Wundefined-var-template]

vxl/core/vgl/tests/test_pointset.cxx:81:16: warning: expression result unused [-Wunused-value]
vxl/core/vgl/tests/test_pointset.cxx:81:8: warning: self-comparison always evaluates to true [-Wtautological-compare]
vxl/core/vgl/tests/test_pointset.cxx:93:16: warning: expression result unused [-Wunused-value]
vxl/core/vgl/tests/test_pointset.cxx:93:8: warning: self-comparison always evaluates to true [-Wtautological-compare]
vxl/core/vgl/vgl_line_segment_2d.hxx:21:5: warning: expression result unused [-Wunused-value]
vxl/core/vgl/vgl_oriented_box_2d.hxx:142:6: warning: expression result unused [-Wunused-value]
vxl/core/vgl/vgl_pointset_3d.h:142:20: warning: '&&' within '||' [-Wlogical-op-parentheses]
vxl/core/vgl/vgl_pointset_3d.h:142:20: warning: '&&' within '||' [-Wlogical-op-parentheses][ 19%] Building C object v3p/netlib/CMakeFiles/v3p_netlib.dir/lapack/complex16/zlassq.c.o
vxl/core/vgl/vgl_pointset_3d.h:142:65: warning: '&&' within '||' [-Wlogical-op-parentheses]
vxl/core/vgl/vgl_pointset_3d.h:152:20: warning: '&&' within '||' [-Wlogical-op-parentheses]
vxl/core/vgl/vgl_pointset_3d.h:152:65: warning: '&&' within '||' [-Wlogical-op-parentheses]
vxl/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx:4:1: warning: explicit instantiation of 'vsl_b_read<vil_image_view_base>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
vxl/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx:4:1: warning: explicit instantiation of 'vsl_b_write<vil_image_view_base>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
vxl/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx:5:1: warning: explicit instantiation of 'vsl_b_read<vil_image_resource>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
vxl/core/vil/io/Templates/vil_io_smart_ptr+vil_image_view_base-.cxx:5:1: warning: explicit instantiation of 'vsl_b_write<vil_image_resource>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
vxl/core/vil/tests/test_image_view_maths.cxx:379:57: warning: implicit conversion from 'double' to 'unsigned char' changes value from 1.0E-8 to 0 [-Wliteral-conversion]
vxl/core/vil/tests/test_image_view_maths.cxx:382:56: warning: implicit conversion from 'double' to 'unsigned char' changes value from 1.0E-8 to 0 [-Wliteral-conversion]
vxl/core/vil/tests/test_image_view_maths.cxx:385:55: warning: implicit conversion from 'double' to 'unsigned char' changes value from 1.0E-8 to 0 [-Wliteral-conversion]
vxl/core/vil/tests/test_image_view_maths.cxx:388:55: warning: implicit conversion from 'double' to 'unsigned char' changes value from 1.0E-8 to 0 [-Wliteral-conversion]
vxl/core/vnl/vnl_numeric_traits.cxx:60:104: warning: implicit conversion from 'int' to 'const char' changes value from 255 to -1 [-Wconstant-conversion]