### PR TITLE
Fix vidl visibility

### DIFF
--- a/core/vidl/Templates/vil_smart_ptr+vidl_frame-.cxx
+++ b/core/vidl/Templates/vil_smart_ptr+vidl_frame-.cxx
@@ -1,3 +1,3 @@
 #include <vil/vil_smart_ptr.hxx>
 #include <vidl/vidl_frame.h>
-VIL_SMART_PTR_INSTANTIATE(vidl_frame);
+VIL_SMART_PTR_INSTANTIATE(vidl_frame, VIDL_EXPORT);

--- a/core/vidl/Templates/vil_smart_ptr+vidl_istream-.cxx
+++ b/core/vidl/Templates/vil_smart_ptr+vidl_istream-.cxx
@@ -1,3 +1,3 @@
 #include <vil/vil_smart_ptr.hxx>
 #include <vidl/vidl_istream.h>
-VIL_SMART_PTR_INSTANTIATE(vidl_istream);
+VIL_SMART_PTR_INSTANTIATE(vidl_istream, VIDL_EXPORT);

--- a/core/vidl/Templates/vil_smart_ptr+vidl_ostream-.cxx
+++ b/core/vidl/Templates/vil_smart_ptr+vidl_ostream-.cxx
@@ -1,3 +1,3 @@
 #include <vil/vil_smart_ptr.hxx>
 #include <vidl/vidl_ostream.h>
-VIL_SMART_PTR_INSTANTIATE(vidl_ostream);
+VIL_SMART_PTR_INSTANTIATE(vidl_ostream, VIDL_EXPORT);

--- a/core/vidl/vidl_convert.h
+++ b/core/vidl/vidl_convert.h
@@ -17,14 +17,15 @@
 
 #include "vidl_frame_sptr.h"
 #include "vidl_frame.h"
+#include <vidl/vidl_export.h>
 #include <vil/vil_image_view_base.h>
-
 
 //: Convert the frame into an image view
 // possibly converts the pixel data type
 // always create a deep copy of the data
 // \param require_color restricts the color mode of the output
 //         if set to UNKNOWN (default) the input color mode is used
+VIDL_EXPORT
 bool vidl_convert_to_view(const vidl_frame& frame,
                           vil_image_view_base& image,
                           vidl_pixel_color require_color = VIDL_PIXEL_COLOR_UNKNOWN);
