### PR TITLE
BUG: New brl libraries had no source

### DIFF
--- a/contrib/brl/bseg/bstm_multi/basic/CMakeLists.txt
+++ b/contrib/brl/bseg/bstm_multi/basic/CMakeLists.txt
@@ -4,9 +4,10 @@ include_directories( ${BRL_INCLUDE_DIR}/bseg )
 
 set(bstm_multi_basic_sources
     array_4d.h
+    array_4d.cxx
    )
 
-aux_source_directory(Templates bstm_multi_basic_sources)
+## This does not exist aux_source_directory(Templates bstm_multi_basic_sources)
 
 vxl_add_library(LIBRARY_NAME bstm_multi_basic LIBRARY_SOURCES  ${bstm_multi_basic_sources})
 set_target_properties(bstm_multi_basic PROPERTIES LINKER_LANGUAGE CXX)

--- a/contrib/brl/bseg/bstm_multi/basic/array_4d.cxx
+++ b/contrib/brl/bseg/bstm_multi/basic/array_4d.cxx
@@ -1,0 +1,6 @@
+#include "array_4d.h"
+
+array_4d<int> avoid_archive_error_for_non_existant_library()
+{
+  return array_4d<int>();
+}

--- a/contrib/brl/bseg/bstm_multi/cpp/algo/tests/test_bstm_to_multi_bstm_block_function.cxx
+++ b/contrib/brl/bseg/bstm_multi/cpp/algo/tests/test_bstm_to_multi_bstm_block_function.cxx
@@ -1158,10 +1158,10 @@ fly_scene_generate(const index_4d &coords) {
   if (coords[0] == coords[1] && coords[1] == coords[2]) {
     if (coords[3] % 16 == 0 && coords[3] / 16 == coords[0]) {
       vcl_cout << coords << vcl_endl;
-      return vcl_make_pair(1, (unsigned char)128);
+      return vcl_make_pair(bstm_data_traits<BSTM_ALPHA>::datatype(1), bstm_data_traits<BSTM_MOG3_GREY>::datatype((unsigned char)128));
     }
   }
-  return vcl_make_pair(0, (unsigned char)0);
+  return vcl_make_pair(bstm_data_traits<BSTM_ALPHA>::datatype(0), bstm_data_traits<BSTM_MOG3_GREY>::datatype((unsigned char)0));
 }
 
 void test_fly_problem2() {

--- a/contrib/brl/bseg/bstm_multi/io/CMakeLists.txt
+++ b/contrib/brl/bseg/bstm_multi/io/CMakeLists.txt
@@ -8,8 +8,9 @@ set(bstm_multi_io_sources
     block_simple_cache.h   block_simple_cache.hxx
     block_sio_mgr.h        block_sio_mgr.hxx
     # space_time_lru_cache.h        space_time_lru_cache.cxx
+    not_empty.cxx #<-- This file is only here to provide something to compile
    )
-aux_source_directory(Templates bstm_multi_io_sources)
+## The templates direcotry does not exists aux_source_directory(Templates bstm_multi_io_sources)
 
 vxl_add_library(LIBRARY_NAME bstm_multi_io LIBRARY_SOURCES  ${bstm_multi_io_sources})
 set_target_properties(bstm_multi_io PROPERTIES LINKER_LANGUAGE CXX)

--- a/contrib/brl/bseg/bstm_multi/io/not_empty.cxx
+++ b/contrib/brl/bseg/bstm_multi/io/not_empty.cxx
@@ -1,0 +1,5 @@
+
+int dummy_function_to_provide_something_to_compile()
+{
+  return 0;
+}


### PR DESCRIPTION
A newly added library had no source code
and resulted while trying to generate an
empy archive.  A stub file with
a trivial dummy function was created
to work around the build failure.