### PR TITLE
ENH: Support C++17 deprecation of auto_ptr

### DIFF
--- a/contrib/brl/bbas/bgui3d/bgui3d_project2d_tableau.cxx
+++ b/contrib/brl/bbas/bgui3d/bgui3d_project2d_tableau.cxx
@@ -160,7 +160,7 @@ bgui3d_project2d_tableau::set_camera(const vpgl_proj_camera<double>& cam)
 
 //: Get the scene camera
 // creates a vpgl camera (either perspective or affine) from the graphics camera
-std::auto_ptr<vpgl_proj_camera<double> >
+vcl_unique_ptr<vpgl_proj_camera<double> >
 bgui3d_project2d_tableau::camera() const
 {
   vnl_matrix<double> mm(4,4,16,model_matrix_);
@@ -169,12 +169,12 @@ bgui3d_project2d_tableau::camera() const
   t = R.inverse()*t;
   if (camera_z_[2][2] != 0) {
     vpgl_calibration_matrix<double> K(camera_z_.extract(3,3));
-    return std::auto_ptr<vpgl_proj_camera<double> >
+    return vcl_unique_ptr<vpgl_proj_camera<double> >
         ( new vpgl_perspective_camera<double>(K,t,R) );
   }
   else
     // FIXME - construct a vpgl_affine_camera
-    return std::auto_ptr<vpgl_proj_camera<double> >
+    return vcl_unique_ptr<vpgl_proj_camera<double> >
       ( new vpgl_proj_camera<double>(camera_z_*mm.transpose()) );
 }
 

--- a/contrib/brl/bbas/bgui3d/bgui3d_project2d_tableau.h
+++ b/contrib/brl/bbas/bgui3d/bgui3d_project2d_tableau.h
@@ -44,7 +44,7 @@ class bgui3d_project2d_tableau : public bgui3d_tableau
 
   //: Get the scene camera
   // creates a vpgl camera (either perspective or affine) from the graphics camera
-  virtual std::auto_ptr<vpgl_proj_camera<double> > camera() const;
+  virtual vcl_unique_ptr<vpgl_proj_camera<double> > camera() const;
 
   //: Activate a headlight
   void set_headlight(bool enable) { draw_headlight_ = enable; this->post_redraw(); }

--- a/contrib/brl/bbas/bgui3d/bgui3d_tableau.cxx
+++ b/contrib/brl/bbas/bgui3d/bgui3d_tableau.cxx
@@ -290,10 +290,10 @@ bgui3d_tableau::set_camera(const vpgl_proj_camera<double>& /*camera*/)
 
 //: Get the scene camera
 // creates a vpgl camera (either perspective or affine) from the graphics camera
-std::auto_ptr<vpgl_proj_camera<double> >
+vcl_unique_ptr<vpgl_proj_camera<double> >
 bgui3d_tableau::camera() const
 {
-  return std::auto_ptr<vpgl_proj_camera<double> >(NULL);
+  return vcl_unique_ptr<vpgl_proj_camera<double> >(NULL);
 }
 
 

--- a/contrib/brl/bbas/bgui3d/bgui3d_tableau.h
+++ b/contrib/brl/bbas/bgui3d/bgui3d_tableau.h
@@ -13,7 +13,7 @@
 // \endverbatim
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 #include <vgui/vgui_clear_tableau.h>
 #include <vgui/vgui_event.h>
@@ -92,7 +92,7 @@ class bgui3d_tableau : public vgui_tableau
 
   //: Get the scene camera
   // creates a vpgl camera (either perspective or affine) from the graphics camera
-  virtual std::auto_ptr<vpgl_proj_camera<double> > camera() const;
+  virtual vcl_unique_ptr<vpgl_proj_camera<double> > camera() const;
   //----------------------------------------------------------------
 
   //: Set the viewport

--- a/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.cxx
+++ b/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.cxx
@@ -224,11 +224,11 @@ bgui3d_viewer_tableau::set_camera(const vpgl_proj_camera<double>& camera)
 
 //: Get the scene camera.
 // Creates a vpgl camera (either perspective or affine) from the active SoCamera
-std::auto_ptr<vpgl_proj_camera<double> >
+vcl_unique_ptr<vpgl_proj_camera<double> >
 bgui3d_viewer_tableau::camera() const
 {
   if (!scene_camera_)
-    return std::auto_ptr<vpgl_proj_camera<double> >(NULL);
+    return vcl_unique_ptr<vpgl_proj_camera<double> >(NULL);
 
   const SbVec3f& t_vec = scene_camera_->position.getValue();
   vnl_double_3 t(t_vec[0], t_vec[1], t_vec[2]);
@@ -256,7 +256,7 @@ bgui3d_viewer_tableau::camera() const
     vgl_point_2d<double> p(0, 0);
     vpgl_calibration_matrix<double> K(f,p,sx,sy);
     vgl_point_3d<double> c(t[0],t[1],t[2]);
-    return std::auto_ptr<vpgl_proj_camera<double> >
+    return vcl_unique_ptr<vpgl_proj_camera<double> >
            ( new vpgl_perspective_camera<double>(K,c,R) );
     }
    case ORTHOGONAL:
@@ -265,10 +265,10 @@ bgui3d_viewer_tableau::camera() const
     double h = cam->height.getValue();
 #endif // 0
     std::cerr << "WARNING: not implemented yet\n";
-    return std::auto_ptr<vpgl_proj_camera<double> >(NULL);
+    return vcl_unique_ptr<vpgl_proj_camera<double> >(NULL);
    default:
     std::cerr << "WARNING: no such camera_type_\n";
-    return std::auto_ptr<vpgl_proj_camera<double> >(NULL);
+    return vcl_unique_ptr<vpgl_proj_camera<double> >(NULL);
   }
 }
 

--- a/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.h
+++ b/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.h
@@ -56,7 +56,7 @@ class bgui3d_viewer_tableau : public bgui3d_tableau
 
   //: Get the scene camera
   // Creates a vpgl camera (either perspective or affine) from the active SoCamera
-  virtual std::auto_ptr<vpgl_proj_camera<double> > camera() const;
+  virtual vcl_unique_ptr<vpgl_proj_camera<double> > camera() const;
 
   //: Set the camera viewing the scene
   virtual void set_camera(SoCamera *camera);