@@ -32,6 +33,7 @@ bool vidl_convert_to_view(const vidl_frame& frame,
 
 //: Wrap the frame buffer in an image view if supported
 // Returns a null pointer if not possible
+VIDL_EXPORT
 vil_image_view_base_sptr vidl_convert_wrap_in_view(const vidl_frame& frame);
 
 
@@ -39,23 +41,27 @@ vil_image_view_base_sptr vidl_convert_wrap_in_view(const vidl_frame& frame);
 // The \p in_frame.data() is converted from \p in_frame.pixel_format()
 // to \p out_frame.pixel_format() and stored in \p out_frame.data()
 // \returns false if the output frame data is not the correct size.
+VIDL_EXPORT
 bool vidl_convert_frame(const vidl_frame& in_frame,
                               vidl_frame& out_frame);
 
 
 //: Convert the pixel format of a frame
 // Convert \p in_frame to a \p format by allocating a new frame buffer
+VIDL_EXPORT
 vidl_frame_sptr vidl_convert_frame(const vidl_frame_sptr& in_frame,
                                    vidl_pixel_format format);
 
 //: Convert the image view smart pointer to a frame
 // Will wrap the memory if possible, if not the image is converted to
 // the closest vidl_pixel_format
+VIDL_EXPORT
 vidl_frame_sptr vidl_convert_to_frame(const vil_image_view_base_sptr& image);
 
 //: Convert the image view to a frame
 // Will wrap the memory if possible, if not the image is converted to
 // the closest vidl_pixel_format
+VIDL_EXPORT
 vidl_frame_sptr vidl_convert_to_frame(const vil_image_view_base& image);
 
 #endif // vidl_convert_h_

--- a/core/vidl/vidl_ffmpeg_istream.h
+++ b/core/vidl/vidl_ffmpeg_istream.h
@@ -24,7 +24,7 @@
 
 
 //: A video input stream using FFMPEG to decoded files
-class vidl_ffmpeg_istream
+class VIDL_EXPORT vidl_ffmpeg_istream
   : public vidl_istream
 {
  public:

--- a/core/vidl/vidl_ffmpeg_ostream.h
+++ b/core/vidl/vidl_ffmpeg_ostream.h
@@ -27,7 +27,7 @@ struct vidl_ffmpeg_ostream_params;
 
 
 //: A video output stream to an encoded file using FFMPEG
-class vidl_ffmpeg_ostream
+class VIDL_EXPORT vidl_ffmpeg_ostream
   : public vidl_ostream
 {
  public:

--- a/core/vidl/vidl_ffmpeg_ostream_params.h
+++ b/core/vidl/vidl_ffmpeg_ostream_params.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <vcl_compiler.h>
+#include <vidl/vidl_export.h>
 
 //: A parameters struct for vidl_ffmpeg_ostream
 //
@@ -29,7 +30,7 @@
 //                 .encoder( vidl_ffmpeg_ostream_params::DVVIDEO )
 //                 .frame_rate( 29.95 ) );
 // \endcode
-struct vidl_ffmpeg_ostream_params
+struct VIDL_EXPORT vidl_ffmpeg_ostream_params
 {
   //: Available video encoders
   enum encoder_type { DEFAULT,

--- a/core/vidl/vidl_frame.h
+++ b/core/vidl/vidl_frame.h
@@ -23,7 +23,7 @@
 
 
 //: A ref counted video frame
-class vidl_frame
+class VIDL_EXPORT vidl_frame
 {
   public:
     //: Destructor
@@ -83,7 +83,7 @@ class vidl_frame
 
 
 //: A frame buffer that shares someone else's data
-class vidl_shared_frame : public vidl_frame
+class VIDL_EXPORT vidl_shared_frame : public vidl_frame
 {
   public:
     //: Constructor
@@ -114,7 +114,7 @@ class vidl_shared_frame : public vidl_frame
 
 //: A frame buffer that wraps a vil_memory_chunk
 //  This is useful when the frame actually came from a vil_image
-class vidl_memory_chunk_frame : public vidl_frame
+class VIDL_EXPORT vidl_memory_chunk_frame : public vidl_frame
 {
   public:
     //: Constructor

--- a/core/vidl/vidl_image_list_istream.h
+++ b/core/vidl/vidl_image_list_istream.h
@@ -25,7 +25,7 @@
 // The number of simultaneously open files is limited on many platforms.
 // The paths are tested for validity at the "open" stage rather than the "stream"
 // stage so that we have random access to the frames (i.e. the stream is seekable).
-class vidl_image_list_istream
+class VIDL_EXPORT vidl_image_list_istream
   : public vidl_istream
 {
  public:

--- a/core/vidl/vidl_image_list_ostream.h
+++ b/core/vidl/vidl_image_list_ostream.h
@@ -16,7 +16,7 @@
 #include <vcl_compiler.h>
 
 //:A video output stream to a list of images
-class vidl_image_list_ostream
+class VIDL_EXPORT vidl_image_list_ostream
   : public vidl_ostream
 {
  public:

--- a/core/vil/vil_smart_ptr.hxx
+++ b/core/vil/vil_smart_ptr.hxx
@@ -37,10 +37,10 @@ std::ostream& operator<< (std::ostream& os, vil_smart_ptr<T> const& r)
 //------------------------------------------------------------------------------
 
 #undef  VIL_SMART_PTR_INSTANTIATE
-#define VIL_SMART_PTR_INSTANTIATE(T) \
-template class vil_smart_ptr<T >; \
-template <> struct vil_smart_ptr_T_as_string<T > \
+#define VIL_SMART_PTR_INSTANTIATE(T,...) \
+template class __VA_ARGS__ vil_smart_ptr<T >; \
+template <> struct __VA_ARGS__ vil_smart_ptr_T_as_string<T > \
 { static char const *str() { return #T; } }; \
-template std::ostream& operator<< (std::ostream&, vil_smart_ptr<T > const&)
+template __VA_ARGS__ std::ostream& operator<< (std::ostream&, vil_smart_ptr<T > const&)
 
 #endif // vil_smart_ptr_hxx_


### PR DESCRIPTION
Add missing export decoration so that vidl is usable when hidden visibility is enabled.

As part of this, fiddle with `VIL_SMART_PTR_INSTANTIATE` so that the instantiations can be export-decorated... on not-Windows. Exporting template instantiations on Windows is an ugly mess for which we have no machinery whatsoever at present. (At least things should be no more broken than already...)