### PR TITLE
COMP: Disable long time failing tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ option(VXL_LEGACY_ERROR_REPORTING "Use old error reporting methods rather than e
 if(VXL_LEGACY_ERROR_REPORTING)
   add_definitions( -DVXL_LEGACY_ERROR_REPORTING )
 endif()
+option(VXL_RUN_FAILING_TESTS "Enable long-time failing tests. If tests are failing for a long time, turn them off by default." OFF)
 
 # Option to build Windows Unicode support, the string
 # type of which is wchar_t, each character is a 16-bit unsigned integer.

--- a/contrib/brl/bbas/bocl/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bocl/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(bocl_test_all ${bocl_test_sources})
 target_link_libraries( bocl_test_all bocl ${VXL_LIB_PREFIX}testlib ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vgl_xio ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}vul)
 
 add_test( NAME bocl_test_global_io_bandwidth COMMAND $<TARGET_FILE:bocl_test_all> test_global_io_bandwidth  )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## This test is always segmentation faulting
+if( VXL_RUN_FAILING_TESTS ) ## This test is always segmentation faulting
   add_test( NAME bocl_test_command_queue COMMAND $<TARGET_FILE:bocl_test_all> test_command_queue  )
 endif()
 add_test( NAME bocl_test_kernel COMMAND $<TARGET_FILE:bocl_test_all> test_kernel )

--- a/contrib/brl/bbas/bsta/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bsta/algo/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/beta_distr_100_10.txt ${CMAKE_CURRENT
 
 add_test( NAME bsta_algo_test_fit_weibull COMMAND $<TARGET_FILE:bsta_algo_test_all> test_fit_weibull )
 add_test( NAME bsta_algo_test_gaussian_model COMMAND $<TARGET_FILE:bsta_algo_test_all> test_gaussian_model )
-if( HACK_FORCE_BRL_FAILING_TESTS )
+if( VXL_RUN_FAILING_TESTS )
 add_test( NAME bsta_algo_test_mean_shift COMMAND $<TARGET_FILE:bsta_algo_test_all> test_mean_shift )
 endif()
 add_test( NAME bsta_algo_test_fit_gaussian COMMAND $<TARGET_FILE:bsta_algo_test_all> test_fit_gaussian )

--- a/contrib/brl/bbas/imesh/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/imesh/algo/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable( imesh_algo_test_all
   test_generate_mesh.cxx
 )
 target_link_libraries( imesh_algo_test_all imesh imesh_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}testlib )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## This test always fails in travis builds, segfault during memory free operation
+if( VXL_RUN_FAILING_TESTS ) ## This test always fails in travis builds, segfault during memory free operation
 add_test( NAME imesh_test_generate_mesh COMMAND $<TARGET_FILE:imesh_algo_test_all> test_generate_mesh)
 endif()
 endif()

