### PR TITLE
COMP: Remove attribute ignored warning

### DIFF
--- a/core/vnl/vnl_c_na_vector.hxx
+++ b/core/vnl/vnl_c_na_vector.hxx
@@ -153,8 +153,8 @@ template VNL_EXPORT void vnl_c_na_vector_inf_norm(T const *, unsigned, S *)
 #undef VNL_C_NA_VECTOR_INSTANTIATE_ordered
 #define VNL_C_NA_VECTOR_INSTANTIATE_ordered(T) \
 VNL_C_NA_VECTOR_INSTANTIATE_norm(T, vnl_c_na_vector<T >::abs_t); \
-template class VNL_EXPORT vnl_c_na_vector<T >; \
-template VNL_EXPORT std::ostream& print_na_vector(std::ostream &,T const *,unsigned)
+template class vnl_c_na_vector<T >; \
+template std::ostream& print_na_vector(std::ostream &,T const *,unsigned)
 
 
 #undef VNL_C_NA_VECTOR_INSTANTIATE_unordered

--- a/core/vnl/vnl_c_vector.hxx
+++ b/core/vnl/vnl_c_vector.hxx
@@ -441,7 +441,7 @@ template VNL_EXPORT void vnl_c_vector_inf_norm(T const *, unsigned, S *)
 #undef VNL_C_VECTOR_INSTANTIATE_ordered
 #define VNL_C_VECTOR_INSTANTIATE_ordered(T) \
 VNL_C_VECTOR_INSTANTIATE_norm(T, vnl_c_vector<T >::abs_t); \
-template class VNL_EXPORT vnl_c_vector<T >; \
+template class vnl_c_vector<T >; \
 template VNL_EXPORT std::ostream& print_vector(std::ostream &,T const *,unsigned)
 
 #undef VNL_C_VECTOR_INSTANTIATE_unordered
@@ -450,7 +450,7 @@ VCL_DO_NOT_INSTANTIATE(T vnl_c_vector<T >::max_value(T const *, unsigned), T(0))
 VCL_DO_NOT_INSTANTIATE(T vnl_c_vector<T >::min_value(T const *, unsigned), T(0)); \
 VCL_DO_NOT_INSTANTIATE(unsigned vnl_c_vector<T >::arg_max(T const *, unsigned), 0U); \
 VCL_DO_NOT_INSTANTIATE(unsigned vnl_c_vector<T >::arg_min(T const *, unsigned), 0U); \
-template class VNL_EXPORT vnl_c_vector<T >; \
+template class vnl_c_vector<T >; \
 VNL_C_VECTOR_INSTANTIATE_norm(T, vnl_c_vector<T >::abs_t);
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/core/vnl/vnl_sparse_matrix_linear_system.cxx
+++ b/core/vnl/vnl_sparse_matrix_linear_system.cxx
@@ -77,6 +77,6 @@ void vnl_sparse_matrix_linear_system<T>::apply_preconditioner(vnl_vector<double>
   px = dot_product(x,jacobi_precond_);
 }
 
-template class VNL_EXPORT vnl_sparse_matrix_linear_system<double>;
-template class VNL_EXPORT vnl_sparse_matrix_linear_system<float>;
+template class vnl_sparse_matrix_linear_system<double>;
+template class vnl_sparse_matrix_linear_system<float>;
 

--- a/core/vnl/vnl_vector_fixed_ref.hxx
+++ b/core/vnl/vnl_vector_fixed_ref.hxx
@@ -123,7 +123,7 @@ vnl_vector_fixed_ref_const<T,n>::print( std::ostream& s ) const
 // instantiation macros for vnl_vector_fixed_ref<T,unsigned> :
 
 #define VNL_VECTOR_FIXED_REF_INSTANTIATE(T,n) \
-template class VNL_EXPORT vnl_vector_fixed_ref<T, n >; \
-template class VNL_EXPORT vnl_vector_fixed_ref_const<T, n >
+template class vnl_vector_fixed_ref<T, n >; \
+template class vnl_vector_fixed_ref_const<T, n >
 
 #endif // vnl_vector_fixed_ref_hxx_


### PR DESCRIPTION
vxl/core/vnl/vnl_c_na_vector.hxx:156:27: warning: type attributes ignored after type is already defined [-Wattributes]
vxl/core/vnl/vnl_c_vector.hxx:444:27: warning: type attributes ignored after type is already defined [-Wattributes]
vxl/core/vnl/vnl_c_vector.hxx:453:27: warning: type attributes ignored after type is already defined [-Wattributes]
vxl/core/vnl/vnl_sparse_matrix_linear_system.cxx:80:27: warning: type attributes ignored after type is already defined [-Wattributes]
vxl/core/vnl/vnl_sparse_matrix_linear_system.cxx:81:27: warning: type attributes ignored after type is already defined [-Wattributes]
vxl/core/vnl/vnl_vector_fixed_ref.hxx:127:27: warning: type attributes ignored after type is already defined [-Wattributes]