### PR TITLE
ENH: Provide vnl_rational support for size_t (aka unsigned long)

### DIFF
--- a/core/vnl/tests/test_rational.cxx
+++ b/core/vnl/tests/test_rational.cxx
@@ -18,6 +18,28 @@ inline vnl_rational vnl_sqrt(vnl_rational x) { return vnl_rational(std::sqrt(dou
 static void test_operators()
 {
   vnl_rational a(-5L), b(7,-1), c, d(3,7), e(2,0);
+  vnl_rational z_default;
+  TEST("==", z_default==0L, true);
+
+  vnl_rational z_int(static_cast<int>(0));
+  TEST("==", z_int==0L, true);
+  vnl_rational z_uint(static_cast<unsigned int>(0) );
+  TEST("==", z_uint==0L, true);
+
+  vnl_rational z_short(static_cast<int>(0));
+  TEST("==", z_short==0L, true);
+  vnl_rational z_ushort(static_cast<unsigned int>(0) );
+  TEST("==", z_ushort==0L, true);
+
+  vnl_rational z_long(static_cast<long>(0));
+  TEST("==", z_long==0L, true);
+  vnl_rational z_ulong(static_cast<unsigned long>(0));
+  TEST("==", z_ulong==0L, true);
+#if 0
+  vnl_rational z_mixed(static_cast<short>(0), static_cast<unsigned int>(1) );
+  TEST("==", z_mixed==0L, true);
+#endif
+
   TEST("==", a==-5L, true);
   TEST("==", 5L==-a, true);
   TEST("==", b==-7, true);

--- a/core/vnl/vnl_rational.cxx
+++ b/core/vnl/vnl_rational.cxx
@@ -6,9 +6,8 @@
 #include <vnl/vnl_numeric_traits.h> // for vnl_numeric_traits<long>::maxval
 #include <vcl_cassert.h>
 
-//: Creates a rational from a double.
-//  This is done by computing the continued fraction approximation for d.
-vnl_rational::vnl_rational(double d)
+template<typename FloatingType>
+inline void makeNumDen( FloatingType d, long &num_, long &den_)
 {
   bool sign = d<0;
   if (sign) d = -d;
@@ -27,6 +26,20 @@ vnl_rational::vnl_rational(double d)
   num_ = num; den_ = den;
   if (sign) num_ = -num_;
   // no need to normalize() since prev_num and prev_den have guaranteed a gcd=1
+}
+
+//: Creates a rational from a double.
+//  This is done by computing the continued fraction approximation for d.
+vnl_rational::vnl_rational(double d)
+{
+  makeNumDen<double>(d,num_,den_);
+}
+
+//: Creates a rational from a double.
+//  This is done by computing the continued fraction approximation for d.
+vnl_rational::vnl_rational(float f)
+{
+  makeNumDen<double>(f,num_,den_);
 }
 
 //: Multiply/assign: replace lhs by lhs * rhs

--- a/core/vnl/vnl_rational.h
+++ b/core/vnl/vnl_rational.h
@@ -80,21 +80,45 @@ class VNL_EXPORT vnl_rational
   //  Also serves as automatic cast from long to vnl_rational.
   //  The only input which is not allowed is (0,0);
   //  the denominator is allowed to be 0, to represent +Inf or -Inf.
-  inline vnl_rational(long num = 0L, long den = 1L)
+
+  inline vnl_rational()
+    : num_(0L), den_(1L) { normalize(); }
+
+  inline vnl_rational(long num)
+    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(long num, long den)
     : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
-  //: Creates a rational with given numerator and denominator.
-  //  Note these are not automatic type conversions because of a bug
-  //  in the Borland compiler.  Since these just convert their
-  //  arguments to long anyway, there is no harm in letting
-  //  the long overload be used for automatic conversions.
-  explicit inline vnl_rational(int num, int den = 1)
+
+  inline vnl_rational(unsigned long num)
+    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(unsigned long num, unsigned long den)
     : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
-  explicit inline vnl_rational(unsigned int num, unsigned int den = 1)
+
+  inline vnl_rational(int num)
+    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(int num, int den)
+    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
+
+  inline vnl_rational(unsigned int num)
+    : num_((long)num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(unsigned int num, unsigned int den)
     : num_((long)num), den_((long)den) { assert(num!=0||den!=0); normalize(); }
+
+  inline vnl_rational(short num)
+    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(short num, short den)
+    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
+
+  inline vnl_rational(unsigned short num)
+    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
+  inline vnl_rational(unsigned short num, unsigned short den)
+    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
+
   //: Creates a rational from a double.
   //  This is done by computing the continued fraction approximation for d.
   //  Note that this is explicitly \e not an automatic type conversion.
-  explicit vnl_rational(double d);
+  vnl_rational(double d);
+  vnl_rational(float d);
   //  Copy constructor
   inline vnl_rational(vnl_rational const& from)
     : num_(from.numerator()), den_(from.denominator()) {}


### PR DESCRIPTION
Explicitly specify conversion types for all supported
integer types to resolve implicit ambigities.

vnl_fixed_matrix exposed ambiguities when the
the vnl_fixed_matrix element indexing is
changed to size_t.