--- a/contrib/brl/bseg/boct/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boct/tests/CMakeLists.txt
@@ -19,7 +19,9 @@ add_test( NAME boct_test_find_neighbors COMMAND $<TARGET_FILE:boct_test_all> tes
 add_test( NAME boct_test_binary_io COMMAND $<TARGET_FILE:boct_test_all> test_binary_io)
 add_test( NAME boct_test_clone_tree COMMAND $<TARGET_FILE:boct_test_all> test_clone_tree   )
 add_test( NAME boct_test_tree_cell_reader COMMAND $<TARGET_FILE:boct_test_all> test_tree_cell_reader   )
+if(VXL_RUN_FAILING_TESTS)
 add_test( NAME boct_test_bit_tree COMMAND $<TARGET_FILE:boct_test_all> test_bit_tree )
+endif()
 
 
 add_executable( boct_test_include test_include.cxx )

--- a/contrib/brl/bseg/boxm/algo/sp/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm/algo/sp/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries( boxm_algo_sp_test_all boxm_algo_sp boxm_algo boxm boxm_ut
 
 add_test( NAME boxm_algo_sp_test_compute_visibility COMMAND $<TARGET_FILE:boxm_algo_sp_test_all> test_compute_visibility  )
 add_test( NAME boxm_algo_sp_test_render_image COMMAND $<TARGET_FILE:boxm_algo_sp_test_all> test_render_image  )
-if( HACK_FORCE_BRL_FAILING_TESTS )
+if( VXL_RUN_FAILING_TESTS )
 add_test( NAME boxm_algo_sp_test_update COMMAND $<TARGET_FILE:boxm_algo_sp_test_all> test_update  )
 endif()
 add_test( NAME boxm_algo_sp_test_update_multi_bin COMMAND $<TARGET_FILE:boxm_algo_sp_test_all> test_update_multi_bin  )

--- a/contrib/brl/bseg/boxm/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/camera0.txt ${CMAKE_CURRENT_BINARY_DI
 add_test( NAME boxm_test_binary_io COMMAND $<TARGET_FILE:boxm_test_all>    test_binary_io  )
 add_test( NAME boxm_test_block_iter COMMAND $<TARGET_FILE:boxm_test_all>    test_block_iter  )
 #add_test( NAME boxm_test_region_finder COMMAND $<TARGET_FILE:boxm_test_all>    test_region_finder )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## SEGFAULT when testing with ctest -j16 (perhaps files are shared between tests)
+if( VXL_RUN_FAILING_TESTS ) ## SEGFAULT when testing with ctest -j16 (perhaps files are shared between tests)
 add_test( NAME boxm_test_cell_iterator COMMAND $<TARGET_FILE:boxm_test_all>    test_cell_iterator )
 endif()
 add_test( NAME boxm_test_load_neighboring_blocks COMMAND $<TARGET_FILE:boxm_test_all>    test_load_neighboring_blocks )

--- a/contrib/brl/bseg/boxm2/cpp/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/cpp/algo/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries( boxm2_cpp_algo_test_all ${VXL_LIB_PREFIX}testlib boxm2_cp
 add_test( NAME boxm2_test_merge_mixtures COMMAND $<TARGET_FILE:boxm2_cpp_algo_test_all>  test_merge_mixtures  )
 add_test( NAME boxm2_test_cone_ray_trace COMMAND $<TARGET_FILE:boxm2_cpp_algo_test_all>  test_cone_ray_trace  )
 add_test( NAME boxm2_test_cone_update COMMAND $<TARGET_FILE:boxm2_cpp_algo_test_all>  test_cone_update     )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## This test is fails on Mac with clang
+if( VXL_RUN_FAILING_TESTS ) ## This test is fails on Mac with clang
 add_test( NAME boxm2_test_merge_function COMMAND $<TARGET_FILE:boxm2_cpp_algo_test_all>  test_merge_function  )
 endif()
 

--- a/contrib/brl/bseg/boxm2/ocl/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/ocl/tests/CMakeLists.txt
@@ -24,10 +24,10 @@ add_executable( boxm2_ocl_test_all
 target_link_libraries( boxm2_ocl_test_all ${VXL_LIB_PREFIX}testlib boxm2_ocl boxm2_ocl_pro boxm2_ocl_utils boxm2_cpp boxm2_cpp_algo boxm2_cpp_pro boxm2_pro brdb ${VXL_LIB_PREFIX}vpgl_algo vpgl_pro vil_pro sdet ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vpl )
 
 add_test( NAME boxm2_ocl_test_refine COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_refine  )
-add_test( NAME boxm2_ocl_test_image_pyramid COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_image_pyramid  )
 add_test( NAME boxm2_ocl_test_process_mains COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_process_mains  )
 add_test( NAME boxm2_ocl_test_weighted_em COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_weighted_em  )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## These tests are always failing on Mac
+if( VXL_RUN_FAILING_TESTS ) ## These tests are always failing on Mac
+add_test( NAME boxm2_ocl_test_image_pyramid COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_image_pyramid  )
 add_test( NAME boxm2_ocl_test_kernel_filter COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_kernel_filter )
 add_test( NAME boxm2_ocl_test_kernel_vector_filter COMMAND $<TARGET_FILE:boxm2_ocl_test_all>       test_kernel_vector_filter )
 endif()

--- a/contrib/brl/bseg/boxm2/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/boxm2/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries( boxm2_test_all ${VXL_LIB_PREFIX}testlib boxm2_cpp_pro brd
 add_test( NAME boxm2_test_scene COMMAND $<TARGET_FILE:boxm2_test_all>  test_scene  )
 add_test( NAME boxm2_test_cache COMMAND $<TARGET_FILE:boxm2_test_all>  test_cache  )
 add_test( NAME boxm2_test_cache2 COMMAND $<TARGET_FILE:boxm2_test_all>  test_cache2  )
-if( HACK_FORCE_BRL_FAILING_TESTS ) ## These tests are always failing on Mac.  An infinite loop occurs in while statement
+if( VXL_RUN_FAILING_TESTS ) ## These tests are always failing on Mac.  An infinite loop occurs in while statement
                                    ## due to failure in aio_read function on Mac.
 add_test( NAME boxm2_test_io COMMAND $<TARGET_FILE:boxm2_test_all>  test_io  )
 endif()

--- a/contrib/brl/bseg/bstm_multi/cpp/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/bstm_multi/cpp/algo/tests/CMakeLists.txt
@@ -4,7 +4,9 @@ add_executable( bstm_multi_cpp_algo_test_all
  )
 target_link_libraries( bstm_multi_cpp_algo_test_all ${VXL_LIB_PREFIX}testlib bstm_multi_cpp_algo bstm_multi bstm bstm_multi_io ${VXL_LIB_PREFIX}vcl)
 
+if(VXL_RUN_FAILING_TESTS)
 add_test( NAME bstm_multi_test_bstm_to_multi_bstm_block_function COMMAND $<TARGET_FILE:bstm_multi_cpp_algo_test_all> test_bstm_to_multi_bstm_block_function )
+endif()
 
 add_executable( bstm_multi_cpp_algo_test_include test_include.cxx )
 target_link_libraries( bstm_multi_cpp_algo_test_include bstm_multi_cpp_algo )

--- a/contrib/brl/bseg/bvpl/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/bvpl/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ add_test( NAME bvpl_test_bvpl_kernel_functors COMMAND $<TARGET_FILE:bvpl_test_al
 add_test( NAME bvpl_test_direction_to_color_map COMMAND $<TARGET_FILE:bvpl_test_all> test_direction_to_color_map  )
 add_test( NAME bvpl_test_vector_operator COMMAND $<TARGET_FILE:bvpl_test_all> test_bvpl_vector_operator  )
 add_test( NAME bvpl_test_vector_directions COMMAND $<TARGET_FILE:bvpl_test_all> test_vector_directions  )
-if( HACK_FORCE_BRL_FAILING_TESTS )
+if( VXL_RUN_FAILING_TESTS )
 add_test( NAME bvpl_test_detect_corner COMMAND $<TARGET_FILE:bvpl_test_all> test_detect_corner  )
 endif()
 

--- a/contrib/cul/bundler/tests/CMakeLists.txt
+++ b/contrib/cul/bundler/tests/CMakeLists.txt
@@ -22,22 +22,25 @@ add_test( NAME bundler_test_tracks_detect
           COMMAND $<TARGET_FILE:bundler_test_all> test_tracks_detect ${cul_SOURCE_DIR}/bundler/tests/test_data/checkers.png)
 add_test( NAME bundler_test_propose_matches
           COMMAND $<TARGET_FILE:bundler_test_all> test_propose_matches )
+add_test( NAME bundler_test_tracks
+          COMMAND $<TARGET_FILE:bundler_test_all> test_tracks ${cul_SOURCE_DIR}/bundler/tests/test_data)
+add_test( NAME bundler_test_ply
+          COMMAND $<TARGET_FILE:bundler_test_all> test_ply )
+add_test( NAME bundler_test_bundle_adjust
+          COMMAND $<TARGET_FILE:bundler_test_all> test_bundle_adjust )
+
+if(VXL_RUN_FAILING_TESTS)
 add_test( NAME bundler_test_match_ann
           COMMAND $<TARGET_FILE:bundler_test_all> test_match_ann )
 add_test( NAME bundler_test_refine
           COMMAND $<TARGET_FILE:bundler_test_all> test_refine )
-add_test( NAME bundler_test_tracks
-          COMMAND $<TARGET_FILE:bundler_test_all> test_tracks ${cul_SOURCE_DIR}/bundler/tests/test_data)
 add_test( NAME bundler_test_initial_recon
           COMMAND $<TARGET_FILE:bundler_test_all> test_initial_recon )
 add_test( NAME bundler_test_pipeline
           COMMAND $<TARGET_FILE:bundler_test_all> test_pipeline )
-add_test( NAME bundler_test_ply
-          COMMAND $<TARGET_FILE:bundler_test_all> test_ply )
 add_test( NAME bundler_test_add_next_image
           COMMAND $<TARGET_FILE:bundler_test_all> test_add_next_image )
-add_test( NAME bundler_test_bundle_adjust
-          COMMAND $<TARGET_FILE:bundler_test_all> test_bundle_adjust )
+endif()
 
 
 add_executable( bundler_test_include test_include.cxx )


### PR DESCRIPTION
A vxl option is added to controlling if longtime failing tests are run.
These failing tests make it difficult to identify new failures during
routine code maintenance.