--- a/contrib/brl/bbas/bjson/bjsoncpp.cxx
+++ b/contrib/brl/bbas/bjson/bjsoncpp.cxx
@@ -232,7 +232,7 @@ static inline void fixNumericLocaleInput(char* begin, char* end) {
 #include <cstring>
 #include <istream>
 #include <sstream>
-#include <memory>
+#include <vcl_memory.h>
 #include <set>
 #include <limits>
 
@@ -266,11 +266,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
-typedef std::unique_ptr<CharReader> CharReaderPtr;
-#else
-typedef std::auto_ptr<CharReader>   CharReaderPtr;
-#endif
+typedef vcl_unique_ptr<CharReader>   CharReaderPtr;
 
 // Implementation of class Features
 // ////////////////////////////////
@@ -4077,7 +4073,7 @@ Value& Path::make(Value& root) const {
 #include "json_tool.h"
 #endif // if !defined(JSON_IS_AMALGAMATION)
 #include <iomanip>
-#include <memory>
+#include <vcl_memory.h>
 #include <sstream>
 #include <utility>
 #include <set>
@@ -4144,11 +4140,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
-typedef std::unique_ptr<StreamWriter> StreamWriterPtr;
-#else
-typedef std::auto_ptr<StreamWriter>   StreamWriterPtr;
-#endif
+typedef vcl_unique_ptr<StreamWriter>   StreamWriterPtr;
 
 static bool containsControlCharacter(const char* str) {
   while (*str) {

--- a/contrib/brl/bbas/bjson/jsoncpp.cxx
+++ b/contrib/brl/bbas/bjson/jsoncpp.cxx
@@ -232,7 +232,7 @@ static inline void fixNumericLocaleInput(char* begin, char* end) {
 #include <cstring>
 #include <istream>
 #include <sstream>
-#include <memory>
+#include <vcl_memory.h>
 #include <set>
 #include <limits>
 
@@ -266,11 +266,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
-typedef std::unique_ptr<CharReader> CharReaderPtr;
-#else
-typedef std::auto_ptr<CharReader>   CharReaderPtr;
-#endif
+typedef vcl_unique_ptr<CharReader>   CharReaderPtr;
 
 // Implementation of class Features
 // ////////////////////////////////
@@ -4077,7 +4073,7 @@ Value& Path::make(Value& root) const {
 #include "json_tool.h"
 #endif // if !defined(JSON_IS_AMALGAMATION)
 #include <iomanip>
-#include <memory>
+#include <vcl_memory.h>
 #include <sstream>
 #include <utility>
 #include <set>
@@ -4144,11 +4140,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
-typedef std::unique_ptr<StreamWriter> StreamWriterPtr;
-#else
-typedef std::auto_ptr<StreamWriter>   StreamWriterPtr;
-#endif
+typedef vcl_unique_ptr<StreamWriter>   StreamWriterPtr;
 
 static bool containsControlCharacter(const char* str) {
   while (*str) {

--- a/contrib/brl/bbas/brdb/brdb_database.cxx
+++ b/contrib/brl/bbas/brdb/brdb_database.cxx
@@ -244,7 +244,7 @@ brdb_database::select(const std::string& relation_name, brdb_query_aptr q) const
 
   brdb_relation_sptr relation = this->get_relation(relation_name);
 
-  return new brdb_selection(relation, q);
+  return new brdb_selection(relation, vcl_move(q) );
 }
 
 

--- a/contrib/brl/bbas/brdb/brdb_query.h
+++ b/contrib/brl/bbas/brdb/brdb_query.h
@@ -22,8 +22,12 @@ class brdb_query
 {
  protected:
   //: Destructor - private to prevent allocation on the heap
+#if __cplusplus >= 201103L
+  friend vcl_unique_ptr<brdb_query>;
+#else
   virtual ~brdb_query() {}
-  friend class std::auto_ptr<brdb_query>;
+  friend class vcl_unique_ptr<brdb_query>;
+#endif
 
  public:
   virtual brdb_query_aptr clone() const = 0;
@@ -128,7 +132,7 @@ class brdb_query_comp : public brdb_query
   //: make a query on a certain attribute, with a certain type of comparison to a value
   brdb_query_comp(const std::string& attribute_name,
                   const brdb_query::comp_type& type,
-                  std::auto_ptr<brdb_value> value);
+                  vcl_unique_ptr<brdb_value> value);
 
   //: Copy Constructor
   brdb_query_comp(const brdb_query_comp& other);
@@ -167,7 +171,7 @@ class brdb_query_comp : public brdb_query
   brdb_query::comp_type comparison_type_;
 
   //: the value which will be used by the constraints
-  std::auto_ptr<brdb_value> value_;
+  vcl_unique_ptr<brdb_value> value_;
 };
 
 
@@ -178,7 +182,7 @@ brdb_query_aptr
                         const T& value)
 {
   return brdb_query_aptr(new brdb_query_comp(attribute_name, type,
-                            std::auto_ptr<brdb_value>(new brdb_value_t<T>(value))));
+                            vcl_unique_ptr<brdb_value>(new brdb_value_t<T>(value))));
 }
 
 

--- a/contrib/brl/bbas/brdb/brdb_query_aptr.h
+++ b/contrib/brl/bbas/brdb/brdb_query_aptr.h
@@ -7,10 +7,10 @@
 class brdb_query;
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 
-typedef std::auto_ptr<brdb_query> brdb_query_aptr;
+typedef vcl_unique_ptr<brdb_query> brdb_query_aptr;
 
 
 #endif // brdb_query_aptr_h

--- a/contrib/brl/bbas/brdb/brdb_selection.cxx
+++ b/contrib/brl/bbas/brdb/brdb_selection.cxx
@@ -17,7 +17,7 @@
 
 //: Constructor
 brdb_selection::brdb_selection(const brdb_relation_sptr& relation, brdb_query_aptr query)
-  : relation_(relation), query_(query)
+  : relation_(relation), query_(vcl_move(query))
 {
   this->time_stamp_ = relation->get_timestamp();
   produce(query_, selected_set_);
@@ -32,7 +32,7 @@ brdb_selection::brdb_selection(const brdb_selection_sptr& selection, brdb_query_
     selection->check_and_update();
     this->selected_set_ = selection->selected_set_;
     refine(query, selected_set_);
-    this->query_ = brdb_query_aptr(new brdb_query_and(selection->query_->clone(), query));
+    this->query_ = brdb_query_aptr(new brdb_query_and(selection->query_->clone(), vcl_move(query)));
   }
 }
 

--- a/contrib/brl/bbas/brdb/tests/test_query.cxx
+++ b/contrib/brl/bbas/brdb/tests/test_query.cxx
@@ -21,7 +21,7 @@ static void test_query()
 
   brdb_query_aptr q1 = brdb_query_comp_new("attr", brdb_query::EQ, 1);
   brdb_query_aptr q2 = brdb_query_comp_new("attr", brdb_query::EQ, 3);
-  brdb_query_aptr q1or2 = q1 | q2;
+  brdb_query_aptr q1or2 = vcl_move(q1) | vcl_move(q2);
 }
 
 TESTMAIN(test_query);

--- a/contrib/brl/bbas/bwm/algo/bwm_shape_file.cxx
+++ b/contrib/brl/bbas/bwm/algo/bwm_shape_file.cxx
@@ -5,7 +5,7 @@
 bool bwm_shape_file::load(std::string filename)
 {
   std::string ext = vul_file::extension(filename);
-  if (!ext.compare(".shp") == 0) {
+  if ((!ext.compare(".shp") ) == 0) {
     std::cerr << filename << "is not a .shp file\n";
     return false;
   }

--- a/contrib/brl/bbas/imesh/algo/imesh_detect.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_detect.cxx
@@ -173,7 +173,7 @@ imesh_detect_exterior_faces(const imesh_mesh& mesh,
                             unsigned int num_dir_samples,
                             unsigned int img_size)
 {
-  std::auto_ptr<imesh_mesh> tri_mesh;
+  vcl_unique_ptr<imesh_mesh> tri_mesh;
   const imesh_mesh* mesh_ptr = &mesh;
   std::vector<unsigned int> tri_map;
   if (mesh.faces().regularity() != 3) {
@@ -182,9 +182,9 @@ imesh_detect_exterior_faces(const imesh_mesh& mesh,
       for (unsigned int j=2; j<mesh.faces().num_verts(i); ++j)
         tri_map.push_back(i);
     }
-    std::auto_ptr<imesh_vertex_array_base> verts_copy(mesh.vertices().clone());
-    std::auto_ptr<imesh_face_array_base> faces_tri(imesh_triangulate(mesh.faces()));
-    tri_mesh.reset(new imesh_mesh(verts_copy,faces_tri));
+    vcl_unique_ptr<imesh_vertex_array_base> verts_copy(mesh.vertices().clone());
+    vcl_unique_ptr<imesh_face_array_base> faces_tri(imesh_triangulate(mesh.faces()));
+    tri_mesh.reset(new imesh_mesh(vcl_move(verts_copy),vcl_move(faces_tri)));
     tri_mesh->compute_face_normals();
     mesh_ptr = tri_mesh.get();
   }
@@ -227,7 +227,7 @@ imesh_detect_exterior_faces(const imesh_mesh& mesh,
                             unsigned int num_dir_samples,
                             unsigned int img_size)
 {
-  std::auto_ptr<imesh_mesh> tri_mesh;
+  vcl_unique_ptr<imesh_mesh> tri_mesh;
   const imesh_mesh* mesh_ptr = &mesh;
   std::vector<unsigned int> tri_map;
   if (mesh.faces().regularity() != 3) {
@@ -236,9 +236,9 @@ imesh_detect_exterior_faces(const imesh_mesh& mesh,
       for (unsigned int j=2; j<mesh.faces().num_verts(i); ++j)
         tri_map.push_back(i);
     }
-    std::auto_ptr<imesh_vertex_array_base> verts_copy(mesh.vertices().clone());
-    std::auto_ptr<imesh_face_array_base> faces_tri(imesh_triangulate(mesh.faces()));
-    tri_mesh.reset(new imesh_mesh(verts_copy,faces_tri));
+    vcl_unique_ptr<imesh_vertex_array_base> verts_copy(mesh.vertices().clone());
+    vcl_unique_ptr<imesh_face_array_base> faces_tri(imesh_triangulate(mesh.faces()));
+    tri_mesh.reset(new imesh_mesh(vcl_move(verts_copy),vcl_move(faces_tri)));
     tri_mesh->compute_face_normals();
     mesh_ptr = tri_mesh.get();
   }

--- a/contrib/brl/bbas/imesh/algo/imesh_generate_mesh.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_generate_mesh.cxx
@@ -149,8 +149,8 @@ imesh_generate_mesh_2d(std::vector<vgl_point_2d<double> > const& convex_hull,
   unsigned k = 0;
   for (unsigned i = 0; i<npts; ++i, k+=2)
     verts->push_back(imesh_vertex<2>(out.pointlist[k], out.pointlist[k+1]));
-  std::auto_ptr<imesh_vertex_array_base> v(verts);
-  mesh.set_vertices(v);
+  vcl_unique_ptr<imesh_vertex_array_base> v(verts);
+  mesh.set_vertices(vcl_move(v));
   //construct triangular faces
   unsigned ntri = static_cast<unsigned>(out.numberoftriangles);
   imesh_regular_face_array<3>* faces = new imesh_regular_face_array<3>();
@@ -162,8 +162,8 @@ imesh_generate_mesh_2d(std::vector<vgl_point_2d<double> > const& convex_hull,
     faces->push_back(tri);
   }
   //set the faces on the mesh
-  std::auto_ptr<imesh_face_array_base> f(faces);
-  mesh.set_faces(f);
+  vcl_unique_ptr<imesh_face_array_base> f(faces);
+  mesh.set_faces(vcl_move(f));
 }
 
 
@@ -262,8 +262,8 @@ imesh_generate_mesh_2d_2(std::vector<vgl_point_2d<double> > const& convex_hull,
   unsigned k = 0;
   for (unsigned i = 0; i<npts; ++i, k+=2)
     verts->push_back(imesh_vertex<2>(out.pointlist[k], out.pointlist[k+1]));
-  std::auto_ptr<imesh_vertex_array_base> v(verts);
-  mesh.set_vertices(v);
+  vcl_unique_ptr<imesh_vertex_array_base> v(verts);
+  mesh.set_vertices(vcl_move(v));
   //construct triangular faces
   unsigned ntri = static_cast<unsigned>(out.numberoftriangles);
   imesh_regular_face_array<3>* faces = new imesh_regular_face_array<3>();
@@ -275,6 +275,6 @@ imesh_generate_mesh_2d_2(std::vector<vgl_point_2d<double> > const& convex_hull,
     faces->push_back(tri);
   }
   //set the faces on the mesh
-  std::auto_ptr<imesh_face_array_base> f(faces);
-  mesh.set_faces(f);
+  vcl_unique_ptr<imesh_face_array_base> f(vcl_move(faces));
+  mesh.set_faces(vcl_move(f));
 }

--- a/contrib/brl/bbas/imesh/algo/imesh_imls_surface.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_imls_surface.cxx
@@ -163,7 +163,7 @@ void imesh_imls_surface::compute_enclosing_phi()
 
 //: recursively compute the area weighted centroids
 void imesh_imls_surface::
-compute_centroids_rec(const std::auto_ptr<imesh_kd_tree_node>& node,
+compute_centroids_rec(const vcl_unique_ptr<imesh_kd_tree_node>& node,
                       const std::set<unsigned int>& no_normal_faces)
 {
   const unsigned int& i = node->index_;
@@ -207,7 +207,7 @@ compute_centroids_rec(const std::auto_ptr<imesh_kd_tree_node>& node,
 
 //: recursively compute the unweighted integrals
 void imesh_imls_surface::
-compute_unweighed_rec(const std::auto_ptr<imesh_kd_tree_node>& node)
+compute_unweighed_rec(const vcl_unique_ptr<imesh_kd_tree_node>& node)
 {
   const unsigned int& i = node->index_;
   if (node->is_leaf()) {

--- a/contrib/brl/bbas/imesh/algo/imesh_imls_surface.h
+++ b/contrib/brl/bbas/imesh/algo/imesh_imls_surface.h
@@ -164,11 +164,11 @@ class imesh_imls_surface
  private:
 
   //: recursively compute the area weighted centroids
-  void compute_centroids_rec(const std::auto_ptr<imesh_kd_tree_node>& node,
+  void compute_centroids_rec(const vcl_unique_ptr<imesh_kd_tree_node>& node,
                              const std::set<unsigned int>& no_normal_faces);
 
   //: recursively compute the unweighted integrals
-  void compute_unweighed_rec(const std::auto_ptr<imesh_kd_tree_node>& node);
+  void compute_unweighed_rec(const vcl_unique_ptr<imesh_kd_tree_node>& node);
 
 
   //: compute the iso value such that the mean value at the vertices is zero
@@ -179,9 +179,9 @@ class imesh_imls_surface
   void compute_enclosing_phi();
 
   std::vector<vgl_point_3d<double> > verts_;     // mesh vertices
-  std::auto_ptr<imesh_regular_face_array<3> > triangles_; // mesh triangles
+  vcl_unique_ptr<imesh_regular_face_array<3> > triangles_; // mesh triangles
 
-  std::auto_ptr<imesh_kd_tree_node> kd_tree_;    // root node of a kd-tree on triangles
+  vcl_unique_ptr<imesh_kd_tree_node> kd_tree_;    // root node of a kd-tree on triangles
   std::vector<double> phi_;                      // phi values assigned per vertex
   std::vector<double> area_;                     // surface area per node
   std::vector<double> unweighted_;               // unweighted integrals of phi over the surface per node

--- a/contrib/brl/bbas/imesh/algo/imesh_kd_tree.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_kd_tree.cxx
@@ -138,7 +138,7 @@ best_split(const std::vector<vgl_box_3d<double> >& boxes,
 
 
 //: recursively construct a kd-tree of mesh triangles
-std::auto_ptr<imesh_kd_tree_node>
+vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree_rec(const std::vector<vgl_box_3d<double> >& boxes,
                         const vgl_box_3d<double>& outer_box,
                         const vgl_box_3d<double>& inner_box,
@@ -146,7 +146,7 @@ imesh_build_kd_tree_rec(const std::vector<vgl_box_3d<double> >& boxes,
 {
   // If only one triangle is left, create and return a leaf node.
   if (indices.size() == 1) {
-    return std::auto_ptr<imesh_kd_tree_node>(new imesh_kd_tree_node( outer_box,
+    return vcl_unique_ptr<imesh_kd_tree_node>(new imesh_kd_tree_node( outer_box,
                                                                     inner_box,
                                                                     indices[0] ));
   }
@@ -214,20 +214,20 @@ imesh_build_kd_tree_rec(const std::vector<vgl_box_3d<double> >& boxes,
   }
 
   // recursively construct child nodes
-  std::auto_ptr<imesh_kd_tree_node>
+  vcl_unique_ptr<imesh_kd_tree_node>
       left_child(imesh_build_kd_tree_rec(boxes,left_outer_box,left_inner_box,left_indices));
-  std::auto_ptr<imesh_kd_tree_node>
+  vcl_unique_ptr<imesh_kd_tree_node>
       right_child(imesh_build_kd_tree_rec(boxes,right_outer_box,right_inner_box,right_indices));
 
-  return std::auto_ptr<imesh_kd_tree_node>(new imesh_kd_tree_node(outer_box,
+  return vcl_unique_ptr<imesh_kd_tree_node>(new imesh_kd_tree_node(outer_box,
                                                                  inner_box,
-                                                                 left_child,
-                                                                 right_child));
+                                                                 vcl_move(left_child),
+                                                                 vcl_move(right_child) ));
 }
 
 
 //: Construct a kd-tree (in 3d) of axis aligned boxes
-std::auto_ptr<imesh_kd_tree_node>
+vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree(const std::vector<vgl_box_3d<double> >& boxes)
 {
   // make the outer box
@@ -247,7 +247,7 @@ imesh_build_kd_tree(const std::vector<vgl_box_3d<double> >& boxes)
   }
 
   // call recursive function to do the real work
-  std::auto_ptr<imesh_kd_tree_node> root(imesh_build_kd_tree_rec(boxes, outer_box, inner_box, indices));
+  vcl_unique_ptr<imesh_kd_tree_node> root(imesh_build_kd_tree_rec(boxes, outer_box, inner_box, indices));
 
   // assign additional indices to internal nodes
   // reverse breadth first (root gets last index)
@@ -269,7 +269,7 @@ imesh_build_kd_tree(const std::vector<vgl_box_3d<double> >& boxes)
 
 
 //: construct a kd-tree of mesh faces
-std::auto_ptr<imesh_kd_tree_node>
+vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree(const imesh_vertex_array<3>& verts,
                     const imesh_face_array_base& faces)
 {
@@ -339,7 +339,7 @@ class tri_dist_func
 unsigned int
 imesh_kd_tree_closest_point(const vgl_point_3d<double>& query,
                             const imesh_mesh& mesh,
-                            const std::auto_ptr<imesh_kd_tree_node>& root,
+                            const vcl_unique_ptr<imesh_kd_tree_node>& root,
                             vgl_point_3d<double>& cp,
                             std::vector<imesh_kd_tree_queue_entry>* dists)
 {
@@ -357,7 +357,7 @@ imesh_kd_tree_closest_point(const vgl_point_3d<double>& query,
 //  Also returns a vector of the unexplored internal node-distance^2 pairs
 //  Resulting vectors are unsorted
 void imesh_kd_tree_traverse(const vgl_point_3d<double>& query,
-                            const std::auto_ptr<imesh_kd_tree_node>& root,
+                            const vcl_unique_ptr<imesh_kd_tree_node>& root,
                             std::vector<imesh_kd_tree_queue_entry>& leaf,
                             std::vector<imesh_kd_tree_queue_entry>& internal_node)
 {

--- a/contrib/brl/bbas/imesh/algo/imesh_kd_tree.h
+++ b/contrib/brl/bbas/imesh/algo/imesh_kd_tree.h
@@ -27,18 +27,24 @@ struct imesh_kd_tree_node
   //: Constructor for internal node
   imesh_kd_tree_node( const vgl_box_3d<double>& outer_box,
                       const vgl_box_3d<double>& inner_box,
-                      std::auto_ptr<imesh_kd_tree_node> left,
-                      std::auto_ptr<imesh_kd_tree_node> right)
+                      vcl_unique_ptr<imesh_kd_tree_node> left,
+                      vcl_unique_ptr<imesh_kd_tree_node> right)
     : outer_box_(outer_box), inner_box_(inner_box),
       index_(static_cast<unsigned int>(-1)),
-      left_(left), right_(right) {}
+      left_(vcl_move(left)), right_(vcl_move(right)) {}
 
   //: Constructor for leaf node
   imesh_kd_tree_node( const vgl_box_3d<double>& outer_box,
                       const vgl_box_3d<double>& inner_box,
                       unsigned int index )
     : outer_box_(outer_box), inner_box_(inner_box),
-      index_(index), left_(0), right_(0) {}
+      index_(index),
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+      left_(), right_()
+#else
+      left_(0), right_(0)
+#endif
+  {}
 
   //: Copy Constructor (makes a deep copy recursively)
   imesh_kd_tree_node(const imesh_kd_tree_node& other)
@@ -60,25 +66,25 @@ struct imesh_kd_tree_node
   //  Additional indices are assigned to internal nodes
   unsigned int index_;
   //: Left child
-  std::auto_ptr<imesh_kd_tree_node> left_;
+  vcl_unique_ptr<imesh_kd_tree_node> left_;
   //: Right child
-  std::auto_ptr<imesh_kd_tree_node> right_;
+  vcl_unique_ptr<imesh_kd_tree_node> right_;
 };
 
 
 //: Construct a kd-tree (in 3d) of axis aligned boxes
-std::auto_ptr<imesh_kd_tree_node>
+vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree(const std::vector<vgl_box_3d<double> >& boxes);
 
 
 //: construct a kd-tree of mesh faces
-std::auto_ptr<imesh_kd_tree_node>
+vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree(const imesh_vertex_array<3>& verts,
                     const imesh_face_array_base& faces);
 
 
 //: construct a kd-tree of mesh faces
-inline std::auto_ptr<imesh_kd_tree_node>
+inline vcl_unique_ptr<imesh_kd_tree_node>
 imesh_build_kd_tree(const imesh_mesh& mesh)
 {
   return imesh_build_kd_tree(mesh.vertices<3>(), mesh.faces());
@@ -113,7 +119,7 @@ class imesh_kd_tree_queue_entry
 unsigned int
 imesh_kd_tree_closest_point(const vgl_point_3d<double>& query,
                             const imesh_mesh& mesh,
-                            const std::auto_ptr<imesh_kd_tree_node>& root,
+                            const vcl_unique_ptr<imesh_kd_tree_node>& root,
                             vgl_point_3d<double>& cp,
                             std::vector<imesh_kd_tree_queue_entry>* dists = 0);
 
@@ -123,7 +129,7 @@ imesh_kd_tree_closest_point(const vgl_point_3d<double>& query,
 //  Also returns a vector of the unexplored internal node-distance^2 pairs
 //  Resulting vectors are unsorted
 void imesh_kd_tree_traverse(const vgl_point_3d<double>& query,
-                            const std::auto_ptr<imesh_kd_tree_node>& root,
+                            const vcl_unique_ptr<imesh_kd_tree_node>& root,
                             std::vector<imesh_kd_tree_queue_entry>& internal,
                             std::vector<imesh_kd_tree_queue_entry>& leaf);
 

--- a/contrib/brl/bbas/imesh/algo/imesh_kd_tree.hxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_kd_tree.hxx
@@ -28,7 +28,7 @@
 template <class F>
 unsigned int
 imesh_closest_index(const vgl_point_3d<double>& query,
-                    const std::auto_ptr<imesh_kd_tree_node>& kd_root,
+                    const vcl_unique_ptr<imesh_kd_tree_node>& kd_root,
                     F dist,
                     std::vector<imesh_kd_tree_queue_entry>* dists = 0)
 {

--- a/contrib/brl/bbas/imesh/algo/imesh_operations.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_operations.cxx
@@ -29,8 +29,8 @@ imesh_mesh dual_mesh_with_normals(const imesh_mesh& mesh,
   const unsigned int num_verts = mesh.num_verts();
   const unsigned int num_faces = mesh.num_faces();
 
-  std::auto_ptr<imesh_face_array> new_faces(new imesh_face_array);
-  std::auto_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
+  vcl_unique_ptr<imesh_face_array> new_faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
 
   for (unsigned int i=0; i<num_verts; ++i)
   {
@@ -73,9 +73,9 @@ imesh_mesh dual_mesh_with_normals(const imesh_mesh& mesh,
     new_verts->push_back(p1);
   }
 
-  std::auto_ptr<imesh_face_array_base> nf(new_faces);
-  std::auto_ptr<imesh_vertex_array_base > nv(new_verts);
-  return imesh_mesh(nv,nf);
+  vcl_unique_ptr<imesh_face_array_base> nf(vcl_move(new_faces));
+  vcl_unique_ptr<imesh_vertex_array_base > nv(vcl_move(new_verts));
+  return imesh_mesh(vcl_move(nv),vcl_move(nf));
 }
 
 
@@ -164,7 +164,7 @@ imesh_triangulate_nonconvex(imesh_mesh& mesh)
   assert(mesh.vertices().dim() == 3);
   const imesh_vertex_array<3>& verts = mesh.vertices<3>();
 
-  std::auto_ptr<imesh_face_array_base> tris_base(new imesh_regular_face_array<3>);
+  vcl_unique_ptr<imesh_face_array_base> tris_base(new imesh_regular_face_array<3>);
   imesh_regular_face_array<3>* tris =
       static_cast<imesh_regular_face_array<3>*> (tris_base.get());
   int group = -1;
@@ -215,5 +215,5 @@ imesh_triangulate_nonconvex(imesh_mesh& mesh)
     }
   }
 
-  mesh.set_faces(tris_base);
+  mesh.set_faces(vcl_move(tris_base));
 }

--- a/contrib/brl/bbas/imesh/algo/imesh_pca.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_pca.cxx
@@ -98,7 +98,7 @@ imesh_pca_mesh& imesh_pca_mesh::operator=(const imesh_pca_mesh& other)
     this->imesh_mesh::operator=(other);
     std_devs_ = other.std_devs_;
     pc_ = other.pc_;
-    mean_verts_ = std::auto_ptr<imesh_vertex_array_base>((other.mean_verts_.get()) ?
+    mean_verts_ = vcl_unique_ptr<imesh_vertex_array_base>((other.mean_verts_.get()) ?
                                                         other.mean_verts_->clone() : VXL_NULLPTR);
     params_ = other.params_;
   }
@@ -347,9 +347,9 @@ void imesh_write_pca(const std::string& mesh_file,
   for (unsigned int i=0; i<num_data; ++i)
     mean[i] = mverts[i/3][i%3];
 
-  std::auto_ptr<imesh_vertex_array_base> verts(mverts.clone());
-  std::auto_ptr<imesh_face_array_base> faces(pmesh.faces().clone());
-  imesh_mesh mean_mesh(verts,faces);
+  vcl_unique_ptr<imesh_vertex_array_base> verts(mverts.clone());
+  vcl_unique_ptr<imesh_face_array_base> faces(pmesh.faces().clone());
+  imesh_mesh mean_mesh(vcl_move(verts),vcl_move(faces));
 
   imesh_write_pca(pca_file,mean,std_dev,pc);
   imesh_write_obj(mesh_file,mean_mesh);

--- a/contrib/brl/bbas/imesh/algo/imesh_pca.h
+++ b/contrib/brl/bbas/imesh/algo/imesh_pca.h
@@ -101,7 +101,7 @@ class imesh_pca_mesh : public imesh_mesh
 
   vnl_vector<double> std_devs_;
   vnl_matrix<double> pc_;
-  std::auto_ptr<imesh_vertex_array_base> mean_verts_;
+  vcl_unique_ptr<imesh_vertex_array_base> mean_verts_;
 
   vnl_vector<double> params_;
 };

--- a/contrib/brl/bbas/imesh/algo/imesh_project.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_project.cxx
@@ -170,7 +170,7 @@ imesh_render_faces(const imesh_mesh& mesh,
                    vil_image_view<bool>& image)
 {
   const imesh_face_array_base& faces = mesh.faces();
-  std::auto_ptr<imesh_regular_face_array<3> > tri_data;
+  vcl_unique_ptr<imesh_regular_face_array<3> > tri_data;
   const imesh_regular_face_array<3>* tris;
   if (faces.regularity() != 3) {
     tri_data = imesh_triangulate(faces);
@@ -208,7 +208,7 @@ imesh_render_faces_interp(const imesh_mesh& mesh,
                           vil_image_view<double>& image)
 {
   const imesh_face_array_base& faces = mesh.faces();
-  std::auto_ptr<imesh_regular_face_array<3> > tri_data;
+  vcl_unique_ptr<imesh_regular_face_array<3> > tri_data;
   const imesh_regular_face_array<3>* tris;
   if (faces.regularity() != 3) {
     tri_data = imesh_triangulate(faces);
@@ -249,7 +249,7 @@ void imesh_project(const imesh_mesh& mesh,
                    vgl_box_2d<unsigned int>* bbox)
 {
   const imesh_face_array_base& faces = mesh.faces();
-  std::auto_ptr<imesh_regular_face_array<3> > tri_data;
+  vcl_unique_ptr<imesh_regular_face_array<3> > tri_data;
   const imesh_regular_face_array<3>* tri_ptr;
   if (faces.regularity() != 3) {
     tri_data = imesh_triangulate(faces);

--- a/contrib/brl/bbas/imesh/algo/imesh_render.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_render.cxx
@@ -93,7 +93,7 @@ void imesh_render_textured(const imesh_mesh& mesh,
   assert(tex_coords.size() == verts2d.size());
 
   const imesh_face_array_base& faces = mesh.faces();
-  std::auto_ptr<imesh_regular_face_array<3> > tri_data;
+  vcl_unique_ptr<imesh_regular_face_array<3> > tri_data;
   const imesh_regular_face_array<3>* tris;
   if (faces.regularity() != 3) {
     tri_data = imesh_triangulate(faces);

--- a/contrib/brl/bbas/imesh/imesh_face.cxx
+++ b/contrib/brl/bbas/imesh/imesh_face.cxx
@@ -109,12 +109,12 @@ void imesh_face_array::append(const imesh_face_array_base& other,
 
 
 //: Merge the two face arrays
-std::auto_ptr<imesh_face_array_base>
+vcl_unique_ptr<imesh_face_array_base>
 imesh_merge(const imesh_face_array_base& f1,
             const imesh_face_array_base& f2,
             unsigned int ind_shift)
 {
-  std::auto_ptr<imesh_face_array_base> f;
+  vcl_unique_ptr<imesh_face_array_base> f;
   // if both face sets are regular with the same number of vertices per face
   if (f1.regularity() == f2.regularity() || f1.regularity() == 0) {
     f.reset(f1.clone());

--- a/contrib/brl/bbas/imesh/imesh_face.h
+++ b/contrib/brl/bbas/imesh/imesh_face.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 #include <set>
-#include <memory>
+#include <vcl_memory.h>
 #include <utility>
 #include <string>
 #include <iostream>
@@ -317,7 +317,7 @@ class imesh_regular_face_array : public imesh_face_array_base
 
 //: Merge the two face arrays
 //  Shift the mesh indices in \param f2 by \param ind_shift
-std::auto_ptr<imesh_face_array_base>
+vcl_unique_ptr<imesh_face_array_base>
 imesh_merge(const imesh_face_array_base& f1,
             const imesh_face_array_base& f2,
             unsigned int ind_shift=0);

--- a/contrib/brl/bbas/imesh/imesh_fileio.cxx
+++ b/contrib/brl/bbas/imesh/imesh_fileio.cxx
@@ -42,8 +42,8 @@ bool imesh_read_ply2(std::istream& is, imesh_mesh& mesh)
 {
   unsigned int num_verts, num_faces;
   is >> num_verts >> num_faces;
-  std::auto_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(num_verts));
-  std::auto_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
+  vcl_unique_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(num_verts));
+  vcl_unique_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
   for (unsigned int v=0; v<num_verts; ++v) {
     imesh_vertex<3>& vert = (*verts)[v];
     is >> vert[0] >> vert[1] >> vert[2];
@@ -57,8 +57,8 @@ bool imesh_read_ply2(std::istream& is, imesh_mesh& mesh)
       is >> face[v];
   }
 
-  mesh.set_vertices(std::auto_ptr<imesh_vertex_array_base>(verts));
-  mesh.set_faces(std::auto_ptr<imesh_face_array_base>(faces));
+  mesh.set_vertices(vcl_unique_ptr<imesh_vertex_array_base>(vcl_move(verts)));
+  mesh.set_faces(vcl_unique_ptr<imesh_face_array_base>(vcl_move(faces)));
   return true;
 }
 
@@ -94,8 +94,8 @@ bool imesh_read_ply(std::istream& is, imesh_mesh& mesh)
       done = true;
     }
   }
-  std::auto_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(num_verts));
-  std::auto_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
+  vcl_unique_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(num_verts));
+  vcl_unique_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
   for (unsigned int v=0; v<num_verts; ++v) {
     imesh_vertex<3>& vert = (*verts)[v];
     is >> vert[0] >> vert[1] >> vert[2];
@@ -109,8 +109,8 @@ bool imesh_read_ply(std::istream& is, imesh_mesh& mesh)
       is >> face[v];
   }
 
-  mesh.set_vertices(std::auto_ptr<imesh_vertex_array_base>(verts));
-  mesh.set_faces(std::auto_ptr<imesh_face_array_base>(faces));
+  mesh.set_vertices(vcl_unique_ptr<imesh_vertex_array_base>(vcl_move(verts)));
+  mesh.set_faces(vcl_unique_ptr<imesh_face_array_base>(vcl_move(faces)));
   return true;
 }
 
@@ -186,8 +186,8 @@ bool imesh_read_obj(const std::string& filename, imesh_mesh& mesh)
 //: Read a mesh from a wavefront OBJ stream
 bool imesh_read_obj(std::istream& is, imesh_mesh& mesh)
 {
-  std::auto_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>);
-  std::auto_ptr<imesh_face_array> faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>);
+  vcl_unique_ptr<imesh_face_array> faces(new imesh_face_array);
   std::vector<vgl_vector_3d<double> > normals;
   std::vector<vgl_point_2d<double> > tex;
   std::string last_group = "ungrouped";
@@ -290,8 +290,8 @@ bool imesh_read_obj(std::istream& is, imesh_mesh& mesh)
   if (normals.size() == verts->size())
     verts->set_normals(normals);
 
-  mesh.set_vertices(std::auto_ptr<imesh_vertex_array_base>(verts));
-  mesh.set_faces(std::auto_ptr<imesh_face_array_base>(faces));
+  mesh.set_vertices(vcl_unique_ptr<imesh_vertex_array_base>(vcl_move(verts)));
+  mesh.set_faces(vcl_unique_ptr<imesh_face_array_base>(vcl_move(faces)));
   mesh.set_tex_coords(tex);
 
   return true;

--- a/contrib/brl/bbas/imesh/imesh_mesh.cxx
+++ b/contrib/brl/bbas/imesh/imesh_mesh.cxx
@@ -27,9 +27,9 @@ imesh_mesh::imesh_mesh(const imesh_mesh& other)
 imesh_mesh& imesh_mesh::operator=(imesh_mesh const& other)
 {
   if (this != &other) {
-    verts_ = std::auto_ptr<imesh_vertex_array_base>((other.verts_.get()) ?
+    verts_ = vcl_unique_ptr<imesh_vertex_array_base>((other.verts_.get()) ?
                                                    other.verts_->clone() : VXL_NULLPTR);
-    faces_ = std::auto_ptr<imesh_face_array_base>((other.faces_.get()) ?
+    faces_ = vcl_unique_ptr<imesh_face_array_base>((other.faces_.get()) ?
                                                  other.faces_->clone() : VXL_NULLPTR);
     half_edges_ = other.half_edges_;
     tex_coords_ = other.tex_coords_;

--- a/contrib/brl/bbas/imesh/imesh_mesh.h
+++ b/contrib/brl/bbas/imesh/imesh_mesh.h
@@ -9,7 +9,7 @@
 
 #include <vector>
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 #include <vcl_cassert.h>
 
@@ -33,8 +33,8 @@ class imesh_mesh : public vbl_ref_count
 
   //: Constructor from vertex and face arrays
   //  Takes ownership of these arrays
-  imesh_mesh(std::auto_ptr<imesh_vertex_array_base> verts, std::auto_ptr<imesh_face_array_base> faces)
-  : verts_(verts), faces_(faces), tex_coord_status_(TEX_COORD_NONE) {}
+  imesh_mesh(vcl_unique_ptr<imesh_vertex_array_base> verts, vcl_unique_ptr<imesh_face_array_base> faces)
+  : verts_(vcl_move(verts)), faces_(vcl_move(faces)), tex_coord_status_(TEX_COORD_NONE) {}
 
   //: Copy Constructor
   imesh_mesh(const imesh_mesh& other);
@@ -81,10 +81,10 @@ class imesh_mesh : public vbl_ref_count
   imesh_face_array_base& faces() { return *faces_; }
 
   //: Set the vertices
-  void set_vertices(std::auto_ptr<imesh_vertex_array_base> verts) { verts_ = verts; }
+  void set_vertices(vcl_unique_ptr<imesh_vertex_array_base> verts) { verts_ = vcl_move(verts); }
 
   //: Set the faces
-  void set_faces(std::auto_ptr<imesh_face_array_base> faces) { faces_ = faces; }
+  void set_faces(vcl_unique_ptr<imesh_face_array_base> faces) { faces_ = vcl_move(faces); }
 
   //: Returns true if the mesh has computed half edges
   bool has_half_edges() const { return half_edges_.size() > 0; }
@@ -144,8 +144,8 @@ class imesh_mesh : public vbl_ref_count
 
 
  private:
-  std::auto_ptr<imesh_vertex_array_base> verts_;
-  std::auto_ptr<imesh_face_array_base> faces_;
+  vcl_unique_ptr<imesh_vertex_array_base> verts_;
+  vcl_unique_ptr<imesh_face_array_base> faces_;
   imesh_half_edge_set half_edges_;
 
   //: vector of texture coordinates

--- a/contrib/brl/bbas/imesh/imesh_operations.cxx
+++ b/contrib/brl/bbas/imesh/imesh_operations.cxx
@@ -12,10 +12,10 @@
 #include <vgl/vgl_vector_3d.h>
 
 //: Subdivide mesh faces into triangle
-std::auto_ptr<imesh_regular_face_array<3> >
+vcl_unique_ptr<imesh_regular_face_array<3> >
 imesh_triangulate(const imesh_face_array_base& faces)
 {
-  std::auto_ptr<imesh_regular_face_array<3> > tris(new imesh_regular_face_array<3>);
+  vcl_unique_ptr<imesh_regular_face_array<3> > tris(new imesh_regular_face_array<3>);
   int group = -1;
   if (faces.has_groups())
     group = 0;
@@ -31,10 +31,10 @@ imesh_triangulate(const imesh_face_array_base& faces)
 
 
 //: Subdivide quadrilaterals into triangle
-std::auto_ptr<imesh_regular_face_array<3> >
+vcl_unique_ptr<imesh_regular_face_array<3> >
 imesh_triangulate(const imesh_regular_face_array<4>& faces)
 {
-  std::auto_ptr<imesh_regular_face_array<3> > tris(new imesh_regular_face_array<3>);
+  vcl_unique_ptr<imesh_regular_face_array<3> > tris(new imesh_regular_face_array<3>);
   int group = -1;
   if (faces.has_groups())
     group = 0;
@@ -59,15 +59,15 @@ imesh_triangulate(imesh_mesh& mesh)
     case 3: break;
     case 4:
     {
-      std::auto_ptr<imesh_face_array_base> tris(
+      vcl_unique_ptr<imesh_face_array_base> tris(
           imesh_triangulate(static_cast<const imesh_regular_face_array<4>&>(mesh.faces())));
-      mesh.set_faces(tris);
+      mesh.set_faces(vcl_move(tris));
       break;
     }
     default:
     {
-      std::auto_ptr<imesh_face_array_base> tris(imesh_triangulate(mesh.faces()));
-      mesh.set_faces(tris);
+      vcl_unique_ptr<imesh_face_array_base> tris(imesh_triangulate(mesh.faces()));
+      mesh.set_faces(vcl_move(tris));
       break;
     }
   }
@@ -190,7 +190,7 @@ imesh_quad_subdivide(imesh_mesh& mesh)
   }
 
   // construct the new quad faces
-  std::auto_ptr<imesh_regular_face_array<4> > new_faces(new imesh_regular_face_array<4>);
+  vcl_unique_ptr<imesh_regular_face_array<4> > new_faces(new imesh_regular_face_array<4>);
   std::vector<vgl_point_2d<double> > tex_coords;
   unsigned int f_vert_base = num_o_verts+num_e_verts;
   for (unsigned int he=0; he<half_edges.size(); ++he) {
@@ -210,7 +210,12 @@ imesh_quad_subdivide(imesh_mesh& mesh)
   }
 
 
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+  vcl_unique_ptr<imesh_face_array_base> temp( vcl_move(new_faces) );
+  mesh.set_faces(vcl_move(temp));
+#else
   mesh.set_faces(std::auto_ptr<imesh_face_array_base>(new_faces));
+#endif
   mesh.remove_edge_graph();
   if (had_edges)
     mesh.build_edge_graph();
@@ -296,7 +301,7 @@ imesh_quad_subdivide(imesh_mesh& mesh, const std::set<unsigned int>& sel_faces)
   // construct the new faces
   typedef std::map<unsigned int,unsigned int>::const_iterator map_itr;
   typedef imesh_half_edge_set::f_const_iterator face_itr;
-  std::auto_ptr<imesh_face_array> new_faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_face_array> new_faces(new imesh_face_array);
   int group = -1;
   if (faces.has_groups())
     group = 0;
@@ -335,7 +340,12 @@ imesh_quad_subdivide(imesh_mesh& mesh, const std::set<unsigned int>& sel_faces)
   }
 
 
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+  vcl_unique_ptr<imesh_face_array_base> temp = vcl_move(new_faces);
+  mesh.set_faces(vcl_move(temp));
+#else
   mesh.set_faces(std::auto_ptr<imesh_face_array_base>(new_faces));
+#endif
   mesh.remove_edge_graph();
   if (had_edges)
     mesh.build_edge_graph();
@@ -348,8 +358,8 @@ imesh_submesh_from_faces(const imesh_mesh& mesh, const std::set<unsigned int>& s
 {
   const imesh_vertex_array<3>& verts = mesh.vertices<3>();
 
-  std::auto_ptr<imesh_face_array> new_faces(new imesh_face_array);
-  std::auto_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
+  vcl_unique_ptr<imesh_face_array> new_faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
   std::vector<int> vert_map(mesh.num_verts(),-1);
 
   unsigned int new_count = 0;
@@ -393,9 +403,9 @@ imesh_submesh_from_faces(const imesh_mesh& mesh, const std::set<unsigned int>& s
     new_verts->set_normals(vnormals);
 
 
-  std::auto_ptr<imesh_vertex_array_base> nverts(new_verts);
-  std::auto_ptr<imesh_face_array_base> nfaces(new_faces);
-  imesh_mesh submesh(nverts,nfaces);
+  vcl_unique_ptr<imesh_vertex_array_base> nverts(vcl_move(new_verts));
+  vcl_unique_ptr<imesh_face_array_base> nfaces(vcl_move(new_faces));
+  imesh_mesh submesh(vcl_move(nverts),vcl_move(nfaces));
 
   if (mesh.has_tex_coords())
     submesh.set_tex_coords(tex_coords);
@@ -433,8 +443,8 @@ imesh_mesh dual_mesh(const imesh_mesh& mesh)
   const unsigned int num_verts = mesh.num_verts();
   const unsigned int num_faces = mesh.num_faces();
 
-  std::auto_ptr<imesh_face_array> new_faces(new imesh_face_array);
-  std::auto_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
+  vcl_unique_ptr<imesh_face_array> new_faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
 
   for (unsigned int i=0; i<num_faces; ++i)
   {
@@ -464,16 +474,16 @@ imesh_mesh dual_mesh(const imesh_mesh& mesh)
   if (mesh.vertices().has_normals())
     new_faces->set_normals(mesh.vertices().normals());
 
-  std::auto_ptr<imesh_face_array_base> nf(new_faces);
-  std::auto_ptr<imesh_vertex_array_base > nv(new_verts);
-  return imesh_mesh(nv,nf);
+  vcl_unique_ptr<imesh_face_array_base> nf(vcl_move(new_faces));
+  vcl_unique_ptr<imesh_vertex_array_base > nv(vcl_move(new_verts));
+  return imesh_mesh(vcl_move(nv),vcl_move(nf));
 }
 
 //: Contains a 3d point in convex polygon
 bool contains_point(const imesh_mesh& mesh,vgl_point_3d<double> p)
 {
-  std::auto_ptr<imesh_face_array> new_faces(new imesh_face_array);
-  std::auto_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
+  vcl_unique_ptr<imesh_face_array> new_faces(new imesh_face_array);
+  vcl_unique_ptr<imesh_vertex_array<3> > new_verts(new imesh_vertex_array<3>);
 
   for (unsigned int i=0; i<mesh.num_faces(); ++i)
   {

--- a/contrib/brl/bbas/imesh/imesh_operations.h
+++ b/contrib/brl/bbas/imesh/imesh_operations.h
@@ -20,11 +20,11 @@
 #include <vgl/vgl_point_3d.h>
 
 //: Subdivide mesh faces into triangle
-std::auto_ptr<imesh_regular_face_array<3> >
+vcl_unique_ptr<imesh_regular_face_array<3> >
 imesh_triangulate(const imesh_face_array_base& faces);
 
 //: Subdivide quadrilaterals into triangle
-std::auto_ptr<imesh_regular_face_array<3> >
+vcl_unique_ptr<imesh_regular_face_array<3> >
 imesh_triangulate(const imesh_regular_face_array<4>& faces);
 
 

--- a/contrib/brl/bbas/imesh/tests/test_kd_tree.cxx
+++ b/contrib/brl/bbas/imesh/tests/test_kd_tree.cxx
@@ -11,7 +11,7 @@
 
 void test_closest_point(const imesh_mesh& mesh, const std::vector<vgl_point_3d<double> >& pts)
 {
-  std::auto_ptr<imesh_kd_tree_node> kd_tree = imesh_build_kd_tree(mesh);
+  vcl_unique_ptr<imesh_kd_tree_node> kd_tree = imesh_build_kd_tree(mesh);
 
   bool same_tri = true;
   bool same_pt = true;
@@ -56,7 +56,7 @@ static void test_kd_tree()
   test_closest_point(cube,pts);
 
   std::vector<imesh_kd_tree_queue_entry> dists;
-  std::auto_ptr<imesh_kd_tree_node> kd_tree = imesh_build_kd_tree(cube);
+  vcl_unique_ptr<imesh_kd_tree_node> kd_tree = imesh_build_kd_tree(cube);
   vgl_point_3d<double> cp;
   imesh_kd_tree_closest_point(pts[3],cube,kd_tree,cp,&dists);
   unsigned int leaf_count = 0;

--- a/contrib/brl/bbas/imesh/tests/test_share.cxx
+++ b/contrib/brl/bbas/imesh/tests/test_share.cxx
@@ -13,8 +13,8 @@ void make_cube(imesh_mesh& cube)
   verts->push_back(imesh_vertex<3>(-1, 1,-1));
   verts->push_back(imesh_vertex<3>(-1,-1,-1));
   verts->push_back(imesh_vertex<3>( 1,-1,-1));
-  std::auto_ptr<imesh_vertex_array_base> v(verts);
-  cube.set_vertices(v);
+  vcl_unique_ptr<imesh_vertex_array_base> v(verts);
+  cube.set_vertices(vcl_move(v));
 
   imesh_regular_face_array<4>* faces = new imesh_regular_face_array<4>();
   faces->push_back(imesh_quad(0,1,2,3));
@@ -23,7 +23,7 @@ void make_cube(imesh_mesh& cube)
   faces->push_back(imesh_quad(2,6,7,3));
   faces->push_back(imesh_quad(3,7,4,0));
   faces->push_back(imesh_quad(7,6,5,4));
-  std::auto_ptr<imesh_face_array_base> f(faces);
-  cube.set_faces(f);
+  vcl_unique_ptr<imesh_face_array_base> f(faces);
+  cube.set_faces(vcl_move(f));
 }
 

--- a/contrib/brl/bpro/bprb/bprb_batch_process_manager.cxx
+++ b/contrib/brl/bpro/bprb/bprb_batch_process_manager.cxx
@@ -107,7 +107,7 @@ bool bprb_batch_process_manager::set_input_from_db(unsigned i,
   // query to get the data
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-  brdb_selection_sptr selec = DATABASE->select(relation_name, Q);
+  brdb_selection_sptr selec = DATABASE->select(relation_name, vcl_move(Q));
   if (selec->size()!=1) {
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
     return false;
@@ -141,7 +141,7 @@ bool bprb_batch_process_manager::set_input_from_db(unsigned i,
   // query to get the data
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-  brdb_selection_sptr selec = DATABASE->select(relation_name, Q);
+  brdb_selection_sptr selec = DATABASE->select(relation_name, vcl_move(Q));
   if (!selec||selec->size()!=1) {
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
     return false;
@@ -221,7 +221,7 @@ bool bprb_batch_process_manager::remove_data(unsigned id)
     // query to get the data
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-    brdb_selection_sptr selec = DATABASE->select(*nit, Q);
+    brdb_selection_sptr selec = DATABASE->select(*nit, vcl_move(Q));
     if (selec->size()!=1)
       continue;
     selec->delete_tuples();

--- a/contrib/brl/bpro/bprb/tests/test_process.cxx
+++ b/contrib/brl/bpro/bprb/tests/test_process.cxx
@@ -29,7 +29,7 @@ static void test_process()
     // query to get the data
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-  brdb_selection_sptr selec = DATABASE->select("float_data", Q);
+  brdb_selection_sptr selec = DATABASE->select("float_data", vcl_move(Q));
   if (selec->size()!=1) {
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
   }

--- a/contrib/brl/bpro/bprb/tests/test_process_params.cxx
+++ b/contrib/brl/bpro/bprb/tests/test_process_params.cxx
@@ -32,7 +32,7 @@ void test_process_params()
     // query to get the data
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-  brdb_selection_sptr selec = DATABASE->select("float_data", Q);
+  brdb_selection_sptr selec = DATABASE->select("float_data", vcl_move(Q));
   if (selec->size()!=1) {
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bpro/core/vil_pro/tests/test_vil_convert_to_n_planes_process.cxx
+++ b/contrib/brl/bpro/core/vil_pro/tests/test_vil_convert_to_n_planes_process.cxx
@@ -40,7 +40,7 @@ vil_image_view_base_sptr test_process(vil_image_view_base_sptr const &ref_img)
   TEST("run vil_convert_to_n_planes_process", good ,true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img) );
   TEST("output image is in db", S_img->size(), 1);
 
   brdb_value_sptr value_img;

--- a/contrib/brl/bpro/core/vil_pro/tests/test_vil_crop_image_process.cxx
+++ b/contrib/brl/bpro/core/vil_pro/tests/test_vil_crop_image_process.cxx
@@ -46,7 +46,7 @@ vil_image_view_base_sptr test_process(vil_image_view_base_sptr const &ref_img, u
   TEST("run vil_crop_image_process", good ,true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   TEST("output image is in db", S_img->size(), 1);
 
   brdb_value_sptr value_img;

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_generate_3d_point_from_cams_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_generate_3d_point_from_cams_process.cxx
@@ -65,7 +65,7 @@ bool vpgl_generate_3d_point_from_cams_process(bprb_func_process& pro)
   for (unsigned int i=0; i<cam_ids.size(); ++i) {
     unsigned cam_id = cam_ids[i];
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, cam_id);
-    brdb_selection_sptr S = DATABASE->select("vpgl_camera_double_sptr_data", Q);
+    brdb_selection_sptr S = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q));
     if (S->size()!=1) {
       std::cout << "in vpgl_generate_3d_point_from_cams_process - bad input value\n";
       return false;

--- a/contrib/brl/bseg/betr/betr_event_trigger.cxx
+++ b/contrib/brl/bseg/betr/betr_event_trigger.cxx
@@ -268,7 +268,7 @@ bool betr_event_trigger::project_object(vpgl_camera_double_sptr cam, std::string
   } 
   vsol_region_3d* reg_ptr = VXL_NULLPTR;
   vsol_volume_3d* vol_ptr = VXL_NULLPTR;
-  if(reg_ptr = so_ptr->cast_to_region())
+  if( ( reg_ptr = so_ptr->cast_to_region() ) )
     {
       vsol_polygon_3d* poly_3d = reg_ptr->cast_to_polygon();
       if(!poly_3d){
@@ -277,7 +277,7 @@ bool betr_event_trigger::project_object(vpgl_camera_double_sptr cam, std::string
       } 
       poly_2d = project_poly(cam, poly_3d, transl);
       return true;
-    }else if(vol_ptr = so_ptr->cast_to_volume()){
+    }else if( ( vol_ptr = so_ptr->cast_to_volume() ) ){
       vsol_mesh_3d* mesh_3d = vol_ptr->cast_to_mesh();
       if(!mesh_3d){
         std::cout << "only handle vsol_mesh_3d for now " << obj_name << " is not a vsol_mesh_3d\n";

--- a/contrib/brl/bseg/betr/betr_geo_object_3d.cxx
+++ b/contrib/brl/bseg/betr/betr_geo_object_3d.cxx
@@ -32,14 +32,14 @@ vsol_polygon_3d_sptr betr_geo_object_3d::base_polygon() {
   vsol_polygon_3d_sptr local_base_poly;
   vsol_region_3d* reg_ptr = VXL_NULLPTR;
   vsol_volume_3d* vol_ptr = VXL_NULLPTR;
-  if(reg_ptr = so_->cast_to_region()){
+  if( ( reg_ptr = so_->cast_to_region() ) ){
     vsol_polygon_3d* poly_3d = reg_ptr->cast_to_polygon();
       if(!poly_3d){
         std::cout << "only handle polygonal regions for now. Geo object is not a vsol_polygon_3d" << std::endl;
         return VXL_NULLPTR;
       } 
       local_base_poly = poly_3d;
-  }else if(vol_ptr = so_->cast_to_volume()){
+  }else if( ( vol_ptr = so_->cast_to_volume() ) ){
     vsol_mesh_3d* mesh = vol_ptr->cast_to_mesh();
     if(!mesh){
         std::cout << "only handle mesh volumes for now. Geo object is not a vsol_mesh_3d" << std::endl;

--- a/contrib/brl/bseg/betr/betr_params.cxx
+++ b/contrib/brl/bseg/betr/betr_params.cxx
@@ -9,6 +9,7 @@ bool write_params_json(std::string& json_str, betr_params_sptr const& params){
   params->serialize(serialize_root);
   Json::StyledWriter writer;
   json_str = writer.write(serialize_root);
+  return true;
 }
 bool read_params_json(std::string const& json_str, betr_params_sptr& params){
   Json::Value deserialize_root;

--- a/contrib/brl/bseg/bmdl/bmdl_mesh.cxx
+++ b/contrib/brl/bseg/bmdl/bmdl_mesh.cxx
@@ -554,10 +554,10 @@ void bmdl_mesh::mesh_lidar(const std::vector<vgl_polygon<double> >& boundaries,
     faces->push_back(roof);
   }
 
-  std::auto_ptr<imesh_vertex_array_base> vb(verts);
-  std::auto_ptr<imesh_face_array_base> fb(faces);
-  mesh.set_vertices(vb);
-  mesh.set_faces(fb);
+  vcl_unique_ptr<imesh_vertex_array_base> vb(verts);
+  vcl_unique_ptr<imesh_face_array_base> fb(faces);
+  mesh.set_vertices(vcl_move(vb));
+  mesh.set_faces(vcl_move(fb));
 }
 
 
@@ -898,10 +898,10 @@ void bmdl_mesh::mesh_lidar(const std::vector<bmdl_edge>& edges,
     }
   }
 
-  std::auto_ptr<imesh_vertex_array_base> vb(verts);
-  std::auto_ptr<imesh_face_array_base> fb(faces);
-  mesh.set_vertices(vb);
-  mesh.set_faces(fb);
+  vcl_unique_ptr<imesh_vertex_array_base> vb(verts);
+  vcl_unique_ptr<imesh_face_array_base> fb(faces);
+  mesh.set_vertices(vcl_move(vb));
+  mesh.set_faces(vcl_move(fb));
 }
 
 

--- a/contrib/brl/bseg/bmdl/pro/tests/test_bmdl_classify_process.cxx
+++ b/contrib/brl/bseg/bmdl/pro/tests/test_bmdl_classify_process.cxx
@@ -22,7 +22,7 @@ bool get_image(unsigned int id, vil_image_view_base_sptr& image)
 {
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id);
 
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img) );
   if (S_img->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/boxm/algo/tests/test_fill_in_mesh.cxx
+++ b/contrib/brl/bseg/boxm/algo/tests/test_fill_in_mesh.cxx
@@ -33,8 +33,8 @@ static void test_fill_in_mesh()
 
   //// create a mesh
   unsigned int num_faces=6;
-  std::auto_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(8));
-  std::auto_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
+  vcl_unique_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(8));
+  vcl_unique_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
   imesh_vertex<3>& vert0 = (*verts)[0]; imesh_vertex<3>& vert4 = (*verts)[4];
   vert0[0]=2;                           vert4[0]=2;
   vert0[1]=2;                           vert4[1]=2;
@@ -69,8 +69,15 @@ static void test_fill_in_mesh()
 
 
   imesh_mesh mesh;
-  mesh.set_vertices(std::auto_ptr<imesh_vertex_array_base>(verts));
-  mesh.set_faces(std::auto_ptr<imesh_face_array_base>(faces));
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+  vcl_unique_ptr<imesh_vertex_array_base> tempv(vcl_move(verts));
+  mesh.set_vertices(vcl_move(tempv));
+  vcl_unique_ptr<imesh_face_array_base> tempf(vcl_move(faces));
+  mesh.set_faces(vcl_move(tempf));
+#else
+  mesh.set_vertices(vcl_unique_ptr<imesh_vertex_array_base>(verts));
+  mesh.set_faces(vcl_unique_ptr<imesh_face_array_base>(faces));
+#endif
 
   typedef boct_tree<short,boxm_sample<BOXM_APM_MOG_GREY> > tree_type;
   boxm_block_iterator<boct_tree<short,boxm_sample<BOXM_APM_MOG_GREY> > > iter(&scene);

--- a/contrib/brl/bseg/boxm/algo/tests/test_upload_mesh.cxx
+++ b/contrib/brl/bseg/boxm/algo/tests/test_upload_mesh.cxx
@@ -46,8 +46,8 @@ static void test_upload_mesh()
 
   // create a mesh
   unsigned int num_faces=1;
-  std::auto_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(3));
-  std::auto_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
+  vcl_unique_ptr<imesh_vertex_array<3> > verts(new imesh_vertex_array<3>(3));
+  vcl_unique_ptr<imesh_face_array > faces(new imesh_face_array(num_faces));
   imesh_vertex<3>& vert0 = (*verts)[0];
   vert0[0]=2;
   vert0[1]=2;
@@ -69,8 +69,15 @@ static void test_upload_mesh()
       face[v]=v;
   }
   imesh_mesh mesh;
-  mesh.set_vertices(std::auto_ptr<imesh_vertex_array_base>(verts));
-  mesh.set_faces(std::auto_ptr<imesh_face_array_base>(faces));
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+  vcl_unique_ptr<imesh_vertex_array_base> tempv(vcl_move(verts));
+  mesh.set_vertices(vcl_move(tempv));
+  vcl_unique_ptr<imesh_face_array_base> tempf(vcl_move(faces));
+  mesh.set_faces(vcl_move(tempf));
+#else
+  mesh.set_vertices(vcl_unique_ptr<imesh_vertex_array_base>(verts));
+  mesh.set_faces(vcl_unique_ptr<imesh_face_array_base>(faces));
+#endif
 
   typedef boct_tree<short,boxm_sample<BOXM_APM_MOG_GREY> > tree_type;
   boxm_block_iterator<boct_tree<short,boxm_sample<BOXM_APM_MOG_GREY> > > iter(&scene);

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.cxx
@@ -24,7 +24,7 @@ boxm2_points_to_volume::boxm2_points_to_volume(boxm2_scene_sptr scene,
 {
   //store mesh triangles
   std::cout<<"Triangulating points:"<<std::endl;
-  std::auto_ptr<imesh_regular_face_array<3> > meshTris = imesh_triangulate(points_.faces());
+  vcl_unique_ptr<imesh_regular_face_array<3> > meshTris = imesh_triangulate(points_.faces());
   std::cout<<"   ... done."<<std::endl;
 
   //store bvpgl triangles
@@ -285,7 +285,7 @@ boxm2_points_to_volume::tris_in_box(const imesh_mesh& mesh, vgl_box_3d<double>& 
 {
   std::vector<bvgl_triangle_3d<double> > contained;
   const imesh_vertex_array<3>& verts = mesh.vertices<3>();
-  std::auto_ptr<imesh_regular_face_array<3> > tris = imesh_triangulate(mesh.faces());
+  vcl_unique_ptr<imesh_regular_face_array<3> > tris = imesh_triangulate(mesh.faces());
   imesh_regular_face_array<3>::const_iterator iter;
   for (iter = tris->begin(); iter != tris->end(); ++iter) {
     imesh_regular_face<3> idx =(*iter);

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_view_dep_app_color.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_update_view_dep_app_color.cxx
@@ -171,7 +171,7 @@ bool boxm2_ocl_update_view_dep_app_color::update(boxm2_scene_sptr         scene,
   norm_image->create_buffer(CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR);
 
   // Image Dimensions
-  int img_dim_buff[4] = {0, 0, img_view->ni(), img_view->nj() };
+  int img_dim_buff[4] = {0, 0, (int)img_view->ni(), (int) img_view->nj() };
   bocl_mem_sptr img_dim=new bocl_mem(device->context(), img_dim_buff, sizeof(int)*4, "image dims");
   img_dim->create_buffer(CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR);
 

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_estimate_uncertain_viewpoints.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_estimate_uncertain_viewpoints.cxx
@@ -223,7 +223,7 @@ int main(int argc,  char** argv)
                 }
 
                 brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-                brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+                brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
                 if (S->size()!=1) {
                   std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                            << " no selections\n";

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_export_scene.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_export_scene.cxx
@@ -268,7 +268,7 @@ int main(int argc,  char** argv)
                     }
 
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
                     if (S->size()!=1) {
                         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
                     }
@@ -318,7 +318,7 @@ int main(int argc,  char** argv)
                     }
 
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
                     if (S->size()!=1) {
                         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
                     }
@@ -363,7 +363,7 @@ int main(int argc,  char** argv)
                     }
 
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
                     if (S->size()!=1) {
                         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
                     }
@@ -399,7 +399,7 @@ int main(int argc,  char** argv)
                     }
 
                     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+                    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
                     if (S->size()!=1) {
                         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
                     }

--- a/contrib/brl/bseg/boxm2/ocl/exe/boxm2_render_hemisphere.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/exe/boxm2_render_hemisphere.cxx
@@ -134,7 +134,7 @@ int main(int argc,  char** argv)
         return -1;
       }
       brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-      brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+      brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
       if (S->size()!=1) {
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                  << " no selections\n";
@@ -252,7 +252,7 @@ int main(int argc,  char** argv)
           return -1;
         }
         brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, img_id);
-        brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+        brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
         if (S->size()!=1) {
           std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                    << " no selections\n";

--- a/contrib/brl/bseg/boxm2/pro/processes/boxm2_export_textured_mesh_process.cxx
+++ b/contrib/brl/bseg/boxm2/pro/processes/boxm2_export_textured_mesh_process.cxx
@@ -381,9 +381,9 @@ void boxm2_export_textured_mesh_process_globals::boxm2_texture_mesh_from_imgs(st
     }
 
     //create the submesh using the auto ptrs
-    std::auto_ptr<imesh_vertex_array_base> v3(verts3);
-    std::auto_ptr<imesh_face_array_base> f3(flist);
-    imesh_mesh subMesh(v3, f3);
+    vcl_unique_ptr<imesh_vertex_array_base> v3(verts3);
+    vcl_unique_ptr<imesh_face_array_base> f3(flist);
+    imesh_mesh subMesh(vcl_move(v3), vcl_move(f3));
 
     std::cout<<"Setting tex source: "<<apps->first<<std::endl;
     meshes[apps->first] = subMesh;

--- a/contrib/brl/bseg/boxm2/pro/processes/boxm2_texture_mesh_process.cxx
+++ b/contrib/brl/bseg/boxm2/pro/processes/boxm2_texture_mesh_process.cxx
@@ -297,9 +297,9 @@ void boxm2_texture_mesh_process_globals::boxm2_texture_mesh_from_imgs(std::strin
     }
 
     //create the submesh using the auto ptrs
-    std::auto_ptr<imesh_vertex_array_base> v3(verts3);
-    std::auto_ptr<imesh_face_array_base> f3(flist);
-    imesh_mesh subMesh(v3, f3);
+    vcl_unique_ptr<imesh_vertex_array_base> v3(verts3);
+    vcl_unique_ptr<imesh_face_array_base> f3(flist);
+    imesh_mesh subMesh(vcl_move(v3), vcl_move(f3));
 
     std::cout<<"Setting tex source: "<<apps->first<<std::endl;
     meshes[apps->first] = subMesh;

--- a/contrib/brl/bseg/boxm2/vecf/ocl/tests/test_filter.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/ocl/tests/test_filter.cxx
@@ -3,7 +3,7 @@
 // \author J.L. Mundy
 // \date 10/12/14
 
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/contrib/brl/bseg/boxm2_multi/exe/boxm2_multi_render.cxx
+++ b/contrib/brl/bseg/boxm2_multi/exe/boxm2_multi_render.cxx
@@ -96,7 +96,7 @@ void test_render_expected_images(boxm2_scene_sptr scene,
     }
 
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, out_img);
-    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+    brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q));
     if (S->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                << " no selections\n";

--- a/contrib/brl/bseg/brec/pro/tests/test_brec_create_mog_image_process.cxx
+++ b/contrib/brl/bseg/brec/pro/tests/test_brec_create_mog_image_process.cxx
@@ -113,7 +113,7 @@ static void test_brec_create_mog_image_process()
   good = good && bprb_batch_process_manager::instance()->commit_output(0, id_img1);
   TEST("run create mog image process", good ,true);
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img1);
-  brdb_selection_sptr S_img = DATABASE->select("bbgm_image_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("bbgm_image_sptr_data", vcl_move(Q_img));
   TEST("output image is in db", S_img->size(), 1);
   brdb_value_sptr value_img;
   TEST("output image is in db", S_img->get_value(std::string("value"), value_img), true);

--- a/contrib/brl/bseg/brec/pro/tests/test_brec_update_changes_process.cxx
+++ b/contrib/brl/bseg/brec/pro/tests/test_brec_update_changes_process.cxx
@@ -180,7 +180,7 @@ static void test_brec_update_changes_process()
   TEST("run bvxmGenSyntheticWorldProcess", good ,true);
 
   brdb_query_aptr Q_w = brdb_query_comp_new("id", brdb_query::EQ, id_world);
-  brdb_selection_sptr S_w = DATABASE->select("bvxm_voxel_world_sptr_data", Q_w);
+  brdb_selection_sptr S_w = DATABASE->select("bvxm_voxel_world_sptr_data", vcl_move(Q_w));
   TEST("output world is in db", S_w->size(), 1);
 
   brdb_value_sptr value_w;
@@ -230,7 +230,7 @@ static void test_brec_update_changes_process()
   good = good && bprb_batch_process_manager::instance()->commit_output(0, id_img1);
   TEST("run bvxm detect instance process", good ,true);
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img1);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   TEST("output image is in db", S_img->size(), 1);
   brdb_value_sptr value_img;
   TEST("output image is in db", S_img->get_value(std::string("value"), value_img), true);

--- a/contrib/brl/bseg/bvpl/bvpl_octree/pro/tests/test_bvpl_plane_propagation_process.cxx
+++ b/contrib/brl/bseg/bvpl/bvpl_octree/pro/tests/test_bvpl_plane_propagation_process.cxx
@@ -99,7 +99,7 @@ static void test_bvpl_plane_propagation_process()
 
   // check if the results are in DB
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
-  brdb_selection_sptr S = DATABASE->select("boxm_scene_base_sptr_data", Q);
+  brdb_selection_sptr S = DATABASE->select("boxm_scene_base_sptr_data", vcl_move(Q));
   if (S->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_change_detection_display_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_change_detection_display_process.cxx
@@ -54,7 +54,7 @@ static void test_bvxm_change_detection_display_process()
 
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   if (S_img->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_local_rpc_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_local_rpc_process.cxx
@@ -63,7 +63,7 @@ static void test_bvxm_create_local_rpc_process()
 
   // check if the results are in DB
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id_cam);
-  brdb_selection_sptr S = DATABASE->select("vpgl_camera_double_sptr_data", Q);
+  brdb_selection_sptr S = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q));
   if (S->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_normalized_image_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_normalized_image_process.cxx
@@ -84,7 +84,7 @@ static void test_bvxm_create_normalized_image_process()
   TEST("run bvxm create normalized image process", good ,true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   TEST("output image is in db", S_img->size(), 1);
 
   brdb_value_sptr value_img;

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_synth_lidar_data_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_synth_lidar_data_process.cxx
@@ -36,7 +36,7 @@ static void test_bvxm_create_synth_lidar_data_process()
 
   // check if the results are in DB
   brdb_query_aptr Q_cam = brdb_query_comp_new("id", brdb_query::EQ, id_cam);
-  brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", Q_cam);
+  brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q_cam));
   if (S_cam->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";
@@ -51,7 +51,7 @@ static void test_bvxm_create_synth_lidar_data_process()
   TEST("camera output non-null", non_null, true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   if (S_img->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_voxel_world_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_create_voxel_world_process.cxx
@@ -44,7 +44,7 @@ static void test_bvxm_create_voxel_world_process()
 
   // check if the results are in DB
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id);
-  brdb_selection_sptr S = DATABASE->select("bvxm_voxel_world_sptr_data", Q);
+  brdb_selection_sptr S = DATABASE->select("bvxm_voxel_world_sptr_data", vcl_move(Q));
   if (S->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_illum_index_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_illum_index_process.cxx
@@ -61,7 +61,7 @@ static void test_bvxm_illum_index_process()
     if (good)
     {
       brdb_query_aptr bin_idx_Q = brdb_query_comp_new("id", brdb_query::EQ, id_bin_idx);
-      brdb_selection_sptr bin_idx_S = DATABASE->select("unsigned_data", bin_idx_Q);
+      brdb_selection_sptr bin_idx_S = DATABASE->select("unsigned_data", vcl_move(bin_idx_Q));
       if (bin_idx_S->size()!=1){
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                  << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_normalize_image_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_normalize_image_process.cxx
@@ -312,7 +312,7 @@ static void test_bvxm_normalize_image_process()
   TEST("bprb_batch_process_manager commit_output", good, true);
 
   brdb_query_aptr Q_slab = brdb_query_comp_new("id", brdb_query::EQ, id_slab);
-  brdb_selection_sptr S_slab = DATABASE->select("bvxm_voxel_slab_base_sptr_data", Q_slab);
+  brdb_selection_sptr S_slab = DATABASE->select("bvxm_voxel_slab_base_sptr_data", vcl_move(Q_slab));
   TEST("output slab is in db", S_slab->size(), 1);
 
   brdb_value_sptr value_slab;
@@ -335,7 +335,7 @@ static void test_bvxm_normalize_image_process()
   TEST("bprb_batch_process_manager commit_output", good, true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   TEST("output image is in db", S_img->size(), 1);
 
   brdb_value_sptr value_img;
@@ -351,7 +351,7 @@ static void test_bvxm_normalize_image_process()
 
   // get a
   brdb_query_aptr Q_a = brdb_query_comp_new("id", brdb_query::EQ, id_a);
-  brdb_selection_sptr S_a = DATABASE->select("float_data", Q_a);
+  brdb_selection_sptr S_a = DATABASE->select("float_data", vcl_move(Q_a));
   TEST("output a is in db", S_a->size(), 1);
 
   brdb_value_sptr value_a;
@@ -363,7 +363,7 @@ static void test_bvxm_normalize_image_process()
 
   // get b
   brdb_query_aptr Q_b = brdb_query_comp_new("id", brdb_query::EQ, id_b);
-  brdb_selection_sptr S_b = DATABASE->select("float_data", Q_b);
+  brdb_selection_sptr S_b = DATABASE->select("float_data", vcl_move(Q_b));
   TEST("output b is in db", S_b->size(), 1);
 
   brdb_value_sptr value_b;

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_roi_init_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_roi_init_process.cxx
@@ -78,7 +78,7 @@ static void test_bvxm_roi_init_process()
 
   // check if the results are in DB
   brdb_query_aptr Q_cam = brdb_query_comp_new("id", brdb_query::EQ, id_cam);
-  brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", Q_cam);
+  brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q_cam));
   if (S_cam->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";
@@ -93,7 +93,7 @@ static void test_bvxm_roi_init_process()
   TEST("camera output non-null", non_null ,true);
 
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
   if (S_img->size()!=1){
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_rpc_registration_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_rpc_registration_process.cxx
@@ -154,7 +154,7 @@ static void test_bvxm_rpc_registration_process()
 
     // check if the results are in DB
     brdb_query_aptr Q_cam = brdb_query_comp_new("id", brdb_query::EQ, id_cam);
-    brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", Q_cam);
+    brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q_cam));
     if (S_cam->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
     }
@@ -171,7 +171,7 @@ static void test_bvxm_rpc_registration_process()
     vpgl_camera_double_sptr cam = result_cam->value();
 
     brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
     if (S_img->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                 << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_update_lidar_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_update_lidar_process.cxx
@@ -65,7 +65,7 @@ static void test_bvxm_update_lidar_process()
 
     //retrieve lidar image
     brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_lidar_img);
-    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
 
     if (S_img->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
@@ -94,7 +94,7 @@ static void test_bvxm_update_lidar_process()
 
     //retrieve lidar camera
     brdb_query_aptr Q_cam = brdb_query_comp_new("id", brdb_query::EQ, id_cam);
-    brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", Q_cam);
+    brdb_selection_sptr S_cam = DATABASE->select("vpgl_camera_double_sptr_data", vcl_move(Q_cam));
 
     if (S_cam->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
@@ -188,7 +188,7 @@ static void test_bvxm_update_lidar_process()
 
     //retrieve world
     brdb_query_aptr Q_world = brdb_query_comp_new("id", brdb_query::EQ, id_world);
-    brdb_selection_sptr S_world = DATABASE->select("bvxm_voxel_world_sptr_data", Q_world);
+    brdb_selection_sptr S_world = DATABASE->select("bvxm_voxel_world_sptr_data", vcl_move(Q_world));
     if (S_world->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                << " no selections\n";
@@ -272,7 +272,7 @@ static void test_bvxm_update_lidar_process()
 
     //retrieve prob_map
     brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_prob_map);
-    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+    brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", vcl_move(Q_img));
     if (S_img->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                << " no selections\n";

--- a/contrib/brl/bseg/sdet/sdet_image_mesh.cxx
+++ b/contrib/brl/bseg/sdet/sdet_image_mesh.cxx
@@ -212,8 +212,8 @@ bool sdet_image_mesh::compute_mesh()
     imesh_vertex<3> v3(verts[iv][0], verts[iv][1], height);
     verts3->push_back(v3);
   }
-  std::auto_ptr<imesh_vertex_array_base> v3(verts3);
-  mesh_one.set_vertices(v3);
+  vcl_unique_ptr<imesh_vertex_array_base> v3(verts3);
+  mesh_one.set_vertices(vcl_move(v3));
   //mesh_valid_ = true;
 
   ///////////////////////////////////////////////////////
@@ -241,8 +241,8 @@ bool sdet_image_mesh::compute_mesh()
     imesh_vertex<3> v3(verts2[iv][0], verts2[iv][1], height);
     newVerts->push_back(v3);
   }
-  std::auto_ptr<imesh_vertex_array_base> v3_ptr(newVerts);
-  mesh_.set_vertices(v3_ptr);
+  vcl_unique_ptr<imesh_vertex_array_base> v3_ptr(newVerts);
+  mesh_.set_vertices(vcl_move(v3_ptr));
   mesh_valid_ = true;
 
   return true;

--- a/contrib/mul/clsfy/clsfy_binary_1d_wrapper_builder.cxx
+++ b/contrib/mul/clsfy/clsfy_binary_1d_wrapper_builder.cxx
@@ -28,7 +28,7 @@ clsfy_binary_1d_wrapper_builder::clsfy_binary_1d_wrapper_builder():
 //: Create a new untrained linear classifier with binary output
   clsfy_classifier_base* clsfy_binary_1d_wrapper_builder::new_classifier() const
 {
-  std::auto_ptr<clsfy_classifier_1d> c_1d(builder_1d_->new_classifier());
+  vcl_unique_ptr<clsfy_classifier_1d> c_1d(builder_1d_->new_classifier());
 
   clsfy_binary_1d_wrapper classifier;
   classifier.set_classifier_1d(*c_1d);
@@ -71,7 +71,7 @@ double clsfy_binary_1d_wrapper_builder::build(
 
   clsfy_binary_1d_wrapper &c_wrap = (clsfy_binary_1d_wrapper &) classifier;
 
-  std::auto_ptr<clsfy_classifier_1d> c_1d(builder_1d_->new_classifier());
+  vcl_unique_ptr<clsfy_classifier_1d> c_1d(builder_1d_->new_classifier());
 
   vnl_vector<double> inputs_1d(inputs.size());
   unsigned i=0;
@@ -152,7 +152,7 @@ void clsfy_binary_1d_wrapper_builder::config(std::istream &as)
 
   {
     std::stringstream ss2(props.get_required_property("builder_1d"));
-    std::auto_ptr<clsfy_builder_1d> b_1d =
+    vcl_unique_ptr<clsfy_builder_1d> b_1d =
       clsfy_builder_1d::new_builder(ss2);
   }
 

--- a/contrib/mul/clsfy/clsfy_builder_1d.cxx
+++ b/contrib/mul/clsfy/clsfy_builder_1d.cxx
@@ -50,13 +50,13 @@ void clsfy_builder_1d::config(std::istream &as)
 // parameters for the builder. This function will construct
 // the appropriate clsfy_builder_1d derivative and return that.
 // \throws if the parse fails.
-std::auto_ptr<clsfy_builder_1d> clsfy_builder_1d::new_builder(
+vcl_unique_ptr<clsfy_builder_1d> clsfy_builder_1d::new_builder(
   std::istream &as)
 {
   std::string name;
   as >> name;
 
-  std::auto_ptr<clsfy_builder_1d> ps;
+  vcl_unique_ptr<clsfy_builder_1d> ps;
   try
   {
     ps = mbl_cloneables_factory<clsfy_builder_1d>::get_clone(name);

--- a/contrib/mul/clsfy/clsfy_builder_1d.h
+++ b/contrib/mul/clsfy/clsfy_builder_1d.h
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <vector>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <vbl/vbl_triple.h>
 #include <vsl/vsl_binary_io.h>
@@ -86,7 +86,7 @@ class clsfy_builder_1d
   virtual void config(std::istream &as);
 
   //: Load description from a text stream
-  static std::auto_ptr<clsfy_builder_1d> new_builder(
+  static vcl_unique_ptr<clsfy_builder_1d> new_builder(
     std::istream &as);
 };
 

--- a/contrib/mul/clsfy/clsfy_builder_base.cxx
+++ b/contrib/mul/clsfy/clsfy_builder_base.cxx
@@ -39,13 +39,13 @@ void clsfy_builder_base::config(std::istream &as)
 // parameters for the builder. This function will construct
 // the appropriate clsfy_builder_base derivative and return that.
 // \throws if the parse fails.
-std::auto_ptr<clsfy_builder_base> clsfy_builder_base::new_builder(
+vcl_unique_ptr<clsfy_builder_base> clsfy_builder_base::new_builder(
   std::istream &as)
 {
   std::string name;
   as >> name;
 
-  std::auto_ptr<clsfy_builder_base> ps;
+  vcl_unique_ptr<clsfy_builder_base> ps;
   try
   {
     ps = mbl_cloneables_factory<clsfy_builder_base>::get_clone(name);

--- a/contrib/mul/clsfy/clsfy_builder_base.h
+++ b/contrib/mul/clsfy/clsfy_builder_base.h
@@ -13,7 +13,7 @@
 
 #include <vector>
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <mbl/mbl_data_wrapper.h>
@@ -61,7 +61,7 @@ class clsfy_builder_base
   virtual void b_read(vsl_b_istream& bfs) = 0;
 
   //: Load description from a text stream
-  static std::auto_ptr<clsfy_builder_base> new_builder(
+  static vcl_unique_ptr<clsfy_builder_base> new_builder(
     std::istream &as);
 
   //: Initialise the parameters from a text stream.

--- a/contrib/mul/clsfy/tests/test_binary_1d_wrapper.cxx
+++ b/contrib/mul/clsfy/tests/test_binary_1d_wrapper.cxx
@@ -102,7 +102,7 @@ void test_binary_1d_wrapper()
   clsfy_binary_1d_wrapper_builder b_thresh_builder;
   b_thresh_builder.set_builder_1d(clsfy_binary_threshold_1d_builder());
 
-  std::auto_ptr<clsfy_classifier_base> b_thresh_clsfr(
+  vcl_unique_ptr<clsfy_classifier_base> b_thresh_clsfr(
     b_thresh_builder.new_classifier());
 
   double error1= b_thresh_builder.build(*b_thresh_clsfr,
@@ -166,7 +166,7 @@ void test_binary_1d_wrapper()
 
   std::istringstream ss(
     "clsfy_binary_1d_wrapper_builder { builder_1d: clsfy_binary_threshold_1d_builder }\n" );
-  std::auto_ptr<clsfy_builder_base> builder_configged =
+  vcl_unique_ptr<clsfy_builder_base> builder_configged =
     clsfy_builder_base::new_builder(ss);
 
   std::cout<<"Builder Constructed :\n"

--- a/contrib/mul/clsfy/tests/test_k_nearest_neighbour.cxx
+++ b/contrib/mul/clsfy/tests/test_k_nearest_neighbour.cxx
@@ -253,7 +253,7 @@ void test_k_nearest_neighbour()
     knn_build.set_k(5);
 
     std::istringstream ss("clsfy_knn_builder { k: 5 }\n");
-    std::auto_ptr<clsfy_builder_base> knn_build_conf =
+    vcl_unique_ptr<clsfy_builder_base> knn_build_conf =
       clsfy_builder_base::new_builder(ss);
 
     TEST("Builder config knn", mbl_test_summaries_are_equal(knn_build_conf.get(),

--- a/contrib/mul/mbl/mbl_cloneable_ptr.h
+++ b/contrib/mul/mbl/mbl_cloneable_ptr.h
@@ -15,7 +15,7 @@
 //  suitable polymorphic I/O is invoked.
 //
 // \code
-// std::auto_ptr<T> inst = get_from_some_factory_function();
+// vcl_unique_ptr<T> inst = get_from_some_factory_function();
 // mbl_cloneable_ptr<T> long_term_store;
 // long_term_store = inst.release();
 // \endcode
@@ -132,9 +132,9 @@ void vsl_b_read(vsl_b_istream& bfs, mbl_cloneable_ptr<BaseClass>& p)
 //  When written or read to/from binary streams,
 //  suitable polymorphic I/O is invoked.
 //
-// To take ownership of the contents of a std::auto_ptr<T> use
+// To take ownership of the contents of a vcl_unique_ptr<T> use
 // \code
-// std::auto_ptr<T> inst = get_from_some_factory_function();
+// vcl_unique_ptr<T> inst = get_from_some_factory_function();
 // mbl_cloneable_nzptr<T> long_term_store(inst.release());
 // \endcode
 template <class BaseClass>

--- a/contrib/mul/mbl/mbl_cloneables_factory.h
+++ b/contrib/mul/mbl/mbl_cloneables_factory.h
@@ -8,7 +8,7 @@
 
 #include <iostream>
 #include <map>
-#include <memory>
+#include <vcl_memory.h>
 #include <string>
 #include <sstream>
 #include <vcl_compiler.h>
@@ -40,7 +40,7 @@
 // mbl_cloneables_factory<vimt_image>::add(vimt_image_2d());
 // mbl_cloneables_factory<vimt_image>::add(vimt_image_3d());
 //
-// std::auto_ptr<vimt_image> p = mbl_cloneables_factory<vimt_image>::get_clone("vimt_image_2d()");
+// vcl_unique_ptr<vimt_image> p = mbl_cloneables_factory<vimt_image>::get_clone("vimt_image_2d()");
 // assert(dynamic_cast<vimt_image_2d>(p));
 // \endcode
 
@@ -58,7 +58,7 @@ class mbl_cloneables_factory
   //: Get singleton instance.
   static MAP &objects()
   {
-    static std::auto_ptr<MAP> objects_;
+    static vcl_unique_ptr<MAP> objects_;
     if (objects_.get() == 0)
       objects_.reset(new MAP);
 
@@ -81,7 +81,7 @@ class mbl_cloneables_factory
 
   //: Get a pointer to a new copy of the object identified by name.
   // An exception will be thrown if name does not exist.
-  static std::auto_ptr<BASE > get_clone(const std::string & name)
+  static vcl_unique_ptr<BASE > get_clone(const std::string & name)
   {
     typedef typename MAP::const_iterator IT;
 
@@ -99,9 +99,9 @@ class mbl_cloneables_factory
           ss << ", " << it->first;
       }
       mbl_exception_error(mbl_exception_no_name_in_factory(name, ss.str()));
-      return std::auto_ptr<BASE >();
+      return vcl_unique_ptr<BASE >();
     }
-    return std::auto_ptr<BASE >(found->second->clone());
+    return vcl_unique_ptr<BASE >(found->second->clone());
   }
 };
 

--- a/contrib/mul/mbl/mbl_log.cxx
+++ b/contrib/mul/mbl/mbl_log.cxx
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 #include <fstream>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <algorithm>
 #include <sstream>
@@ -404,10 +404,10 @@ void mbl_logger::mtstop()
 
 mbl_logger_root &mbl_logger::root()
 {
-  static std::auto_ptr<mbl_logger_root> root_;
+  static vcl_unique_ptr<mbl_logger_root> root_;
 
   if (!root_.get())
-    root_ = std::auto_ptr<mbl_logger_root>(new mbl_logger_root());
+    root_ = vcl_unique_ptr<mbl_logger_root>(new mbl_logger_root());
   return *root_;
 }
 

--- a/contrib/mul/mbl/tests/test_cloneables_factory.cxx
+++ b/contrib/mul/mbl/tests/test_cloneables_factory.cxx
@@ -44,17 +44,17 @@ void test_cloneables_factory()
 
   // Check we can get all objects.
   {
-    std::auto_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("mbl_test_cf_A");
+    vcl_unique_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("mbl_test_cf_A");
     TEST("get A == A",dynamic_cast<mbl_test_cf_A*>(p.get())!=VXL_NULLPTR,true);
   }
   {
-    std::auto_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("mbl_test_cf_B");
+    vcl_unique_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("mbl_test_cf_B");
     TEST("get B == B",dynamic_cast<mbl_test_cf_B*>(p.get())!=VXL_NULLPTR,true);
     // Check the tests would fail if there was a problem.
     TEST("get B != A",dynamic_cast<mbl_test_cf_A*>(p.get())==VXL_NULLPTR,true);
   }
   {
-    std::auto_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("wibble");
+    vcl_unique_ptr<mbl_test_cf_base> p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("wibble");
     TEST("get wibble == A",dynamic_cast<mbl_test_cf_A*>(p.get())!=VXL_NULLPTR,true);
   }
 
@@ -62,7 +62,7 @@ void test_cloneables_factory()
 #if VCL_HAS_EXCEPTIONS
   {
     testlib_test_begin("!get foo");
-    std::auto_ptr<mbl_test_cf_base> p;
+    vcl_unique_ptr<mbl_test_cf_base> p;
     bool caught_error = false;
     try { p = mbl_cloneables_factory<mbl_test_cf_base>::get_clone("foo");  }
     catch (const mbl_exception_no_name_in_factory &) { caught_error=true; }

--- a/contrib/mul/mcal/mcal_component_analyzer.cxx
+++ b/contrib/mul/mcal/mcal_component_analyzer.cxx
@@ -82,13 +82,13 @@ std::string  mcal_component_analyzer::is_a() const
 
 
 //: Create a concrete mcal_component_analyzer object, from a text specification.
-std::auto_ptr<mcal_component_analyzer>
+vcl_unique_ptr<mcal_component_analyzer>
   mcal_component_analyzer::create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
 
-  std::auto_ptr<mcal_component_analyzer> mca;
+  vcl_unique_ptr<mcal_component_analyzer> mca;
   try
   {
     mca = mbl_cloneables_factory<mcal_component_analyzer>::get_clone(name);

--- a/contrib/mul/mcal/mcal_component_analyzer.h
+++ b/contrib/mul/mcal/mcal_component_analyzer.h
@@ -6,7 +6,7 @@
 // \brief Base for objects which perform some form of linear component analysis.
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vsl/vsl_fwd.h>
@@ -80,7 +80,7 @@ class mcal_component_analyzer
   virtual void config_from_stream(std::istream &);
 
   //: Create a concrete mcal_component_analyzer object, from a text specification.
-  static std::auto_ptr<mcal_component_analyzer> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<mcal_component_analyzer> create_from_stream(std::istream &is);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/mcal/mcal_general_ca.cxx
+++ b/contrib/mul/mcal/mcal_general_ca.cxx
@@ -414,7 +414,7 @@ void mcal_general_ca::config_from_stream(std::istream & is)
   if (props.find("initial_ca")!=props.end())
   {
     std::istringstream ss(props["initial_ca"]);
-    std::auto_ptr<mcal_component_analyzer> ca;
+    vcl_unique_ptr<mcal_component_analyzer> ca;
     ca=mcal_component_analyzer::create_from_stream(ss);
     initial_ca_ = *ca;
 
@@ -424,7 +424,7 @@ void mcal_general_ca::config_from_stream(std::istream & is)
   if (props.find("basis_cost")!=props.end())
   {
     std::istringstream ss(props["basis_cost"]);
-    std::auto_ptr<mcal_single_basis_cost> bc;
+    vcl_unique_ptr<mcal_single_basis_cost> bc;
     bc=mcal_single_basis_cost::create_from_stream(ss);
     basis_cost_ = *bc;
 

--- a/contrib/mul/mcal/mcal_single_basis_cost.cxx
+++ b/contrib/mul/mcal/mcal_single_basis_cost.cxx
@@ -46,13 +46,13 @@ std::string  mcal_single_basis_cost::is_a() const
 
 
 //: Create a concrete mcal_single_basis_cost object, from a text specification.
-std::auto_ptr<mcal_single_basis_cost>
+vcl_unique_ptr<mcal_single_basis_cost>
   mcal_single_basis_cost::create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
 
-  std::auto_ptr<mcal_single_basis_cost> pvmb;
+  vcl_unique_ptr<mcal_single_basis_cost> pvmb;
   try
   {
     pvmb = mbl_cloneables_factory<mcal_single_basis_cost>::get_clone(name);

--- a/contrib/mul/mcal/mcal_single_basis_cost.h
+++ b/contrib/mul/mcal/mcal_single_basis_cost.h
@@ -6,7 +6,7 @@
 // \brief Base for objects which compute a cost function for one basis direction
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vsl/vsl_fwd.h>
@@ -76,7 +76,7 @@ class mcal_single_basis_cost
   virtual void config_from_stream(std::istream &);
 
   //: Create a concrete mcal_single_basis_cost object, from a text specification.
-  static std::auto_ptr<mcal_single_basis_cost> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<mcal_single_basis_cost> create_from_stream(std::istream &is);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/mcal/tests/test_general_ca.cxx
+++ b/contrib/mul/mcal/tests/test_general_ca.cxx
@@ -146,7 +146,7 @@ void test_general_ca()
           "  basis_cost: mcal_sparse_basis_cost { alpha: 0.1 }\n"
           "}\n");
 
-    std::auto_ptr<mcal_component_analyzer>
+    vcl_unique_ptr<mcal_component_analyzer>
             ca = mcal_component_analyzer::create_from_stream(ss);
 
     TEST("Correct component analyzer",ca->is_a(),"mcal_general_ca");

--- a/contrib/mul/mcal/tests/test_pca.cxx
+++ b/contrib/mul/mcal/tests/test_pca.cxx
@@ -105,7 +105,7 @@ void test_pca()
           "  use_chunks:  true\n"
           "}\n");
 
-    std::auto_ptr<mcal_component_analyzer>
+    vcl_unique_ptr<mcal_component_analyzer>
             ca = mcal_component_analyzer::create_from_stream(ss);
 
     TEST("Correct component analyzer",ca->is_a(),"mcal_pca");

--- a/contrib/mul/mcal/tests/test_trivial_ca.cxx
+++ b/contrib/mul/mcal/tests/test_trivial_ca.cxx
@@ -90,7 +90,7 @@ void test_trivial_ca()
           "{\n"
           "}\n");
 
-    std::auto_ptr<mcal_component_analyzer>
+    vcl_unique_ptr<mcal_component_analyzer>
             ca = mcal_component_analyzer::create_from_stream(ss);
 
     TEST("Correct component analyzer",ca->is_a(),"mcal_trivial_ca");

--- a/contrib/mul/mfpf/mfpf_hog_box_finder_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_hog_box_finder_builder.cxx
@@ -254,7 +254,7 @@ bool mfpf_hog_box_finder_builder::set_from_stream(std::istream &is)
   {
     std::istringstream ss2(props["norm"]);
     mbl_read_props_type dummy_extra_props;
-    std::auto_ptr<mipa_vector_normaliser> norm = mipa_vector_normaliser::new_normaliser_from_stream(ss2, dummy_extra_props);
+    vcl_unique_ptr<mipa_vector_normaliser> norm = mipa_vector_normaliser::new_normaliser_from_stream(ss2, dummy_extra_props);
     normaliser_=norm.release();
     reonfigureNormaliser=true;
 #if 0
@@ -298,7 +298,7 @@ bool mfpf_hog_box_finder_builder::set_from_stream(std::istream &is)
   if (props.find("cost_builder")!=props.end())
   {
     std::istringstream b_ss(props["cost_builder"]);
-    std::auto_ptr<mfpf_vec_cost_builder> bb =
+    vcl_unique_ptr<mfpf_vec_cost_builder> bb =
       mfpf_vec_cost_builder::create_from_stream(b_ss);
     cost_builder_ = bb->clone();
     props.erase("cost_builder");

--- a/contrib/mul/mfpf/mfpf_point_finder_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_point_finder_builder.cxx
@@ -151,12 +151,12 @@ bool mfpf_point_finder_builder::set_from_stream(std::istream &is)
 }
 
 //: Create a concrete object, from a text specification.
-std::auto_ptr<mfpf_point_finder_builder> mfpf_point_finder_builder::
+vcl_unique_ptr<mfpf_point_finder_builder> mfpf_point_finder_builder::
   create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
-  std::auto_ptr<mfpf_point_finder_builder> opt;
+  vcl_unique_ptr<mfpf_point_finder_builder> opt;
   try {
     opt = mbl_cloneables_factory<mfpf_point_finder_builder>::get_clone(name);
   }

--- a/contrib/mul/mfpf/mfpf_point_finder_builder.h
+++ b/contrib/mul/mfpf/mfpf_point_finder_builder.h
@@ -6,7 +6,7 @@
 // \author Tim Cootes
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vimt/vimt_image_2d_of.h>
@@ -143,7 +143,7 @@ class mfpf_point_finder_builder
   virtual void b_read(vsl_b_istream& bfs);
 
   //: Create a concrete object, from a text specification.
-  static std::auto_ptr<mfpf_point_finder_builder> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<mfpf_point_finder_builder> create_from_stream(std::istream &is);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/mfpf/mfpf_profile_pdf_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_profile_pdf_builder.cxx
@@ -150,7 +150,7 @@ bool mfpf_profile_pdf_builder::set_from_stream(std::istream &is)
   if (props.find("pdf_builder")!=props.end())
   {
     std::istringstream b_ss(props["pdf_builder"]);
-    std::auto_ptr<vpdfl_builder_base> bb =
+    vcl_unique_ptr<vpdfl_builder_base> bb =
          vpdfl_builder_base::new_pdf_builder_from_stream(b_ss);
     pdf_builder_ = bb->clone();
     props.erase("pdf_builder");

--- a/contrib/mul/mfpf/mfpf_region_definer.cxx
+++ b/contrib/mul/mfpf/mfpf_region_definer.cxx
@@ -48,12 +48,12 @@ bool mfpf_region_definer::set_from_stream(std::istream &is)
 }
 
 //: Create a concrete object, from a text specification.
-std::auto_ptr<mfpf_region_definer> mfpf_region_definer::
+vcl_unique_ptr<mfpf_region_definer> mfpf_region_definer::
   create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
-  std::auto_ptr<mfpf_region_definer> vcb;
+  vcl_unique_ptr<mfpf_region_definer> vcb;
   try {
     vcb = mbl_cloneables_factory<mfpf_region_definer>::get_clone(name);
   }

--- a/contrib/mul/mfpf/mfpf_region_definer.h
+++ b/contrib/mul/mfpf/mfpf_region_definer.h
@@ -6,7 +6,7 @@
 // \author Tim Cootes
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <mfpf/mfpf_region_form.h>
@@ -97,7 +97,7 @@ class mfpf_region_definer
   virtual void b_read(vsl_b_istream& bfs) =0;
 
   //: Create a concrete object, from a text specification.
-  static std::auto_ptr<mfpf_region_definer> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<mfpf_region_definer> create_from_stream(std::istream &is);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/mfpf/mfpf_region_finder_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_region_finder_builder.cxx
@@ -438,7 +438,7 @@ bool mfpf_region_finder_builder::set_from_stream(std::istream &is)
   if (props.find("cost_builder")!=props.end())
   {
     std::istringstream b_ss(props["cost_builder"]);
-    std::auto_ptr<mfpf_vec_cost_builder> bb =
+    vcl_unique_ptr<mfpf_vec_cost_builder> bb =
          mfpf_vec_cost_builder::create_from_stream(b_ss);
     cost_builder_ = bb->clone();
     props.erase("cost_builder");

--- a/contrib/mul/mfpf/mfpf_region_pdf_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_region_pdf_builder.cxx
@@ -397,7 +397,7 @@ bool mfpf_region_pdf_builder::set_from_stream(std::istream &is)
   if (props.find("pdf_builder")!=props.end())
   {
     std::istringstream b_ss(props["pdf_builder"]);
-    std::auto_ptr<vpdfl_builder_base> bb =
+    vcl_unique_ptr<vpdfl_builder_base> bb =
          vpdfl_builder_base::new_pdf_builder_from_stream(b_ss);
     pdf_builder_ = bb->clone();
     props.erase("pdf_builder");

--- a/contrib/mul/mfpf/mfpf_vec_cost_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_vec_cost_builder.cxx
@@ -49,12 +49,12 @@ bool mfpf_vec_cost_builder::set_from_stream(std::istream &is)
 }
 
 //: Create a concrete object, from a text specification.
-std::auto_ptr<mfpf_vec_cost_builder> mfpf_vec_cost_builder::
+vcl_unique_ptr<mfpf_vec_cost_builder> mfpf_vec_cost_builder::
   create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
-  std::auto_ptr<mfpf_vec_cost_builder> vcb;
+  vcl_unique_ptr<mfpf_vec_cost_builder> vcb;
   try {
     vcb = mbl_cloneables_factory<mfpf_vec_cost_builder>::get_clone(name);
   }

--- a/contrib/mul/mfpf/mfpf_vec_cost_builder.h
+++ b/contrib/mul/mfpf/mfpf_vec_cost_builder.h
@@ -6,7 +6,7 @@
 // \author Tim Cootes
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <mfpf/mfpf_vec_cost.h>
@@ -62,7 +62,7 @@ class mfpf_vec_cost_builder
   virtual void b_read(vsl_b_istream& bfs)=0;
 
   //: Create a concrete object, from a text specification.
-  static std::auto_ptr<mfpf_vec_cost_builder> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<mfpf_vec_cost_builder> create_from_stream(std::istream &is);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/mfpf/tests/test_edge_finder.cxx
+++ b/contrib/mul/mfpf/tests/test_edge_finder.cxx
@@ -104,7 +104,7 @@ void test_edge_finder()
           "  search_ni: 17\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pfb = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Builder",pfb->is_a(),"mfpf_edge_finder_builder");

--- a/contrib/mul/mfpf/tests/test_norm_corr1d.cxx
+++ b/contrib/mul/mfpf/tests/test_norm_corr1d.cxx
@@ -103,7 +103,7 @@ void test_norm_corr1d()
           "  search_ni: 17\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_norm_corr1d_builder");

--- a/contrib/mul/mfpf/tests/test_norm_corr2d.cxx
+++ b/contrib/mul/mfpf/tests/test_norm_corr2d.cxx
@@ -163,7 +163,7 @@ void test_norm_corr2d()
           "  search_nj: 15\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_norm_corr2d_builder");

--- a/contrib/mul/mfpf/tests/test_profile_pdf.cxx
+++ b/contrib/mul/mfpf/tests/test_profile_pdf.cxx
@@ -111,7 +111,7 @@ void test_profile_pdf()
           "  pdf_builder: vpdfl_axis_gaussian_builder { }\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_profile_pdf_builder");

--- a/contrib/mul/mfpf/tests/test_region_finder.cxx
+++ b/contrib/mul/mfpf/tests/test_region_finder.cxx
@@ -138,7 +138,7 @@ void test_region_finder()
           "  cost_builder: mfpf_sad_vec_cost_builder { min_mad: 1.1 }\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_region_finder_builder");
@@ -169,7 +169,7 @@ void test_region_finder()
           "  cost_builder: mfpf_sad_vec_cost_builder { min_mad: 1.2 }\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_region_finder_builder");

--- a/contrib/mul/mfpf/tests/test_region_pdf.cxx
+++ b/contrib/mul/mfpf/tests/test_region_pdf.cxx
@@ -124,7 +124,7 @@ void test_region_pdf()
           "  search_nj: 15\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_region_pdf_builder");
@@ -152,7 +152,7 @@ void test_region_pdf()
           "  step_size: 1.01\n"
           "}\n");
 
-    std::auto_ptr<mfpf_point_finder_builder>
+    vcl_unique_ptr<mfpf_point_finder_builder>
             pf = mfpf_point_finder_builder::create_from_stream(ss);
 
     TEST("Correct Point Finder Builder", pf->is_a(),"mfpf_region_pdf_builder");

--- a/contrib/mul/mfpf/tools/mfpf_build_finder.cxx
+++ b/contrib/mul/mfpf/tools/mfpf_build_finder.cxx
@@ -59,7 +59,7 @@ struct tool_params
   unsigned pt_index;
 
   //: Object to build patch model
-  std::auto_ptr<mfpf_point_finder_builder> patch_builder;
+  vcl_unique_ptr<mfpf_point_finder_builder> patch_builder;
 
   //: Image directory
   std::string image_dir;

--- a/contrib/mul/mipa/mipa_block_normaliser.cxx
+++ b/contrib/mul/mipa/mipa_block_normaliser.cxx
@@ -175,7 +175,7 @@ void mipa_block_normaliser::config_from_stream(
         mbl_exception_error(x);
     }
     std::istringstream ss2(props["normaliser"]);
-    std::auto_ptr<mipa_vector_normaliser> norm = new_normaliser_from_stream(ss2, extra_props);
+    vcl_unique_ptr<mipa_vector_normaliser> norm = new_normaliser_from_stream(ss2, extra_props);
     normaliser_=norm.release();
     props.erase("normaliser");
 

--- a/contrib/mul/mipa/mipa_vector_normaliser.cxx
+++ b/contrib/mul/mipa/mipa_vector_normaliser.cxx
@@ -44,14 +44,14 @@ void mipa_vector_normaliser::config_from_stream(
 
 //=======================================================================
 //: Create a concrete mipa_vector_normaliser-derived object, from a text specification.
-std::auto_ptr<mipa_vector_normaliser>
+vcl_unique_ptr<mipa_vector_normaliser>
   mipa_vector_normaliser::new_normaliser_from_stream(
     std::istream &is, const mbl_read_props_type &extra_props)
 {
   std::string name;
   is >> name;
 
-  std::auto_ptr<mipa_vector_normaliser> ps =
+  vcl_unique_ptr<mipa_vector_normaliser> ps =
     mbl_cloneables_factory<mipa_vector_normaliser>::get_clone(name);
 
   ps -> config_from_stream(is, extra_props);

--- a/contrib/mul/mipa/mipa_vector_normaliser.h
+++ b/contrib/mul/mipa/mipa_vector_normaliser.h
@@ -7,7 +7,7 @@
 // \brief Base class for normalisation algorithms for image feature vectors
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vcl_compiler.h>
@@ -48,7 +48,7 @@ class mipa_vector_normaliser
   virtual void b_read(vsl_b_istream& /*bfs*/) = 0;
 
   //: Create a concrete mipa_vector_normaliser-derived object, from a text specification.
-  static std::auto_ptr<mipa_vector_normaliser> new_normaliser_from_stream(std::istream &is,
+  static vcl_unique_ptr<mipa_vector_normaliser> new_normaliser_from_stream(std::istream &is,
                                                                          const mbl_read_props_type &extra_props);
 
   //: Initialise from a text stream.

--- a/contrib/mul/mipa/tests/test_vector_normalisers.cxx
+++ b/contrib/mul/mipa/tests/test_vector_normalisers.cxx
@@ -65,7 +65,7 @@ static void test_vector_normalisers()
 
     std::istringstream ss(strConfig);
     mbl_read_props_type dummy_extra_props;
-    std::auto_ptr<mipa_vector_normaliser> norm = mipa_vector_normaliser::new_normaliser_from_stream(ss, dummy_extra_props);
+    vcl_unique_ptr<mipa_vector_normaliser> norm = mipa_vector_normaliser::new_normaliser_from_stream(ss, dummy_extra_props);
     TEST("Block normaliser created",norm->is_a()=="mipa_block_normaliser",true);
 
     mipa_vector_normaliser* pNorm = norm->clone();
@@ -262,7 +262,7 @@ static void test_vector_normalisers()
 
         std::istringstream ss(strConfig);
         mbl_read_props_type dummy_extra_props;
-        std::auto_ptr<mipa_vector_normaliser> msnorm = mipa_vector_normaliser::new_normaliser_from_stream(ss, dummy_extra_props);
+        vcl_unique_ptr<mipa_vector_normaliser> msnorm = mipa_vector_normaliser::new_normaliser_from_stream(ss, dummy_extra_props);
         TEST("Block normaliser created",msnorm->is_a()=="mipa_ms_block_normaliser",true);
 
         mipa_vector_normaliser* pNorm = msnorm->clone();

--- a/contrib/mul/mmn/mmn_solver.cxx
+++ b/contrib/mul/mmn/mmn_solver.cxx
@@ -74,12 +74,12 @@ void vsl_add_to_binary_loader(const mmn_solver& b)
 }
 
 //: Create a concrete region_model-derived object, from a text specification.
-std::auto_ptr<mmn_solver> mmn_solver::
+vcl_unique_ptr<mmn_solver> mmn_solver::
   create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
-  std::auto_ptr<mmn_solver> pair_cost;
+  vcl_unique_ptr<mmn_solver> pair_cost;
   try {
     pair_cost = mbl_cloneables_factory<mmn_solver>::get_clone(name);
   }

--- a/contrib/mul/mmn/mmn_solver.h
+++ b/contrib/mul/mmn/mmn_solver.h
@@ -7,7 +7,7 @@
 
 #include <vector>
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <mmn/mmn_arc.h>
@@ -69,7 +69,7 @@ public:
     //: Load class from binary file stream
   virtual void b_read(vsl_b_istream& bfs) =0;
 
-  static std::auto_ptr<mmn_solver>
+  static vcl_unique_ptr<mmn_solver>
     create_from_stream(std::istream &is);
 };
 

--- a/contrib/mul/msm/msm_aligner.cxx
+++ b/contrib/mul/msm/msm_aligner.cxx
@@ -81,12 +81,12 @@ void msm_aligner::config_from_stream(std::istream &is)
 
 //=======================================================================
 //: Create a concrete msm_aligner-derived object, from a text specification.
-std::auto_ptr<msm_aligner> msm_aligner::create_from_stream(std::istream &is)
+vcl_unique_ptr<msm_aligner> msm_aligner::create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
 
-  std::auto_ptr<msm_aligner> ps =
+  vcl_unique_ptr<msm_aligner> ps =
     mbl_cloneables_factory<msm_aligner>::get_clone(name);
 
   ps -> config_from_stream(is);

--- a/contrib/mul/msm/msm_aligner.h
+++ b/contrib/mul/msm/msm_aligner.h
@@ -7,7 +7,7 @@
 // \brief Base for functions which calculate and apply 2D transformations
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vcl_compiler.h>
@@ -132,7 +132,7 @@ class msm_aligner
   virtual void b_read(vsl_b_istream& bfs);
 
   //: Create a concrete msm_aligner-derived object, from a text specification.
-  static std::auto_ptr<msm_aligner> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<msm_aligner> create_from_stream(std::istream &is);
 
   //: Initialise from a text stream.
   // The default implementation is for attribute-less normalisers,

--- a/contrib/mul/msm/msm_param_limiter.cxx
+++ b/contrib/mul/msm/msm_param_limiter.cxx
@@ -44,12 +44,12 @@ void msm_param_limiter::config_from_stream(std::istream &is)
 
 //=======================================================================
 //: Create a concrete msm_param_limiter-derived object, from a text specification.
-std::auto_ptr<msm_param_limiter> msm_param_limiter::create_from_stream(std::istream &is)
+vcl_unique_ptr<msm_param_limiter> msm_param_limiter::create_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
 
-  std::auto_ptr<msm_param_limiter> ps =
+  vcl_unique_ptr<msm_param_limiter> ps =
     mbl_cloneables_factory<msm_param_limiter>::get_clone(name);
 
   ps -> config_from_stream(is);

--- a/contrib/mul/msm/msm_param_limiter.h
+++ b/contrib/mul/msm/msm_param_limiter.h
@@ -6,7 +6,7 @@
 // \brief Base for objects with apply limits to parameters
 
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vcl_compiler.h>
@@ -51,7 +51,7 @@ class msm_param_limiter
   virtual void b_read(vsl_b_istream& bfs) = 0;
 
   //: Create a concrete msm_param_limiter-derived object, from a text specification.
-  static std::auto_ptr<msm_param_limiter> create_from_stream(std::istream &is);
+  static vcl_unique_ptr<msm_param_limiter> create_from_stream(std::istream &is);
 
   //: Initialise from a text stream.
   // The default implementation is for attribute-less normalisers,

--- a/contrib/mul/msm/msm_shape_model_builder.cxx
+++ b/contrib/mul/msm/msm_shape_model_builder.cxx
@@ -383,7 +383,7 @@ void msm_shape_model_builder::config_from_stream(std::istream &is)
 
   std::string aligner_str = props.get_required_property("aligner");
   std::stringstream aligner_ss(aligner_str);
-  std::auto_ptr<msm_aligner> aligner=msm_aligner::create_from_stream(aligner_ss);
+  vcl_unique_ptr<msm_aligner> aligner=msm_aligner::create_from_stream(aligner_ss);
   aligner_=aligner->clone();
 
   std::string param_limiter_str
@@ -393,7 +393,7 @@ void msm_shape_model_builder::config_from_stream(std::istream &is)
   {
     std::stringstream ss(param_limiter_str);
 
-    std::auto_ptr<msm_param_limiter> param_limiter;
+    vcl_unique_ptr<msm_param_limiter> param_limiter;
     param_limiter = msm_param_limiter::create_from_stream(ss);
     param_limiter_ = param_limiter->clone();
   }

--- a/contrib/mul/msm/tools/msm_build_shape_model.cxx
+++ b/contrib/mul/msm/tools/msm_build_shape_model.cxx
@@ -93,12 +93,12 @@ void print_usage()
 struct tool_params
 {
   //: Aligner for shape model
-  std::auto_ptr<msm_aligner> aligner;
+  vcl_unique_ptr<msm_aligner> aligner;
 
   msm_aligner::ref_pose_source ref_pose_source;
 
   //: Object to apply limits to parameters
-  std::auto_ptr<msm_param_limiter> limiter;
+  vcl_unique_ptr<msm_param_limiter> limiter;
 
   //: Maximum number of shape modes
   unsigned max_modes;

--- a/contrib/mul/msm/tools/msm_compare_markups.cxx
+++ b/contrib/mul/msm/tools/msm_compare_markups.cxx
@@ -70,7 +70,7 @@ void print_usage()
 struct tool_params
 {
   //: Aligner for shape model
-  vcl_auto_ptr<msm_aligner> aligner;
+  vcl_unique_ptr<msm_aligner> aligner;
   
   //: Radius of points to display 
   double point_radius;

--- a/contrib/mul/msm/tools/msm_estimate_residuals.cxx
+++ b/contrib/mul/msm/tools/msm_estimate_residuals.cxx
@@ -70,10 +70,10 @@ void print_usage()
 struct tool_params
 {
   //: Aligner for shape model
-  std::auto_ptr<msm_aligner> aligner;
+  vcl_unique_ptr<msm_aligner> aligner;
 
   //: Object to apply limits to parameters
-  std::auto_ptr<msm_param_limiter> limiter;
+  vcl_unique_ptr<msm_param_limiter> limiter;
 
   //: Maximum number of shape modes
   unsigned max_modes;

--- a/contrib/mul/msm/tools/msm_plot_aligned_shapes.cxx
+++ b/contrib/mul/msm/tools/msm_plot_aligned_shapes.cxx
@@ -64,7 +64,7 @@ void print_usage()
 struct tool_params
 {
   //: Aligner for shape model
-  std::auto_ptr<msm_aligner> aligner;
+  vcl_unique_ptr<msm_aligner> aligner;
 
   std::string curves_path;
 

--- a/contrib/mul/vimt3d/vimt3d_vil3d_v3i.cxx
+++ b/contrib/mul/vimt3d/vimt3d_vil3d_v3i.cxx
@@ -37,7 +37,7 @@ unsigned vimt3d_vil3d_v3i_format::magic_number()
 
 vil3d_image_resource_sptr vimt3d_vil3d_v3i_format::make_input_image(const char *filename) const
 {
-  std::auto_ptr<std::fstream> file(new std::fstream(filename, std::ios::in | std::ios::binary ));
+  vcl_unique_ptr<std::fstream> file(new std::fstream(filename, std::ios::in | std::ios::binary ));
   if (!file.get() || !file->is_open())
     return VXL_NULLPTR;
 
@@ -49,7 +49,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3i_format::make_input_image(const char *
     vsl_b_read(is, magic);
     if (magic != vimt3d_vil3d_v3i_format::magic_number()) return VXL_NULLPTR;
   }
-  return new vimt3d_vil3d_v3i_image(file);
+  return new vimt3d_vil3d_v3i_image(vcl_move(file));
 }
 
 
@@ -72,7 +72,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3i_format::make_output_image
     return VXL_NULLPTR;
   }
 
-  std::auto_ptr<std::fstream> of(
+  vcl_unique_ptr<std::fstream> of(
     new std::fstream(filename, std::ios::out | std::ios::binary | std::ios::trunc) );
   if (!of.get() || !of->is_open())
   {
@@ -81,7 +81,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3i_format::make_output_image
     return VXL_NULLPTR;
   }
 
-  return new vimt3d_vil3d_v3i_image(of, ni, nj, nk, nplanes, format);
+  return new vimt3d_vil3d_v3i_image(vcl_move(of), ni, nj, nk, nplanes, format);
 }
 
 
@@ -226,7 +226,7 @@ void vimt3d_vil3d_v3i_image::load_full_image() const
 
 //: Private constructor, use vil3d_load instead.
 // This object takes ownership of the file, for reading.
-vimt3d_vil3d_v3i_image::vimt3d_vil3d_v3i_image(std::auto_ptr<std::fstream> file):
+vimt3d_vil3d_v3i_image::vimt3d_vil3d_v3i_image(vcl_unique_ptr<std::fstream> file):
   file_(file.release()), im_(VXL_NULLPTR), dirty_(false)
 {
   file_->seekg(0);
@@ -426,7 +426,7 @@ vimt3d_vil3d_v3i_image::vimt3d_vil3d_v3i_image(std::auto_ptr<std::fstream> file)
 
 //: Private constructor, use vil3d_save instead.
 // This object takes ownership of the file, for writing.
-vimt3d_vil3d_v3i_image::vimt3d_vil3d_v3i_image(std::auto_ptr<std::fstream> file, unsigned ni,
+vimt3d_vil3d_v3i_image::vimt3d_vil3d_v3i_image(vcl_unique_ptr<std::fstream> file, unsigned ni,
                                                unsigned nj, unsigned nk,
                                                unsigned nplanes,
                                                vil_pixel_format format):

--- a/contrib/mul/vimt3d/vimt3d_vil3d_v3i.h
+++ b/contrib/mul/vimt3d/vimt3d_vil3d_v3i.h
@@ -27,7 +27,7 @@
 
 #include <iostream>
 #include <iosfwd>
-#include <memory>
+#include <vcl_memory.h>
 #include <vil3d/vil3d_file_format.h>
 #include <vimt3d/vimt3d_image_3d.h>
 #include <vcl_compiler.h>
@@ -88,10 +88,10 @@ class vimt3d_vil3d_v3i_image: public vil3d_image_resource
 
   //: Private constructor, use vil3d_load instead.
   // This object takes ownership of the image.
-  vimt3d_vil3d_v3i_image(std::auto_ptr<std::fstream> im);
+  vimt3d_vil3d_v3i_image(vcl_unique_ptr<std::fstream> im);
   //: Private constructor, use vil3d_save instead.
   // This object takes ownership of the file, for writing.
-  vimt3d_vil3d_v3i_image(std::auto_ptr<std::fstream> file, unsigned ni, unsigned nj,
+  vimt3d_vil3d_v3i_image(vcl_unique_ptr<std::fstream> file, unsigned ni, unsigned nj,
                          unsigned nk, unsigned nplanes, vil_pixel_format format);
 
   //: Storage type for header information when the whole image has not yet been loaded.

--- a/contrib/mul/vimt3d/vimt3d_vil3d_v3m.cxx
+++ b/contrib/mul/vimt3d/vimt3d_vil3d_v3m.cxx
@@ -35,7 +35,7 @@ unsigned vimt3d_vil3d_v3m_format::magic_number()
 
 vil3d_image_resource_sptr vimt3d_vil3d_v3m_format::make_input_image(const char *filename) const
 {
-  std::auto_ptr<std::fstream> file(new std::fstream(filename, std::ios::in | std::ios::binary ));
+  vcl_unique_ptr<std::fstream> file(new std::fstream(filename, std::ios::in | std::ios::binary ));
   if (!file.get() || !file->is_open())
     return VXL_NULLPTR;
 
@@ -47,7 +47,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3m_format::make_input_image(const char *
     vsl_b_read(is, magic);
     if (magic != vimt3d_vil3d_v3m_format::magic_number()) return VXL_NULLPTR;
   }
-  return new vimt3d_vil3d_v3m_image(file);
+  return new vimt3d_vil3d_v3m_image(vcl_move(file));
 }
 
 
@@ -70,7 +70,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3m_format::make_output_image
     return VXL_NULLPTR;
   }
 
-  std::auto_ptr<std::fstream> of(
+  vcl_unique_ptr<std::fstream> of(
     new std::fstream(filename, std::ios::out | std::ios::binary | std::ios::trunc) );
   if (!of.get() || !of->is_open())
   {
@@ -79,7 +79,7 @@ vil3d_image_resource_sptr vimt3d_vil3d_v3m_format::make_output_image
     return VXL_NULLPTR;
   }
 
-  return new vimt3d_vil3d_v3m_image(of, ni, nj, nk, nplanes, format);
+  return new vimt3d_vil3d_v3m_image(vcl_move(of), ni, nj, nk, nplanes, format);
 }
 
 
@@ -212,7 +212,7 @@ macro(VIL_PIXEL_FORMAT_DOUBLE , double )
 
 //: Private constructor, use vil3d_load instead.
 // This object takes ownership of the file, for reading.
-vimt3d_vil3d_v3m_image::vimt3d_vil3d_v3m_image(std::auto_ptr<std::fstream> file):
+vimt3d_vil3d_v3m_image::vimt3d_vil3d_v3m_image(vcl_unique_ptr<std::fstream> file):
   file_(file.release()), im_(VXL_NULLPTR), dirty_(false)
 {
   file_->seekg(0);
@@ -263,7 +263,7 @@ vimt3d_vil3d_v3m_image::vimt3d_vil3d_v3m_image(std::auto_ptr<std::fstream> file)
 
 //: Private constructor, use vil3d_save instead.
 // This object takes ownership of the file, for writing.
-vimt3d_vil3d_v3m_image::vimt3d_vil3d_v3m_image(std::auto_ptr<std::fstream> file, unsigned ni,
+vimt3d_vil3d_v3m_image::vimt3d_vil3d_v3m_image(vcl_unique_ptr<std::fstream> file, unsigned ni,
                                                unsigned nj, unsigned nk,
                                                unsigned nplanes,
                                                vil_pixel_format format):

--- a/contrib/mul/vimt3d/vimt3d_vil3d_v3m.h
+++ b/contrib/mul/vimt3d/vimt3d_vil3d_v3m.h
@@ -30,7 +30,7 @@
 
 #include <iostream>
 #include <iosfwd>
-#include <memory>
+#include <vcl_memory.h>
 #include <vil3d/vil3d_file_format.h>
 #include <vimt3d/vimt3d_image_3d.h>
 #include <vcl_compiler.h>
@@ -91,10 +91,10 @@ class vimt3d_vil3d_v3m_image: public vil3d_image_resource
 
   //: Private constructor, use vil3d_load instead.
   // This object takes ownership of the image.
-  vimt3d_vil3d_v3m_image(std::auto_ptr<std::fstream> im);
+  vimt3d_vil3d_v3m_image(vcl_unique_ptr<std::fstream> im);
   //: Private constructor, use vil3d_save instead.
   // This object takes ownership of the file, for writing.
-  vimt3d_vil3d_v3m_image(std::auto_ptr<std::fstream> file, unsigned ni, unsigned nj,
+  vimt3d_vil3d_v3m_image(vcl_unique_ptr<std::fstream> file, unsigned ni, unsigned nj,
                          unsigned nk, unsigned nplanes, vil_pixel_format format);
 
   //: Storage type for header information when the whole image has not yet been loaded.

--- a/contrib/mul/vpdfl/tests/test_axis_gaussian.cxx
+++ b/contrib/mul/vpdfl/tests/test_axis_gaussian.cxx
@@ -196,7 +196,7 @@ void test_axis_gaussian()
           "  min_var: 0.1234e-5\n"
           "}\n");
 
-    std::auto_ptr<vpdfl_builder_base>
+    vcl_unique_ptr<vpdfl_builder_base>
             builder = vpdfl_builder_base::new_pdf_builder_from_stream(ss);
 
     TEST("Correct builder",builder->is_a(),"vpdfl_axis_gaussian_builder");

--- a/contrib/mul/vpdfl/tests/test_gaussian.cxx
+++ b/contrib/mul/vpdfl/tests/test_gaussian.cxx
@@ -256,7 +256,7 @@ void test_gaussian()
           "  min_var: 0.1234e-5\n"
           "}\n");
 
-    std::auto_ptr<vpdfl_builder_base>
+    vcl_unique_ptr<vpdfl_builder_base>
             builder = vpdfl_builder_base::new_pdf_builder_from_stream(ss);
 
     TEST("Correct builder",builder->is_a(),"vpdfl_gaussian_builder");

--- a/contrib/mul/vpdfl/tests/test_mixture.cxx
+++ b/contrib/mul/vpdfl/tests/test_mixture.cxx
@@ -248,7 +248,7 @@ void test_mixture()
           "  max_its: 7\n"
           "}\n");
 
-    std::auto_ptr<vpdfl_builder_base>
+    vcl_unique_ptr<vpdfl_builder_base>
             builder = vpdfl_builder_base::new_pdf_builder_from_stream(ss);
 
     TEST("Correct builder",builder->is_a(),"vpdfl_mixture_builder");

--- a/contrib/mul/vpdfl/vpdfl_builder_base.cxx
+++ b/contrib/mul/vpdfl/vpdfl_builder_base.cxx
@@ -52,28 +52,28 @@ bool vpdfl_builder_base::is_class(std::string const& s) const
 
 //: Create a vpdfl_builder_base object given a config stream
 // \throw vcl_runtime_exception if parse error.
-std::auto_ptr<vpdfl_builder_base> vpdfl_builder_base::new_builder_from_stream(std::istream &is)
+vcl_unique_ptr<vpdfl_builder_base> vpdfl_builder_base::new_builder_from_stream(std::istream &is)
 {
   // This function should really be replaced by a general loader scheme
   // Ask Ian for examples from Manchester's private code base.
 
   //: This will store the constructed builder.
-  std::auto_ptr<vpdfl_builder_base> builder;
+  vcl_unique_ptr<vpdfl_builder_base> builder;
 
   std::string type;
   is >> type;
 
   if (type == "vpdfl_axis_gaussian_builder")
   {
-    builder = std::auto_ptr<vpdfl_builder_base>(new vpdfl_axis_gaussian_builder());
+    builder = vcl_unique_ptr<vpdfl_builder_base>(new vpdfl_axis_gaussian_builder());
   }
   else if (type == "vpdfl_gaussian_kernel_pdf_builder")
   {
-    builder = std::auto_ptr<vpdfl_builder_base>(new vpdfl_gaussian_kernel_pdf_builder());
+    builder = vcl_unique_ptr<vpdfl_builder_base>(new vpdfl_gaussian_kernel_pdf_builder());
   }
   else if (type == "vpdfl_gaussian_builder")
   {
-    builder = std::auto_ptr<vpdfl_builder_base>(new vpdfl_gaussian_builder());
+    builder = vcl_unique_ptr<vpdfl_builder_base>(new vpdfl_gaussian_builder());
   }
   else
     mbl_exception_error(mbl_exception_no_name_in_factory(type,
@@ -141,12 +141,12 @@ std::ostream& operator<<(std::ostream& os,const vpdfl_builder_base* b)
 //=======================================================================
 //: Create a vpdfl_builder_base object given a config stream (recursive style)
 //  Creates object, then uses config_from_stream(is) to set up internals
-std::auto_ptr<vpdfl_builder_base> vpdfl_builder_base::
+vcl_unique_ptr<vpdfl_builder_base> vpdfl_builder_base::
   new_pdf_builder_from_stream(std::istream &is)
 {
   std::string name;
   is >> name;
-  std::auto_ptr<vpdfl_builder_base> builder;
+  vcl_unique_ptr<vpdfl_builder_base> builder;
   try
   {
     builder = mbl_cloneables_factory<vpdfl_builder_base>::get_clone(name);

--- a/contrib/mul/vpdfl/vpdfl_builder_base.h
+++ b/contrib/mul/vpdfl/vpdfl_builder_base.h
@@ -13,7 +13,7 @@
 
 #include <vector>
 #include <string>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vnl/vnl_vector.h>
@@ -88,7 +88,7 @@ class vpdfl_builder_base
 
   //: Create a vpdfl_builder_base object given a config stream
   // \throw mbl_exception if parse error.
-  static std::auto_ptr<vpdfl_builder_base> new_builder_from_stream(std::istream &is);
+  static vcl_unique_ptr<vpdfl_builder_base> new_builder_from_stream(std::istream &is);
 
   //: Read initialisation settings from a stream.
   // \throw mbl_exception_parse_error if the parse fails.
@@ -97,7 +97,7 @@ class vpdfl_builder_base
   //: Create a vpdfl_builder_base object given a config stream (recursive style)
   //  Creates object, then uses config_from_stream(is) to set up internals
   // \throw vcl_runtime_exception if parse error.
-  static std::auto_ptr<vpdfl_builder_base> new_pdf_builder_from_stream(std::istream &);
+  static vcl_unique_ptr<vpdfl_builder_base> new_pdf_builder_from_stream(std::istream &);
 };
 
 //: Allows derived class to be loaded by base-class pointer

--- a/contrib/mul/vpdfl/vpdfl_mixture_builder.cxx
+++ b/contrib/mul/vpdfl/vpdfl_mixture_builder.cxx
@@ -678,7 +678,7 @@ void vpdfl_mixture_builder::config_from_stream(std::istream & is)
   if (props.find("basis_pdf")!=props.end())
   {
     std::istringstream pdf_ss(props["basis_pdf"]);
-    std::auto_ptr<vpdfl_builder_base>
+    vcl_unique_ptr<vpdfl_builder_base>
             b = vpdfl_builder_base::new_pdf_builder_from_stream(pdf_ss);
     init(*b,n_pdfs);
     props.erase("basis_pdf");

--- a/contrib/oxl/mvl/ComputeGRIC.cxx
+++ b/contrib/oxl/mvl/ComputeGRIC.cxx
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <cmath>
-#include <memory>
 #include "ComputeGRIC.h"
 #include <mvl/FMatrixComputeMLESAC.h>
 #include <mvl/HMatrix2DComputeMLESAC.h>
@@ -20,7 +19,7 @@ bool ComputeGRIC::compute(PairMatchSetCorner* matches) {
 
   // Compute the two differing relations using MLE
   F_.reset(new FMatrix);
-  std::auto_ptr<FMatrixComputeRobust> computor1(new FMatrixComputeMLESAC(true, std_));
+  vcl_unique_ptr<FMatrixComputeRobust> computor1(new FMatrixComputeMLESAC(true, std_));
   computor1->compute(matches_copy1, F_.get());
   residualsF_ = computor1->get_residuals();
   inliersF_ = computor1->get_inliers();
@@ -28,7 +27,7 @@ bool ComputeGRIC::compute(PairMatchSetCorner* matches) {
   computor1.reset();
 
   H_.reset(new HMatrix2D);
-  std::auto_ptr<HMatrix2DComputeRobust> computor2(new HMatrix2DComputeMLESAC(std_));
+  vcl_unique_ptr<HMatrix2DComputeRobust> computor2(new HMatrix2DComputeMLESAC(std_));
   computor2->compute(matches_copy2, H_.get());
   residualsH_ = computor2->get_residuals();
   inliersH_ = computor2->get_inliers();

--- a/contrib/oxl/mvl/ComputeGRIC.h
+++ b/contrib/oxl/mvl/ComputeGRIC.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <mvl/PairMatchSetCorner.h>
 #include <mvl/FMatrix.h>
 #include <mvl/HMatrix2D.h>
@@ -37,8 +37,8 @@ class ComputeGRIC
 
  protected:
   double std_;
-  std::auto_ptr<FMatrix> F_;
-  std::auto_ptr<HMatrix2D> H_;
+  vcl_unique_ptr<FMatrix> F_;
+  vcl_unique_ptr<HMatrix2D> H_;
   std::vector<double> residualsF_;
   std::vector<double> residualsH_;
   std::vector<bool> inliersF_;

--- a/contrib/rpl/rgrl/examples/match_2d.cxx
+++ b/contrib/rpl/rgrl/examples/match_2d.cxx
@@ -370,8 +370,8 @@ main( int argc, char* argv[] )
   //
   rgrl_weighter_sptr wgter;
   {
-    std::auto_ptr< rrel_m_est_obj > m_est_obj( new rrel_tukey_obj(4) );
-    wgter = new rgrl_weighter_m_est( m_est_obj, true, true) ;
+    vcl_unique_ptr< rrel_m_est_obj > m_est_obj( new rrel_tukey_obj(4) );
+    wgter = new rgrl_weighter_m_est( vcl_move(m_est_obj), true, true) ;
   }
 
   // 5. Scale estimator
@@ -382,8 +382,8 @@ main( int argc, char* argv[] )
   rgrl_scale_estimator_wgted_sptr wgted_scale_est;
   {
     // muse and unwgted_scale_est are not used
-    std::auto_ptr<rrel_objective> obj( new rrel_muset_obj( 1 ) );
-    unwgted_scale_est = new rgrl_scale_est_closest( obj );
+    vcl_unique_ptr<rrel_objective> obj( new rrel_muset_obj( 1 ) );
+    unwgted_scale_est = new rgrl_scale_est_closest( vcl_move(obj) );
     wgted_scale_est = new rgrl_scale_est_all_weights( );
   }
 

--- a/contrib/rpl/rgrl/examples/match_2d_multi.cxx
+++ b/contrib/rpl/rgrl/examples/match_2d_multi.cxx
@@ -366,8 +366,8 @@ main( int argc, char* argv[] )
   //
   rgrl_weighter_sptr wgter;
   {
-    std::auto_ptr< rrel_m_est_obj > m_est_obj( new rrel_cauchy_obj(4) );
-    wgter = new rgrl_weighter_m_est( m_est_obj, true, true) ;
+    vcl_unique_ptr< rrel_m_est_obj > m_est_obj( new rrel_cauchy_obj(4) );
+    wgter = new rgrl_weighter_m_est( vcl_move(m_est_obj), true, true) ;
   }
 
   // 3. Scale estimator
@@ -378,8 +378,8 @@ main( int argc, char* argv[] )
   rgrl_scale_estimator_wgted_sptr wgted_scale_est;
   {
     // muse and unwgted_scale_est are not used
-    std::auto_ptr<rrel_objective> obj( new rrel_muset_obj( 1 ) );
-    unwgted_scale_est = new rgrl_scale_est_closest( obj );
+    vcl_unique_ptr<rrel_objective> obj( new rrel_muset_obj( 1 ) );
+    unwgted_scale_est = new rgrl_scale_est_closest( vcl_move(obj) );
     wgted_scale_est = new rgrl_scale_est_all_weights( );
     wgted_scale_est->set_debug_flag( 1 );
   }

--- a/contrib/rpl/rgrl/examples/registration_landmark.cxx
+++ b/contrib/rpl/rgrl/examples/registration_landmark.cxx
@@ -244,9 +244,9 @@ main( int argc, char* argv[] )
 
   rgrl_estimator_sptr affine_estimator = new rgrl_est_affine(dim);
 
-  std::auto_ptr<rrel_objective> obj_fun( new rrel_lms_obj(1) );
+  vcl_unique_ptr<rrel_objective> obj_fun( new rrel_lms_obj(1) );
   rgrl_scale_estimator_unwgted_sptr unwgted_scale_est =
-    new rgrl_scale_est_closest( obj_fun );
+    new rgrl_scale_est_closest( vcl_move(obj_fun) );
 
   rgrl_initializer_ran_sam* ran_sam = new rgrl_initializer_ran_sam();
   ran_sam->set_data(pruned_match_set,
@@ -272,10 +272,10 @@ main( int argc, char* argv[] )
   // \code{rgrl\_weighter\_m\_est}. Make sure
   // \code{signature\_precomputed} is allowed.
   //
-  std::auto_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
+  vcl_unique_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
   bool use_signature_error = false;
   bool signature_precomputed = true;
-  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(m_est_obj,
+  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(vcl_move(m_est_obj),
                                                      use_signature_error,
                                                      signature_precomputed);
 

--- a/contrib/rpl/rgrl/examples/registration_range_data.cxx
+++ b/contrib/rpl/rgrl/examples/registration_range_data.cxx
@@ -224,18 +224,18 @@ main( int argc, char* argv[] )
 
   //Weighter
   //
-  std::auto_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
-  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(m_est_obj, false, false);
+  vcl_unique_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
+  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(vcl_move(m_est_obj), false, false);
 
   //Scale estimator
   //
   int max_set_size = 1000;  //maximum expected number of features
-  std::auto_ptr<rrel_objective> muset_obj( new rrel_muset_obj( max_set_size , false) );
+  vcl_unique_ptr<rrel_objective> muset_obj( new rrel_muset_obj( max_set_size , false) );
 
   rgrl_scale_estimator_unwgted_sptr unwgted_scale_est;
   rgrl_scale_estimator_wgted_sptr wgted_scale_est;
 
-  unwgted_scale_est = new rgrl_scale_est_closest( muset_obj );
+  unwgted_scale_est = new rgrl_scale_est_closest( vcl_move(muset_obj));
   wgted_scale_est = new rgrl_scale_est_all_weights();
 
   //convergence tester

--- a/contrib/rpl/rgrl/examples/registration_simple_shapes_outliers.cxx
+++ b/contrib/rpl/rgrl/examples/registration_simple_shapes_outliers.cxx
@@ -248,8 +248,8 @@ main()
   // \endlatexonly
 
   // BeginCodeSnippet
-  std::auto_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
-  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(m_est_obj, false, false);
+  vcl_unique_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
+  rgrl_weighter_sptr wgter = new rgrl_weighter_m_est(vcl_move(m_est_obj), false, false);
   // EndCodeSnippet
 
   // \latexonly
@@ -291,10 +291,10 @@ main()
   // \endlatexonly
 
   // BeginCodeSnippet
-  std::auto_ptr<rrel_objective> muset_obj( new rrel_muset_obj(0, false) );
+  vcl_unique_ptr<rrel_objective> muset_obj( new rrel_muset_obj(0, false) );
 
   rgrl_scale_estimator_unwgted_sptr unwgted_scale_est =
-    new rgrl_scale_est_closest( muset_obj );
+    new rgrl_scale_est_closest( vcl_move(muset_obj) );
   rgrl_scale_estimator_wgted_sptr wgted_scale_est =
     new rgrl_scale_est_all_weights();
   // EndCodeSnippet

--- a/contrib/rpl/rgrl/rgrl_data_manager.cxx
+++ b/contrib/rpl/rgrl/rgrl_data_manager.cxx
@@ -259,15 +259,15 @@ generate_defaults(  rgrl_matcher_sptr                  &matcher,
   //
   // weighter:
   if ( !weighter ) {
-    std::auto_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
-    weighter = new rgrl_weighter_m_est(m_est_obj, false, false);
+    vcl_unique_ptr<rrel_m_est_obj>  m_est_obj( new rrel_tukey_obj(4) );
+    weighter = new rgrl_weighter_m_est(vcl_move(m_est_obj), false, false);
     DebugMacro( 1, "Default weighter set to rgrl_weighter_m_est\n");
   }
 
   // unweighted scale estimator:
   if ( !unwgted_scale_est ) {
-    std::auto_ptr<rrel_objective> lms_obj( new rrel_lms_obj(1) );
-    unwgted_scale_est = new rgrl_scale_est_closest( lms_obj );
+    vcl_unique_ptr<rrel_objective> lms_obj( new rrel_lms_obj(1) );
+    unwgted_scale_est = new rgrl_scale_est_closest( vcl_move(lms_obj) );
     DebugMacro( 1, "Default unwgted scale estimator set to rgrl_scale_est_closest\n");
   }
 }

--- a/contrib/rpl/rgrl/rgrl_feature_set_bins.h
+++ b/contrib/rpl/rgrl/rgrl_feature_set_bins.h
@@ -12,7 +12,7 @@
 // \endverbatim
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <rsdl/rsdl_fwd.h>
 #include <rgrl/rgrl_feature_set.h>
 #include <rgrl/rgrl_mask.h>
@@ -103,7 +103,7 @@ class rgrl_feature_set_bins
   rgrl_mask_box bounding_box_;
 
   // Using bins as the data structure
-  std::auto_ptr< bin_type > bins_;
+  vcl_unique_ptr< bin_type > bins_;
 
   // Using kd_tree as the data structure
   //feature_vector features_;

--- a/contrib/rpl/rgrl/rgrl_feature_set_bins_2d.h
+++ b/contrib/rpl/rgrl/rgrl_feature_set_bins_2d.h
@@ -12,7 +12,7 @@
 // \endverbatim
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <rsdl/rsdl_bins_2d.h>
 
 #include "rgrl_feature.h"
@@ -86,7 +86,7 @@ class rgrl_feature_set_bins_2d
   rgrl_mask_box bounding_box_;
 
   // Using bins as the data structure
-  std::auto_ptr< bin2d_type > bins_2d_;
+  vcl_unique_ptr< bin2d_type > bins_2d_;
   // bool use_bins_;
 
 };

--- a/contrib/rpl/rgrl/rgrl_feature_set_location.h
+++ b/contrib/rpl/rgrl/rgrl_feature_set_location.h
@@ -13,7 +13,7 @@
 
 class rsdl_kd_tree;
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vbl/vbl_smart_ptr.h>
 typedef vbl_smart_ptr<rsdl_kd_tree> rsdl_kd_tree_sptr;
 #include <rsdl/rsdl_point.h>

--- a/contrib/rpl/rgrl/rgrl_scale_est_closest.cxx
+++ b/contrib/rpl/rgrl/rgrl_scale_est_closest.cxx
@@ -16,10 +16,10 @@
 #include <vcl_cassert.h>
 
 rgrl_scale_est_closest::
-rgrl_scale_est_closest( std::auto_ptr<rrel_objective>  obj,
+rgrl_scale_est_closest( vcl_unique_ptr<rrel_objective>  obj,
                         bool                          do_signature_scale )
   : do_signature_scale_( do_signature_scale ),
-    obj_( obj )
+    obj_( vcl_move(obj) )
 {
   assert( obj_->can_estimate_scale() );
 }

--- a/contrib/rpl/rgrl/rgrl_scale_est_closest.h
+++ b/contrib/rpl/rgrl/rgrl_scale_est_closest.h
@@ -7,7 +7,7 @@
 // \date   25 Nov 2002
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include "rgrl_scale_estimator.h"
 
 #include <vcl_compiler.h>
@@ -36,7 +36,7 @@ class rgrl_scale_est_closest
   //robust scale.  The one that is commonly used is the MUSE objective
   //function. The flag \a do_signature_scale determines whether a signature
   //covariance will be estimated.
-  rgrl_scale_est_closest( std::auto_ptr<rrel_objective>  obj,
+  rgrl_scale_est_closest( vcl_unique_ptr<rrel_objective>  obj,
                           bool                          do_signature_scale = false );
 
   ~rgrl_scale_est_closest();
@@ -71,7 +71,7 @@ class rgrl_scale_est_closest
 
  protected:
   bool do_signature_scale_;
-  std::auto_ptr<rrel_objective> obj_;
+  vcl_unique_ptr<rrel_objective> obj_;
 };
 
 #endif // rgrl_scale_est_closest_h_

--- a/contrib/rpl/rgrl/rgrl_weighter_indiv_scale.cxx
+++ b/contrib/rpl/rgrl/rgrl_weighter_indiv_scale.cxx
@@ -16,10 +16,10 @@
 #include <rgrl/rgrl_transformation.h>
 
 rgrl_weighter_indiv_scale::
-rgrl_weighter_indiv_scale( std::auto_ptr<rrel_m_est_obj>  m_est,
+rgrl_weighter_indiv_scale( vcl_unique_ptr<rrel_m_est_obj>  m_est,
                      bool                          use_signature_error,
                      bool                          use_precomputed_signature_wgt )
- :rgrl_weighter_m_est( m_est, use_signature_error, use_precomputed_signature_wgt )
+ :rgrl_weighter_m_est( vcl_move(m_est), use_signature_error, use_precomputed_signature_wgt )
 {
 }
 

--- a/contrib/rpl/rgrl/rgrl_weighter_indiv_scale.h
+++ b/contrib/rpl/rgrl/rgrl_weighter_indiv_scale.h
@@ -24,7 +24,7 @@ class rgrl_weighter_indiv_scale
 {
  public:
   //:  constructor takes a pointer to M estimator objective function
-  rgrl_weighter_indiv_scale( std::auto_ptr<rrel_m_est_obj>  m_est,
+  rgrl_weighter_indiv_scale( vcl_unique_ptr<rrel_m_est_obj>  m_est,
                              bool                          use_signature_error,
                              bool                          use_precomputed_signature_wgt = false );
 

--- a/contrib/rpl/rgrl/rgrl_weighter_m_est.cxx
+++ b/contrib/rpl/rgrl/rgrl_weighter_m_est.cxx
@@ -17,10 +17,10 @@
 #include "rgrl_transformation.h"
 
 rgrl_weighter_m_est::
-rgrl_weighter_m_est( std::auto_ptr<rrel_m_est_obj>  m_est,
+rgrl_weighter_m_est( vcl_unique_ptr<rrel_m_est_obj>  m_est,
                      bool                          use_signature_error,
                      bool                          use_precomputed_signature_wgt )
-  : m_est_( m_est ),
+  : m_est_( vcl_move(m_est) ),
     use_signature_error_( use_signature_error ),
     signature_precomputed_( use_precomputed_signature_wgt ),
     weight_more_on_distinct_match_( true )

--- a/contrib/rpl/rgrl/rgrl_weighter_m_est.h
+++ b/contrib/rpl/rgrl/rgrl_weighter_m_est.h
@@ -21,7 +21,7 @@
 //
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 class rrel_m_est_obj;
 class rgrl_transformation;
@@ -33,7 +33,7 @@ class rgrl_weighter_m_est
 {
  public:
   //:  constructor takes a pointer to M estimator objective function
-  rgrl_weighter_m_est( std::auto_ptr<rrel_m_est_obj>  m_est,
+  rgrl_weighter_m_est( vcl_unique_ptr<rrel_m_est_obj>  m_est,
                        bool                          use_signature_error,
                        bool                          use_precomputed_signature_wgt = false );
 
@@ -75,7 +75,7 @@ class rgrl_weighter_m_est
                               rgrl_transformation const&  xform );
 
  protected:
-  std::auto_ptr<rrel_m_est_obj> m_est_;
+  vcl_unique_ptr<rrel_m_est_obj> m_est_;
   bool use_signature_error_;
   bool signature_precomputed_;
   bool weight_more_on_distinct_match_;

--- a/contrib/rpl/rgrl/tests/test_initializer_ran_sam.cxx
+++ b/contrib/rpl/rgrl/tests/test_initializer_ran_sam.cxx
@@ -329,8 +329,8 @@ test_on_matches(rgrl_transformation_sptr xform, rgrl_match_set_sptr matches, uns
   rgrl_mask_sptr to_roi = from_roi;
   rgrl_estimator_sptr est = new rgrl_est_affine(2);
   rgrl_view_sptr  view = new rgrl_view( from_roi, to_roi, from_roi->bounding_box(), from_roi->bounding_box(), est, xform, 0 );
-  std::auto_ptr<rrel_objective> obj( new rrel_muset_obj(matches->from_size()) );
-  rgrl_scale_estimator_unwgted_sptr scale_est = new rgrl_scale_est_closest( obj );
+  vcl_unique_ptr<rrel_objective> obj( new rrel_muset_obj(matches->from_size()) );
+  rgrl_scale_estimator_unwgted_sptr scale_est = new rgrl_scale_est_closest( vcl_move(obj) );
 
   rgrl_initializer_ran_sam* init = new rgrl_initializer_ran_sam();
   init->set_sampling_params();

--- a/contrib/rpl/rgrl/tests/test_scale_est.cxx
+++ b/contrib/rpl/rgrl/tests/test_scale_est.cxx
@@ -1,5 +1,5 @@
 #include <vector>
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <cmath>
 #include <testlib/testlib_test.h>
@@ -61,8 +61,8 @@ static void test_scale_est()
   }
   var /= num_pts;
 
-  std::auto_ptr<rrel_objective> obj( new rrel_muset_obj( num_pts ) );
-  rgrl_scale_est_closest closest_est( obj );
+  vcl_unique_ptr<rrel_objective> obj( new rrel_muset_obj( num_pts ) );
+  rgrl_scale_est_closest closest_est( vcl_move(obj) );
 
   // Simple, one-to-one errors
   double one_to_one_scale = 0.0;

--- a/contrib/rpl/rgtl/rgtl_sqt_object_array.h
+++ b/contrib/rpl/rgtl/rgtl_sqt_object_array.h
@@ -12,7 +12,7 @@
 // \date April 2007
 
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 
 template <unsigned int D> class rgtl_object_array;
@@ -27,7 +27,7 @@ class rgtl_sqt_object_set
   typedef rgtl_sqt_object_set<D> self_type;
  public:
   //: Pointer to an instance of this class.
-  typedef std::auto_ptr<self_type> sqt_object_set_ptr;
+  typedef vcl_unique_ptr<self_type> sqt_object_set_ptr;
 
   //: Need a virtual destructor.
   virtual ~rgtl_sqt_object_set() {}
@@ -47,7 +47,7 @@ class rgtl_sqt_object_set_face: public rgtl_sqt_object_set<D>
   typedef rgtl_sqt_cell_geometry<D, Face> cell_geometry_type;
 
   //: Pointer to an instance of this class.
-  typedef std::auto_ptr<self_type> sqt_object_set_face_ptr;
+  typedef vcl_unique_ptr<self_type> sqt_object_set_face_ptr;
 
   //: Get the number of objects in this set.
   virtual int number_of_objects() const = 0;
@@ -78,7 +78,7 @@ class rgtl_sqt_object_array
   typedef rgtl_object_array<D> object_array_type;
 
   //: Pointer to a set of objects in once cell during construction.
-  typedef std::auto_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
+  typedef vcl_unique_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
 
   //: Get a set of the objects that belong to the given SQT face with respect to the given SQT origin.
   virtual sqt_object_set_ptr new_set(double const origin[D],

--- a/contrib/rpl/rgtl/rgtl_sqt_object_array_triangles_3d.cxx
+++ b/contrib/rpl/rgtl/rgtl_sqt_object_array_triangles_3d.cxx
@@ -291,7 +291,7 @@ rgtl_sqt_object_set_triangles_3d<Face>
   cell_geometry.get_center_planes(center_normals);
 
   // Allocate an output polygon set for each child.
-  std::auto_ptr<rgtl_sqt_object_set_triangles_3d> out[4];
+  vcl_unique_ptr<rgtl_sqt_object_set_triangles_3d> out[4];
   for (unsigned int i=0; i < 4; ++i)
   {
     // Create this polygon set.

--- a/contrib/rpl/rgtl/rgtl_sqt_objects.h
+++ b/contrib/rpl/rgtl/rgtl_sqt_objects.h
@@ -11,7 +11,7 @@
 // (See accompanying file rgtl_license_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <memory>
+#include <vcl_memory.h>
 #include <iostream>
 #include <iosfwd>
 #include <vcl_compiler.h>
@@ -110,7 +110,7 @@ class rgtl_sqt_objects
  private:
   // Internal implementation details.
   typedef rgtl_sqt_objects_internal<D> internal_type;
-  std::auto_ptr<internal_type> internal_;
+  vcl_unique_ptr<internal_type> internal_;
 
   friend class rgtl_serialize_access;
   template <class Serializer> void serialize(Serializer& sr);

--- a/contrib/rpl/rgtl/rgtl_sqt_objects.hxx
+++ b/contrib/rpl/rgtl/rgtl_sqt_objects.hxx
@@ -6,7 +6,7 @@
 #define rgtl_sqt_objects_hxx
 
 #include <limits>
-#include <memory>
+#include <vcl_memory.h>
 #include <cstdlib>
 #include <iostream>
 #include <cmath>
@@ -152,7 +152,7 @@ class rgtl_sqt_objects_face_base
   typedef typename internal_type::object_array_type object_array_type;
 
   // Type of pointer to set of objects during construction.
-  typedef std::auto_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
+  typedef vcl_unique_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
 
   // Construct with reference to main internal representation.
   rgtl_sqt_objects_face_base(internal_type& intern): internal_(intern) {}
@@ -221,10 +221,10 @@ class rgtl_sqt_objects_face: public rgtl_sqt_objects_face_base<D>
   rgtl_sqt_objects_face(internal_type& intern): derived(intern) {}
 
   // Pointer type for object set base class.
-  typedef std::auto_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
+  typedef vcl_unique_ptr< rgtl_sqt_object_set<D> > sqt_object_set_ptr;
 
   // Pointer type for object set representation in this face.
-  typedef std::auto_ptr< rgtl_sqt_object_set_face<D, Face> >
+  typedef vcl_unique_ptr< rgtl_sqt_object_set_face<D, Face> >
   sqt_object_set_face_ptr;
 
   // Spatial parameterization for this face.
@@ -366,12 +366,12 @@ class rgtl_sqt_objects_internal
 
   // Type holding SQT-specific representation of object array.
   typedef rgtl_sqt_object_array<D> sqt_object_array_type;
-  typedef std::auto_ptr<sqt_object_array_type> sqt_object_array_ptr;
+  typedef vcl_unique_ptr<sqt_object_array_type> sqt_object_array_ptr;
 
   // Type holding SQT-specific representation of object set during
   // cell construction.
   typedef rgtl_sqt_object_set<D> sqt_object_set_type;
-  typedef std::auto_ptr<sqt_object_set_type> sqt_object_set_ptr;
+  typedef vcl_unique_ptr<sqt_object_set_type> sqt_object_set_ptr;
 
   // Default constructor.
   rgtl_sqt_objects_internal(object_array_type const& original_objs);

--- a/contrib/rpl/rtvl/rtvl_refine.hxx
+++ b/contrib/rpl/rtvl/rtvl_refine.hxx
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cmath>
-#include <memory>
+#include <vcl_memory.h>
 #include <map>
 #include <functional> //required for greater<..>
 #include <vector>
@@ -53,8 +53,8 @@ class rtvl_refine_internal
   rtvl_refine<N>* external;
   double scale_multiplier;
   double mask_size;
-  std::auto_ptr< rtvl_tokens<N> > level;
-  std::auto_ptr< rgtl_octree_objects<N> > objects;
+  vcl_unique_ptr< rtvl_tokens<N> > level;
+  vcl_unique_ptr< rgtl_octree_objects<N> > objects;
   rgtl_octree_cell_bounds<N> bounds;
   unsigned int vote_count;
 };
@@ -264,7 +264,7 @@ bool rtvl_refine_internal<N>::build_next_level()
   objects.reset(0);
 
   // Create the representation for the next level.
-  std::auto_ptr< rtvl_tokens<N> > next_level(new rtvl_tokens<N>);
+  vcl_unique_ptr< rtvl_tokens<N> > next_level(new rtvl_tokens<N>);
 
   // Increment the scale for the next level.
   next_level->scale = level->scale * scale_multiplier;
@@ -338,7 +338,7 @@ template <unsigned int N>
 rtvl_refine<N>::rtvl_refine(unsigned int num_points, double* points):
   internal_(0)
 {
-  std::auto_ptr<internal_type> internal_p(new internal_type(this));
+  vcl_unique_ptr<internal_type> internal_p(new internal_type(this));
   internal_p->init(num_points, points);
   this->internal_ = internal_p.release();
 }

--- a/core/bin/vxl_filter.pl
+++ b/core/bin/vxl_filter.pl
@@ -73,7 +73,7 @@ $saw_queue_h         = 0; # <queue>
 $saw_map_h           = 0; # <map>
 $saw_set_h           = 0; # <set>
 $saw_string_h        = 0; # <string>
-$saw_memory_h        = 0; # <memory>
+$saw_memory_h        = 0; # <vcl_memory.h>
 
 # flags to indicate that certain types have been used.
 $saw_less      = 0; # less<>
@@ -232,7 +232,7 @@ sub process_headers {
       s/include\s*<typeinfo>/include <vcl_typeinfo.h>/;
       s/include\s*<deque>/include <vcl_deque.h>/;
       s/include\s*<iostream>/include <vcl_iostream.h>/;
-      s/include\s*<memory>/include <vcl_memory.h>/;
+      s/include\s*<vcl_memory.h>/include <vcl_memory.h>/;
       s/include\s*<sstream>/include <vcl_sstream.h>/;
       s/include\s*<utility>/include <vcl_utility.h>/;
       s/include\s*<exception>/include <vcl_exception.h>/;
@@ -929,7 +929,7 @@ sub output_lines {
         print "#include <vcl_set.h>\n"     if ($saw_set    && !$saw_set_h);
       }
 
-      # we need <memory> with allocator<> :
+      # we need <vcl_memory.h> with allocator<> :
       print "#include <vcl_memory.h>\n"    if ($saw_allocator && !$saw_memory_h);
 
       # we need <functional> with less<> :

--- a/core/vbl/vbl_scoped_ptr.h
+++ b/core/vbl/vbl_scoped_ptr.h
@@ -25,7 +25,7 @@
 //  deletion of the object pointed to, either on destruction of the
 //  vbl_scoped_ptr or via an explicit reset(). vbl_scoped_ptr is a
 //  simple solution for simple needs; use vbl_shared_ptr or
-//  std::auto_ptr if your needs are more complex.
+//  vcl_unique_ptr if your needs are more complex.
 //
 //  To use this to manage pointer member variables using forward
 //  declaration, explicitly define a destructor in your .cxx so that

--- a/core/vidl/examples/vidl_player_manager.cxx
+++ b/core/vidl/examples/vidl_player_manager.cxx
@@ -60,8 +60,8 @@ vidl_player_manager::vidl_player_manager()
     time_interval_(0.0f),
     width_(640),
     height_(480),
-    istream_(NULL),
-    ostream_(NULL),
+    istream_(static_cast<vidl_istream *>(NULL)),
+    ostream_(static_cast<vidl_ostream *>(NULL)),
     win_(0)
 {
 }

--- a/core/vidl/examples/vidl_player_manager.h
+++ b/core/vidl/examples/vidl_player_manager.h
@@ -9,7 +9,7 @@
 //
 //----------------------------------------------------------------------------
 
-#include <memory>
+#include <vcl_memory.h>
 #include <vcl_compiler.h>
 #include <vgui/vgui_wrapper_tableau.h>
 #include <vgui/vgui_image_tableau_sptr.h>
@@ -95,8 +95,8 @@ class vidl_player_manager : public vgui_wrapper_tableau
   float time_interval_;
   unsigned width_;
   unsigned height_;
-  std::auto_ptr<vidl_istream> istream_;
-  std::auto_ptr<vidl_ostream> ostream_;
+  vcl_unique_ptr<vidl_istream> istream_;
+  vcl_unique_ptr<vidl_ostream> ostream_;
   vgui_window* win_;
   vgui_viewer2D_tableau_sptr v2D_;
   vgui_image_tableau_sptr itab_;

--- a/core/vidl/tests/test_pixel_iterator.cxx
+++ b/core/vidl/tests/test_pixel_iterator.cxx
@@ -1,8 +1,9 @@
 // This is core/vidl/tests/test_pixel_iterator.cxx
 #include <iostream>
-#include <memory>
+#include <vcl_memory.h>
 #include <testlib/testlib_test.h>
 #include <vcl_compiler.h>
+#include <vcl_memory.h>
 #include <vidl/vidl_frame.h>
 #include <vidl/vidl_frame_sptr.h>
 #include <vidl/vidl_pixel_iterator.h>
@@ -34,7 +35,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,3,1,VIDL_PIXEL_FORMAT_RGB_24);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGB_24> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<3; ++i, ++itr, ++(*pitr)) {
@@ -61,7 +62,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,3,1,VIDL_PIXEL_FORMAT_RGB_24P);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGB_24P> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<3; ++i, ++itr, ++(*pitr)) {
@@ -88,7 +89,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,3,1,VIDL_PIXEL_FORMAT_BGR_24);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_BGR_24> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<3; ++i, ++itr, ++(*pitr)) {
@@ -115,7 +116,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,3,1,VIDL_PIXEL_FORMAT_RGBA_32);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGBA_32> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<3; ++i, ++itr, ++(*pitr)) {
@@ -146,7 +147,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,3,1,VIDL_PIXEL_FORMAT_RGBA_32P);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGBA_32P> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<3; ++i, ++itr, ++(*pitr)) {
@@ -177,7 +178,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,1,VIDL_PIXEL_FORMAT_RGB_555);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGB_555> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<2; ++i, ++itr, ++(*pitr)) {
@@ -204,7 +205,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,1,VIDL_PIXEL_FORMAT_RGB_565);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_RGB_565> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<2; ++i, ++itr, ++(*pitr)) {
@@ -231,7 +232,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_YUV_444P);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUV_444P> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -258,7 +259,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_UYV_444);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_UYV_444> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -287,7 +288,7 @@ static void test_pixel_iterator()
       vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,4,VIDL_PIXEL_FORMAT_YUV_422P);
       vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUV_422P> itr(*frame);
     // polymorphic pixel iterator
-      std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+      vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
       bool success = true, psuccess = true;
       for (unsigned int i=0; i<16; ++i, ++itr, ++(*pitr)) {
@@ -314,7 +315,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_UYVY_422);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_UYVY_422> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -341,7 +342,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_YUYV_422);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUYV_422> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -368,7 +369,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,2,VIDL_PIXEL_FORMAT_YUV_411P);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUV_411P> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<8; ++i, ++itr, ++(*pitr)) {
@@ -395,7 +396,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,2,VIDL_PIXEL_FORMAT_UYVY_411);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_UYVY_411> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<8; ++i, ++itr, ++(*pitr)) {
@@ -423,7 +424,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,4,VIDL_PIXEL_FORMAT_YUV_420P);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUV_420P> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<16; ++i, ++itr, ++(*pitr)) {
@@ -451,7 +452,7 @@ static void test_pixel_iterator()
       vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,4,VIDL_PIXEL_FORMAT_YUV_410P);
       vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_YUV_410P> itr(*frame);
       // polymorphic pixel iterator
-      std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+      vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
       bool success = true, psuccess = true;
       for (unsigned int i=0; i<16; ++i, ++itr, ++(*pitr)) {
@@ -477,7 +478,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_MONO_16);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_MONO_16> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -499,7 +500,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,2,2,VIDL_PIXEL_FORMAT_MONO_8);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_MONO_8> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<4; ++i, ++itr, ++(*pitr)) {
@@ -521,7 +522,7 @@ static void test_pixel_iterator()
     vidl_frame_sptr frame = new vidl_shared_frame(buffer,4,4,VIDL_PIXEL_FORMAT_MONO_1);
     vidl_pixel_iterator_of<VIDL_PIXEL_FORMAT_MONO_1> itr(*frame);
     // polymorphic pixel iterator
-    std::auto_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
+    vcl_unique_ptr<vidl_pixel_iterator> pitr(vidl_make_pixel_iterator(*frame));
 
     bool success = true, psuccess = true;
     for (unsigned int i=0; i<16; ++i, ++itr, ++(*pitr)) {

--- a/core/vidl/vidl_convert.cxx
+++ b/core/vidl/vidl_convert.cxx
@@ -15,7 +15,7 @@
 //-----------------------------------------------------------------------------
 
 #include <cstring>
-#include <memory>
+#include <vcl_memory.h>
 #include "vidl_convert.h"
 #include "vidl_frame.h"
 #include "vidl_pixel_format.h"
@@ -32,6 +32,7 @@
 #include <vil/vil_memory_chunk.h>
 #include <vcl_cassert.h>
 #include <vcl_compiler.h>
+#include <vcl_memory.h>
 
 //--------------------------------------------------------------------------------
 
@@ -82,10 +83,10 @@ bool convert_generic(vidl_frame const& in_frame,
                      vidl_frame& out_frame)
 {
   // create pixel iterators for each frame
-  std::auto_ptr<vidl_pixel_iterator> in_pitr(vidl_make_pixel_iterator(in_frame));
+  vcl_unique_ptr<vidl_pixel_iterator> in_pitr(vidl_make_pixel_iterator(in_frame));
   if (!in_pitr.get())
     return false;
-  std::auto_ptr<vidl_pixel_iterator> out_pitr(vidl_make_pixel_iterator(out_frame));
+  vcl_unique_ptr<vidl_pixel_iterator> out_pitr(vidl_make_pixel_iterator(out_frame));
   if (!out_pitr.get())
     return false;
 

--- a/core/vpdl/vpdl_mixture.h
+++ b/core/vpdl/vpdl_mixture.h
@@ -14,11 +14,12 @@
 
 #include <vector>
 #include <algorithm>
-#include <memory>
+#include <vcl_memory.h>
 #include <vpdl/vpdl_multi_cmp_dist.h>
 #include <vpdl/vpdt/vpdt_access.h>
 #include <vcl_cassert.h>
 #include <vcl_compiler.h>
+#include <vcl_memory.h>
 
 //: A mixture of distributions
 // A mixture is a weighted linear combination of other mixtures.
@@ -58,7 +59,7 @@ class vpdl_mixture : public vpdl_multi_cmp_dist<T,n>
     // ============ Data =============
 
     //: The distribution
-    std::auto_ptr<vpdl_distribution<T,n> > distribution;
+    vcl_unique_ptr<vpdl_distribution<T,n> > distribution;
     //: The weight
     T weight;
   };

--- a/core/vpdl/vpdt/vpdt_mixture_of.h
+++ b/core/vpdl/vpdt/vpdt_mixture_of.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 #include <algorithm>
-#include <memory>
+#include <vcl_memory.h>
 #include <vpdl/vpdt/vpdt_dist_traits.h>
 #include <vpdl/vpdt/vpdt_probability.h>
 #include <vcl_cassert.h>

--- a/scripts/VCL_ModernizeNaming.py
+++ b/scripts/VCL_ModernizeNaming.py
@@ -582,7 +582,7 @@ vcl_map.h,vcl_map,std::map
 vcl_map.h,vcl_multimap,std::multimap
 vcl_map.h,vcl_swap,std::swap
 vcl_memory.h,vcl_allocator,std::allocator
-vcl_memory.h,vcl_auto_ptr,std::auto_ptr
+vcl_memory.h,vcl_unique_ptr,vcl_unique_ptr
 vcl_memory.h,vcl_get_temporary_buffer,std::get_temporary_buffer
 vcl_memory.h,vcl_raw_storage_iterator,std::raw_storage_iterator
 vcl_memory.h,vcl_return_temporary_buffer,std::return_temporary_buffer

--- a/vcl/tests/test_memory.cxx
+++ b/vcl/tests/test_memory.cxx
@@ -14,14 +14,14 @@ struct A
 
 struct B: public A {};
 
-static int function_call(vcl_auto_ptr<A> a)
+static int function_call(vcl_unique_ptr<A> a)
 {
   return a.get()? 1:0;
 }
 
 static A* get_A(A& a) { return &a; }
 
-static vcl_auto_ptr<A> generate_auto_ptr () { return vcl_auto_ptr<A>(new A); }
+static vcl_unique_ptr<A> generate_auto_ptr () { return vcl_unique_ptr<A>(new A); }
 
 int test_memory_main(int /*argc*/,char* /*argv*/[])
 {
@@ -29,11 +29,11 @@ int test_memory_main(int /*argc*/,char* /*argv*/[])
 
   // Keep everything in a subscope so we can detect leaks.
   {
-    vcl_auto_ptr<A> pa0;
-    vcl_auto_ptr<A> pa1(new A());
-    vcl_auto_ptr<B> pb1(new B());
-    vcl_auto_ptr<A> pa2(new B());
-    vcl_auto_ptr<A> pa3(pb1);
+    vcl_unique_ptr<A> pa0;
+    vcl_unique_ptr<A> pa1(new A());
+    vcl_unique_ptr<B> pb1(new B());
+    vcl_unique_ptr<A> pa2(new B());
+    vcl_unique_ptr<A> pa3(vcl_move(pb1));
 
     A* ptr = get_A(*pa1);
     ASSERT(ptr == pa1.get(),
@@ -55,12 +55,12 @@ int test_memory_main(int /*argc*/,char* /*argv*/[])
     delete pa0.release();
     ASSERT(!pa0.get(), "auto_ptr holds an object after release()");
 
-    pa1 = pa3;
+    pa1 = vcl_move(pa3);
     ASSERT(!pa3.get(), "auto_ptr holds an object after assignment to another");
     ASSERT(pa1.get(),
            "auto_ptr does not hold an object after assignment from another");
 
-    int copied = function_call(pa2);
+    int copied = function_call(vcl_move(pa2));
     ASSERT(copied, "auto_ptr did not receive ownership in called function");
     ASSERT(!pa2.get(), "auto_ptr did not release ownership to called function");
 

--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -897,7 +897,7 @@ __inline int vcl_snprintf(char *outBuf, size_t size, const char *format, ...)
 #define vcl_uninitialized_copy std::uninitialized_copy
 #define vcl_uninitialized_fill std::uninitialized_fill
 #define vcl_uninitialized_fill_n std::uninitialized_fill_n
-#define vcl_auto_ptr std::auto_ptr
+#define vcl_auto_ptr vcl_auto_ptr
 #define vcl_bad_alloc std::bad_alloc
 #define vcl_set_new_handler std::set_new_handler
 #define vcl_accumulate std::accumulate

--- a/vcl/vcl_memory.h
+++ b/vcl/vcl_memory.h
@@ -2,6 +2,19 @@
 #define vcl_memory_h_
 
 #include <memory>
+#include  <utility>
 #include "vcl_compiler.h"
+
+// Needed to provide backwards compatibility between C++11 and older compilers
+// https://softwareengineering.stackexchange.com/questions/291141/how-to-handle-design-changes-for-auto-ptr-deprecation-in-c11
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+    template <typename T>
+    using vcl_unique_ptr = std::unique_ptr<T>;
+    #define vcl_move( value ) std::move(value)
+#else
+// NOTE:  THIS DOES NOT MEET THE STANDARDS FOR A UNIQUE POINTER!
+#   define vcl_unique_ptr std::auto_ptr
+#   define vcl_move( value ) value
+#endif
 
 #endif // vcl_memory_h_


### PR DESCRIPTION
The std::auto_ptr is removed in C++17 compilation, and deprecated in C++11.