### PR TITLE
Fix initialization order

### DIFF
--- a/contrib/gel/vdgl/vdgl_digital_region.cxx
+++ b/contrib/gel/vdgl/vdgl_digital_region.cxx
@@ -26,11 +26,11 @@ vsol_spatial_object_2d* vdgl_digital_region::clone() const
 //
 vdgl_digital_region::vdgl_digital_region(vdgl_digital_region const& r)
   : vsol_region_2d(r),
-    npts_(0), pixel_size_(1.f), xp_(VXL_NULLPTR), yp_(VXL_NULLPTR), pix_(VXL_NULLPTR),
+    npts_given_(false), npts_(0), pixel_size_(1.f), xp_(VXL_NULLPTR), yp_(VXL_NULLPTR), pix_(VXL_NULLPTR),
     max_(0), min_((unsigned short)(-1)), xo_(0.f), yo_(0.f),
     io_(0.f), io_stdev_(0.0f), pix_index_(0),
     fit_valid_(false), scatter_matrix_valid_(false),
-    X2_(0), Y2_(0), I2_(0), XY_(0), XI_(0), YI_(0), error_(0), sigma_sq_(0),npts_given_(false)
+    X2_(0), Y2_(0), I2_(0), XY_(0), XI_(0), YI_(0), error_(0), sigma_sq_(0)
 {
   if(r.Npix() == 0)
     return;
@@ -45,11 +45,11 @@ vdgl_digital_region::vdgl_digital_region(vdgl_digital_region const& r)
 vdgl_digital_region::vdgl_digital_region(int npts, const float* xp, const float* yp,
                                          const unsigned short *pix)
   : vsol_region_2d(),
-    npts_(0), pixel_size_(1.f), xp_(VXL_NULLPTR), yp_(VXL_NULLPTR), pix_(VXL_NULLPTR),
+    npts_given_(false), npts_(0), pixel_size_(1.f), xp_(VXL_NULLPTR), yp_(VXL_NULLPTR), pix_(VXL_NULLPTR),
     max_(0), min_((unsigned short)(-1)), xo_(0.f), yo_(0.f),
     io_(0.f), io_stdev_(0.0f), pix_index_(0),
     fit_valid_(false), scatter_matrix_valid_(false),
-    X2_(0), Y2_(0), I2_(0), XY_(0), XI_(0), YI_(0), error_(0), sigma_sq_(0), npts_given_(false)
+    X2_(0), Y2_(0), I2_(0), XY_(0), XI_(0), YI_(0), error_(0), sigma_sq_(0)
 {
   assert(npts > 0);
   for (int i = 0; i<npts; i++)

--- a/contrib/gel/vdgl/vdgl_digital_region.h
+++ b/contrib/gel/vdgl/vdgl_digital_region.h
@@ -46,7 +46,7 @@ class vdgl_digital_region : public vsol_region_2d
   // Constructors/Initializers/Destructors---------------------------------
   vdgl_digital_region()
   : vsol_region_2d(),
-    npts_(0), npts_given_(false), pixel_size_(1.f), xp_(0), yp_(0), pix_(0),
+    npts_given_(false), npts_(0), pixel_size_(1.f), xp_(0), yp_(0), pix_(0),
     max_(0), min_((unsigned short)(-1)), xo_(0.f), yo_(0.f),
     io_(0.f), io_stdev_(0.0f), pix_index_(0),
     fit_valid_(false), scatter_matrix_valid_(false),

--- a/core/vbl/vbl_disjoint_sets.h
+++ b/core/vbl/vbl_disjoint_sets.h
@@ -65,7 +65,7 @@ class vbl_disjoint_sets
   // Internal node data structure used for representing an element
   struct node
   {
-  node():rank(0), index(0), size(1), parent(VXL_NULLPTR){}
+  node():rank(0), index(0), parent(VXL_NULLPTR), size(1){}
     //: represents the approximate max height of the node in its subtree
     int rank;
     int index; // The index of the element the node represents

--- a/core/vgl/vgl_fit_oriented_box_2d.h
+++ b/core/vgl/vgl_fit_oriented_box_2d.h
@@ -22,14 +22,14 @@ template <class T>
 class vgl_fit_oriented_box_2d {
  public:
   //:default constructor
- vgl_fit_oriented_box_2d():dtheta_(default_dtheta),fit_valid_(false), fixed_theta_(false){}
+ vgl_fit_oriented_box_2d():fixed_theta_(false), fit_valid_(false), dtheta_(default_dtheta){}
 
   //: constructor with polygon
   vgl_fit_oriented_box_2d(vgl_polygon<T> const& poly, double dtheta = default_dtheta);
 
   //: constructor with points
  vgl_fit_oriented_box_2d(std::vector<vgl_point_2d<T> > const& pts, double dtheta = default_dtheta):
-  pts_(pts), dtheta_(dtheta), fit_valid_(false), fixed_theta_(false){}
+  fixed_theta_(false), fit_valid_(false), dtheta_(dtheta), pts_(pts){}
 
   //: brute force search
   vgl_oriented_box_2d<T> fitted_box();

--- a/core/vgl/vgl_fit_oriented_box_2d.hxx
+++ b/core/vgl/vgl_fit_oriented_box_2d.hxx
@@ -5,7 +5,7 @@
 #include <limits>
 
 template <class T>
-vgl_fit_oriented_box_2d<T>::vgl_fit_oriented_box_2d(vgl_polygon<T> const& poly, double dtheta):dtheta_(dtheta), fit_valid_(false), fixed_theta_(false){
+vgl_fit_oriented_box_2d<T>::vgl_fit_oriented_box_2d(vgl_polygon<T> const& poly, double dtheta):fixed_theta_(false), fit_valid_(false), dtheta_(dtheta){
   // extract points
   pts_.clear();
   size_t ns = poly.num_sheets();

--- a/core/vidl/vidl_ffmpeg_istream_v56.hxx
+++ b/core/vidl/vidl_ffmpeg_istream_v56.hxx
@@ -46,14 +46,14 @@ struct vidl_ffmpeg_istream::pimpl
     vid_index_( -1 ),
     data_index_( -1 ),
     vid_str_( NULL ),
+    video_enc_( 0 ),
     frame_( NULL ),
     num_frames_( -2 ), // sentinel value to indicate not yet computed
     sws_context_( NULL ),
     cur_frame_( NULL ),
     metadata_( 0 ),
-    pts_( 0 ),
     frame_number_offset_( 0 ),
-    video_enc_( 0 )
+    pts_( 0 )
   {
     packet_.data = NULL;
   }

--- a/core/vpgl/algo/vpgl_backproject_dem.cxx
+++ b/core/vpgl/algo/vpgl_backproject_dem.cxx
@@ -16,7 +16,7 @@
 class dem_bproj_cost_function : public vnl_cost_function{
 public:
   dem_bproj_cost_function(vil_image_view<float> const& dem_view, vpgl_geo_camera* geo_cam, vgl_ray_3d<double> const& ray, bool verbose=false) :
-    vnl_cost_function(1), geo_cam_(geo_cam), dview_(&dem_view),ray_(ray), verbose_(verbose){}
+    vnl_cost_function(1), ray_(ray), geo_cam_(geo_cam), dview_(&dem_view), verbose_(verbose){}
   //: x is the parameter that runs along the ray, with x=0 at the ray origin
   virtual double f(vnl_vector<double> const& x){
     //get the lon and lat values for a given parameter value
@@ -44,7 +44,7 @@ private:
   const vil_image_view<float>* dview_;
   bool verbose_;
 };
-vpgl_backproject_dem::vpgl_backproject_dem( vil_image_resource_sptr const& dem, double zmin, double zmax):dem_(dem), min_samples_(5000.0), tail_fract_(0.025), verbose_(false)
+vpgl_backproject_dem::vpgl_backproject_dem( vil_image_resource_sptr const& dem, double zmin, double zmax):verbose_(false), min_samples_(5000.0), tail_fract_(0.025), dem_(dem)
 {
   //construct a geo_camera for the dem (an orthographic view looking straight down)
   if(!vpgl_geo_camera::init_geo_camera(dem_, geo_cam_)){


### PR DESCRIPTION
Twiddle with the order of member initializers in a bunch of classes so that the order of initializers matches the order in which the compiler actually executes them. This avoids tripping `-Wreorder` warnings. (This isn't all of them, but it covers ones that I was tripping.)