### PR TITLE
Readability non const parameter

### DIFF
--- a/contrib/brl/b3p/shapelib/shapefil.h
+++ b/contrib/brl/b3p/shapelib/shapefil.h
@@ -216,9 +216,9 @@ void SHPAPI_CALL
       SHPComputeExtents( SHPObject * psObject );
 SHPObject SHPAPI_CALL1(*)
       SHPCreateObject( int nSHPType, int nShapeId,
-                       int nParts, int * panPartStart, int * panPartType,
-                       int nVertices, double * padfX, double * padfY,
-                       double * padfZ, double * padfM );
+                       int nParts, const int * panPartStart, const int * panPartType,
+                       int nVertices, const double * padfX, const double * padfY,
+                       const double * padfZ, const double * padfM );
 SHPObject SHPAPI_CALL1(*)
       SHPCreateSimpleObject( int nSHPType, int nVertices,
                              double * padfX, double * padfY, double * padfZ );
@@ -295,7 +295,7 @@ int    SHPAPI_CALL1(*)
                                double * padfBoundsMax,
                                int * );
 int     SHPAPI_CALL
-      SHPCheckBoundsOverlap( double *, double *, double *, double *, int );
+      SHPCheckBoundsOverlap( const double *, const double *, const double *, const double *, int );
 
 /************************************************************************/
 /*                             DBF Support.                             */

--- a/contrib/brl/b3p/shapelib/shpopen.c
+++ b/contrib/brl/b3p/shapelib/shpopen.c
@@ -771,9 +771,9 @@ SHPComputeExtents( SHPObject * psObject )
 
 SHPObject SHPAPI_CALL1(*)
 SHPCreateObject( int nSHPType, int nShapeId, int nParts,
-                 int * panPartStart, int * panPartType,
-                 int nVertices, double * padfX, double * padfY,
-                 double * padfZ, double * padfM )
+                 const int * panPartStart, const int * panPartType,
+                 int nVertices, const double * padfX, const double * padfY,
+                 const double * padfZ, const double * padfM )
 {
     SHPObject *psObject;
     int  i, bHasM, bHasZ;

--- a/contrib/brl/b3p/shapelib/shptree.c
+++ b/contrib/brl/b3p/shapelib/shptree.c
@@ -255,8 +255,8 @@ SHPDestroyTree( SHPTree * psTree )
 /************************************************************************/
 
 int SHPAPI_CALL
-SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
-                       double * padfBox2Min, double * padfBox2Max,
+SHPCheckBoundsOverlap( const double * padfBox1Min, const double * padfBox1Max,
+                       const double * padfBox2Min, const double * padfBox2Max,
                        int nDimension )
 {
     int  iDim;
@@ -280,7 +280,7 @@ SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
 /************************************************************************/
 
 static int SHPCheckObjectContained( SHPObject * psObject, int nDimension,
-                           double * padfBoundsMin, double * padfBoundsMax )
+                           const double * padfBoundsMin, const double * padfBoundsMax )
 {
     if( psObject->dfXMin < padfBoundsMin[0]
         || psObject->dfXMax > padfBoundsMax[0] )

--- a/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
+++ b/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.cxx
@@ -369,7 +369,7 @@ void CreateWedgeHistograms(vil_image_view<vxl_byte>& image, double *mask,
 
 
 //: compute the optimal orientation and edge strength from the vector of edge strengths computed at discrete orientations
-void compute_strength_and_orient(double* dist, int n_orient, float& strength, double& orientation)
+void compute_strength_and_orient(const double* dist, int n_orient, float& strength, double& orientation)
 {
   double wedgesize = vnl_math::pi/n_orient;
 

--- a/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.h
+++ b/contrib/brl/bbas/bil/algo/bil_compass_edge_detector.h
@@ -29,7 +29,7 @@ inline double CArea(double Xhigh, double Xlow, double Y, double r);
 double* MakeQtrMask(double r, int n_wedges);
 
 //: compute the optimal orientation and edge strength from the vector of edge strengths computed at discrete orientations
-void compute_strength_and_orient(double* dist, int n_orient, float& strength, double& orientation);
+void compute_strength_and_orient(const double* dist, int n_orient, float& strength, double& orientation);
 
 typedef struct bin_struct
 {

--- a/contrib/brl/bbas/bil/algo/bil_nms.cxx
+++ b/contrib/brl/bbas/bil/algo/bil_nms.cxx
@@ -250,7 +250,7 @@ void bil_nms::get_relative_corner_coordinates(int face_num, int *corners)
   }
 }
 
-double bil_nms::subpixel_s(double *s, double *f, double &max_f, double &max_d)
+double bil_nms::subpixel_s(const double *s, const double *f, double &max_f, double &max_d)
 {
   // new version: assumes s[1]=0 and s[2]=-s[0]
   double A = -(f[1] - (f[0]+f[2])/2.0)/(s[2]*s[2]);

--- a/contrib/brl/bbas/bil/algo/bil_nms.h
+++ b/contrib/brl/bbas/bil/algo/bil_nms.h
@@ -121,7 +121,7 @@ class bil_nms
   // get the corners related to the given face
   void get_relative_corner_coordinates(int face_num, int *corners);
   // used for 3 points parabola fit
-  double subpixel_s(double *s, double *f, double & max_f, double &max_d);
+  double subpixel_s(const double *s, const double *f, double & max_f, double &max_d);
   // used for 9 points parabola fit
   double subpixel_s(int x, int y, const vgl_vector_2d<double>& direction, double &max_f);
   void find_distance_s_and_f_for_point(int x, int y, vgl_homg_line_2d<double> line,

--- a/contrib/brl/bbas/bjson/bjsoncpp.cxx
+++ b/contrib/brl/bbas/bjson/bjsoncpp.cxx
@@ -177,7 +177,7 @@ static inline void uintToString(LargestUInt value, char*& current) {
  * We had a sophisticated way, but it did not work in WinCE.
  * @see https://github.com/open-source-parsers/jsoncpp/pull/9
  */
-static inline void fixNumericLocale(char* begin, char* end) {
+static inline void fixNumericLocale(char* begin, const char* end) {
   while (begin < end) {
     if (*begin == ',') {
       *begin = '.';
@@ -186,7 +186,7 @@ static inline void fixNumericLocale(char* begin, char* end) {
   }
 }
 
-static inline void fixNumericLocaleInput(char* begin, char* end) {
+static inline void fixNumericLocaleInput(char* begin, const char* end) {
   char decimalPoint = getDecimalPoint();
   if (decimalPoint != '\0' && decimalPoint != '.') {
     while (begin < end) {

--- a/contrib/brl/bbas/volm/volm_buffered_index.cxx
+++ b/contrib/brl/bbas/volm/volm_buffered_index.cxx
@@ -207,7 +207,7 @@ bool volm_buffered_index::add_to_index(std::vector<uchar>& values)
 }
 
 //: caller is responsible to pass a valid array of size layer_size
-bool volm_buffered_index::add_to_index(uchar* values)
+bool volm_buffered_index::add_to_index(const uchar* values)
 {
   if (m_ == READ) {
     std::cout << "index object is in READ mode! cannot add to index!\n";

--- a/contrib/brl/bbas/volm/volm_buffered_index.h
+++ b/contrib/brl/bbas/volm/volm_buffered_index.h
@@ -81,7 +81,7 @@ class volm_buffered_index : public vbl_ref_count
     //  caller is responsible to keep the ordering consistent with the hypotheses ordering
     bool add_to_index(std::vector<uchar>& values);
     //: caller is responsible to pass a valid array of size layer_size
-    bool add_to_index(uchar* values);
+    bool add_to_index(const uchar* values);
 
     //: retrieve the next index, use the active_cache, if all on the active_cache has been retrieved, read from disc
     //  caller is responsible to resize values array to layer_size before passing to this method

--- a/contrib/brl/bseg/boxm/util/boxm_quad_scan_iterator.cxx
+++ b/contrib/brl/bseg/boxm/util/boxm_quad_scan_iterator.cxx
@@ -141,7 +141,7 @@ float boxm_quad_scan_iterator::pix_coverage(int x)
 }
 
 bool
-boxm_quad_scan_iterator:: x_start_end_val(double * vals,double & start_val,double & end_val)
+boxm_quad_scan_iterator:: x_start_end_val(const double * vals,double & start_val,double & end_val)
 {
   int * chainnum=VXL_NULLPTR;
   int * vertnum=VXL_NULLPTR;

--- a/contrib/brl/bseg/boxm/util/boxm_quad_scan_iterator.h
+++ b/contrib/brl/bseg/boxm/util/boxm_quad_scan_iterator.h
@@ -41,7 +41,7 @@ class boxm_quad_scan_iterator : public vgl_region_scan_iterator
   //: returns the amount of pixel at location x in the current scanline covered by the triangle
   float pix_coverage(int x);
 
-  bool x_start_end_val(double * vals,double & start_val,double & end_val);
+  bool x_start_end_val(const double * vals,double & start_val,double & end_val);
 
 
  protected:

--- a/contrib/brl/bseg/boxm/util/boxm_triangle_scan_iterator.cxx
+++ b/contrib/brl/bseg/boxm/util/boxm_triangle_scan_iterator.cxx
@@ -9,7 +9,7 @@
 
 
 //: constructor
-boxm_triangle_scan_iterator::boxm_triangle_scan_iterator(double *verts_x, double *verts_y, unsigned int v0, unsigned int v1, unsigned int v2)
+boxm_triangle_scan_iterator::boxm_triangle_scan_iterator(const double *verts_x, const double *verts_y, unsigned int v0, unsigned int v1, unsigned int v2)
 : tri_it_()
 {
   tri_it_.a.x = verts_x[v0] - 0.5;

--- a/contrib/brl/bseg/boxm/util/boxm_triangle_scan_iterator.h
+++ b/contrib/brl/bseg/boxm/util/boxm_triangle_scan_iterator.h
@@ -14,7 +14,7 @@ class boxm_triangle_scan_iterator : public vgl_region_scan_iterator
 {
  public:
   //: constructor
-  boxm_triangle_scan_iterator(double *verts_x, double *verts_y, unsigned int v0 = 0, unsigned int v1 = 1, unsigned int v2 = 2);
+  boxm_triangle_scan_iterator(const double *verts_x, const double *verts_y, unsigned int v0 = 0, unsigned int v1 = 1, unsigned int v2 = 2);
 
   //: Resets the scan iterator to before the first scan line
   //  After calling this function, next() needs to be called before

--- a/contrib/brl/bseg/boxm/util/boxm_utils.cxx
+++ b/contrib/brl/bseg/boxm/util/boxm_utils.cxx
@@ -141,7 +141,7 @@ boxm_utils::project_point3d(vgl_point_3d<double> const& point,
 }
 
 //: corners of the input face: visible?
-bool boxm_utils::is_face_visible(double * xverts, double *yverts,
+bool boxm_utils::is_face_visible(const double * xverts, const double *yverts,
                                  unsigned id1,unsigned id2,unsigned id3,unsigned id4) // id4 unused?!? - FIXME
 {
   double normal=(xverts[id2]-xverts[id1])*(yverts[id3]-yverts[id2])-(yverts[id2]-yverts[id1])*(xverts[id3]-xverts[id2]);

--- a/contrib/brl/bseg/boxm/util/boxm_utils.h
+++ b/contrib/brl/bseg/boxm/util/boxm_utils.h
@@ -47,7 +47,7 @@ class boxm_utils
                               vpgl_camera_double_sptr const& camera);
 
   //:
-  static bool is_face_visible(double * xverts, double *yerts,
+  static bool is_face_visible(const double * xverts, const double *yerts,
                               unsigned id1,unsigned id2,unsigned id3,unsigned id4);
 
   //: returns the visible faces of a box given a camera.

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.cxx
@@ -182,7 +182,7 @@ bool boxm2_merge_block_function::merge(std::vector<boxm2_data_base*>& datas)
 // so no tree_buffer information is needed, whereas the data is modified
 // on the global level, so buffers, offsets are used
 /////////////////////////////////////////////////////////////////
-boct_bit_tree boxm2_merge_block_function::merge_bit_tree(boct_bit_tree& unrefined_tree, float* alphas, float prob_thresh)
+boct_bit_tree boxm2_merge_block_function::merge_bit_tree(boct_bit_tree& unrefined_tree, const float* alphas, float prob_thresh)
 {
   //initialize tree to return
   boct_bit_tree merged_tree(unrefined_tree.get_bits(), max_level_);
@@ -262,7 +262,7 @@ boct_bit_tree boxm2_merge_block_function::merge_bit_tree(boct_bit_tree& unrefine
 //       data[dataIndex++] = old_data[unrefined_tree.data_ptr(bit)];
 int boxm2_merge_block_function::move_data( boct_bit_tree& old_tree,
                                            boct_bit_tree& merged_tree,
-                                           float*  alpha,
+                                           const float*  alpha,
                                            uchar8* mog,
                                            ushort4* num_obs,
                                            float*  alpha_cpy,

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.h
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_merge_block_function.h
@@ -33,12 +33,12 @@ class boxm2_merge_block_function
   bool merge(std::vector<boxm2_data_base*>& datas);
 
   //: refine bit tree
-  boct_bit_tree merge_bit_tree(boct_bit_tree& curr_tree, float* alphas, float prob_thresh);
+  boct_bit_tree merge_bit_tree(boct_bit_tree& curr_tree, const float* alphas, float prob_thresh);
 
   //: move data into new location
   int move_data( boct_bit_tree& unrefined_tree,
                  boct_bit_tree& merged_tree,
-                 float*   alpha,
+                 const float*   alpha,
                  uchar8*  mog,
                  ushort4* num_obs,
                  float*   alpha_cpy,

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.cxx
@@ -212,7 +212,7 @@ bocl_kernel* boxm2_ocl_paint_batch::compile_kernels( bocl_device_sptr device,
 }
 
 
-void boxm2_ocl_paint_batch::weighted_mean_var(float* obs, float* vis, int numSamples, float& mean, float& var)
+void boxm2_ocl_paint_batch::weighted_mean_var(const float* obs, const float* vis, int numSamples, float& mean, float& var)
 {
   var = 0.0f, mean = 0.0f;
   if (numSamples == 0)

--- a/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.h
+++ b/contrib/brl/bseg/boxm2/ocl/algo/boxm2_ocl_paint_batch.h
@@ -36,7 +36,7 @@ class boxm2_ocl_paint_batch
     //map of paint kernel by device
     static std::map<std::string, bocl_kernel*> kernels_;
 
-    static void weighted_mean_var(float* obs, float* vis, int numSamples, float& mean, float& var);
+    static void weighted_mean_var(const float* obs, const float* vis, int numSamples, float& mean, float& var);
 };
 
 #endif // boxm2_ocl_paint_batch_h_

--- a/contrib/brl/bseg/boxm2/ocl/pro/tests/test_filter_kernel.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/pro/tests/test_filter_kernel.cxx
@@ -35,7 +35,7 @@
 #include <brdb/brdb_value.h>
 
 
-void print_probs(boxm2_block* blk, float* alphas, boxm2_block_metadata data, int /*dataSize*/)
+void print_probs(boxm2_block* blk, const float* alphas, boxm2_block_metadata data, int /*dataSize*/)
 {
   //print in 3x3
   typedef vnl_vector_fixed<unsigned char, 16> uchar16;
@@ -76,7 +76,7 @@ void print_probs(boxm2_block* blk, float* alphas, boxm2_block_metadata data, int
   }
 }
 
-void print_alphas(boxm2_block* blk, float* alphas, boxm2_block_metadata /*data*/, int /*dataSize*/)
+void print_alphas(boxm2_block* blk, const float* alphas, boxm2_block_metadata /*data*/, int /*dataSize*/)
 {
   //print in 3x3
   typedef vnl_vector_fixed<unsigned char, 16> uchar16;

--- a/contrib/brl/bseg/boxm2/ocl/tests/boxm2_ocl_test_utils.cxx
+++ b/contrib/brl/bseg/boxm2/ocl/tests/boxm2_ocl_test_utils.cxx
@@ -187,7 +187,7 @@ void boxm2_ocl_test_utils::clean_up()
 }
 char* boxm2_ocl_test_utils::construct_block_test_stream(int numBuffers,
                                                     int treeLen,
-                                                    int* nums,
+                                                    const int* nums,
                                                     double* dims,
                                                     int init_level,
                                                     int max_level,

--- a/contrib/brl/bseg/boxm2/ocl/tests/boxm2_ocl_test_utils.h
+++ b/contrib/brl/bseg/boxm2/ocl/tests/boxm2_ocl_test_utils.h
@@ -20,7 +20,7 @@ class boxm2_ocl_test_utils
 public:
     static char* construct_block_test_stream( int numBuffers,
                                               int treeLen,
-                                              int* nums,
+                                              const int* nums,
                                               double* dims,
                                               int init_level,
                                               int max_level,

--- a/contrib/brl/bseg/boxm2/pro/processes/boxm2_export_textured_mesh_process.cxx
+++ b/contrib/brl/bseg/boxm2/pro/processes/boxm2_export_textured_mesh_process.cxx
@@ -55,8 +55,8 @@ namespace boxm2_export_textured_mesh_process_globals
   //checks if a triangle in UV space is visible.  us and vs are double buffers of length 3
   bool face_is_visible( vpgl_perspective_camera<double>* cam,
                         vil_image_view<int>* vis_img,
-                        double* us,
-                        double* vs,
+                        const double* us,
+                        const double* vs,
                         int face_id);
 }
 
@@ -435,8 +435,8 @@ void boxm2_export_textured_mesh_process_globals::boxm2_texture_mesh_from_imgs(st
 
 bool boxm2_export_textured_mesh_process_globals::face_is_visible( vpgl_perspective_camera<double>* cam,
                                                                   vil_image_view<int>* vis_img,
-                                                                  double* us,
-                                                                  double* vs,
+                                                                  const double* us,
+                                                                  const double* vs,
                                                                   int face_id)
 {
   //now create a polygon, and find the integer image coordinates (U,V) that this polygon covers

--- a/contrib/brl/bseg/boxm2/tests/test_utils.cxx
+++ b/contrib/brl/bseg/boxm2/tests/test_utils.cxx
@@ -11,7 +11,7 @@ const double boxm2_test_utils::dims_[] = {0.5,0.5,0.5,0};
 
 char* boxm2_test_utils::construct_block_test_stream(int numBuffers,
                                                     int treeLen,
-                                                    int* nums,
+                                                    const int* nums,
                                                     double* dims,
                                                     int init_level,
                                                     int max_level,

--- a/contrib/brl/bseg/boxm2/tests/test_utils.h
+++ b/contrib/brl/bseg/boxm2/tests/test_utils.h
@@ -17,7 +17,7 @@ class boxm2_test_utils
     //: creates a valid, though predictable block byte stream
     static char* construct_block_test_stream( int numBuffers,
                                               int treeLen,
-                                              int* nums,
+                                              const int* nums,
                                               double* dims,
                                               int init_level,
                                               int max_level,

--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.cxx
@@ -26,7 +26,7 @@ void boxm2_vecf_articulated_scene::clear_target(boxm2_scene_sptr target_scene){
   alpha_db->set_default_value(alpha_prefix, m_data);
 
 }
-  double boxm2_vecf_articulated_scene::interp_generic_double(vgl_point_3d<double>* neighbors, double* probs, vgl_point_3d<double> p ){
+  double boxm2_vecf_articulated_scene::interp_generic_double(vgl_point_3d<double>* neighbors, const double* probs, vgl_point_3d<double> p ){
 
   double dx00 = LERP(probs[0],probs[2],  p.x(),neighbors[0].x(),neighbors[2].x()); // interp   between (x0,y0,z0) and (x1,y0,z0)
   double dx10 = LERP(probs[1],probs[3],  p.x(),neighbors[1].x(),neighbors[3].x()); // interp   between (x0,y1,z0) and (x1,y1,z0)

--- a/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.h
+++ b/contrib/brl/bseg/boxm2/vecf/boxm2_vecf_articulated_scene.h
@@ -68,7 +68,7 @@ class boxm2_vecf_articulated_scene : public vbl_ref_count{
   std::string color_apm_id() {return color_apm_id_;}
 
   static  double8 interp_generic_double8(vgl_point_3d<double>* neighbors, double8* probs, vgl_point_3d<double> p );
-  static  double interp_generic_double(vgl_point_3d<double>* neighbors, double* probs, vgl_point_3d<double> p );
+  static  double interp_generic_double(vgl_point_3d<double>* neighbors, const double* probs, vgl_point_3d<double> p );
   double8 to_double8(color_APM& apm){
     double8 apm_f; apm_f.fill(0);
     apm_f[0] = (double) apm[0]; apm_f[1] =(double) apm[1] ; apm_f[2] =(double) apm[2];

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.cxx
@@ -1653,8 +1653,8 @@ bool boxm2_volm_matcher_p1::transfer_weight()
 
 bool boxm2_volm_matcher_p1::volm_matcher_p1_test_ori(unsigned n_ind,
                                                      unsigned char* index,
-                                                     unsigned char* index_ori,
-                                                     unsigned char* index_lnd,
+                                                     const unsigned char* index_ori,
+                                                     const unsigned char* index_lnd,
                                                      float* score_buff,
                                                      float* mu_buff)
 {

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.h
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_matcher_p1.h
@@ -230,8 +230,8 @@ class boxm2_volm_matcher_p1
   //: a test function to check the kernel implementation
   bool volm_matcher_p1_test_ori(unsigned n_ind,
                                 unsigned char* index,
-                                unsigned char* index_ori,
-                                unsigned char* index_lnd,
+                                const unsigned char* index_ori,
+                                const unsigned char* index_lnd,
                                 float* score_buff,
                                 float* mu_buff);
 };

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.cxx
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.cxx
@@ -176,7 +176,7 @@ bool boxm2_volm_wr3db_index::add_to_index(std::vector<uchar>& values)
 }
 
 //: caller is responsible to pass a valid array of size layer_size
-bool boxm2_volm_wr3db_index::add_to_index(uchar* values)
+bool boxm2_volm_wr3db_index::add_to_index(const uchar* values)
 {
   if (m_ == READ) {
     std::cout << "index object is in READ mode! cannot add to index!\n";

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.h
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.h
@@ -92,7 +92,7 @@ class boxm2_volm_wr3db_index : public vbl_ref_count
     //  caller is responsible to keep the ordering consistent with the hypotheses ordering
     bool add_to_index(std::vector<uchar>& values);
     //: caller is responsible to pass a valid array of size layer_size
-    bool add_to_index(uchar* values);
+    bool add_to_index(const uchar* values);
 
     //: retrieve the next index, use the active_cache, if all on the active_cache has been retrieved, read from disc
     //  caller is responsible to resize values array to layer_size before passing to this method

--- a/contrib/brl/bseg/bstm/cpp/algo/bstm_analyze_coherency_function.cxx
+++ b/contrib/brl/bseg/bstm/cpp/algo/bstm_analyze_coherency_function.cxx
@@ -4,7 +4,7 @@
 #include <vgl/vgl_intersection.h>
 
 bstm_analyze_coherency_function::bstm_analyze_coherency_function(bstm_block* blk, bstm_block_metadata blk_data, bstm_time_block* blk_t, bstm_data_traits<BSTM_MOG6_VIEW_COMPACT>::datatype *apps,
-                                       bstm_data_traits<BSTM_ALPHA>::datatype * alphas, double init_local_time, double end_local_time, vgl_box_3d<double> box, float p_threshold,
+                                       const bstm_data_traits<BSTM_ALPHA>::datatype * alphas, double init_local_time, double end_local_time, vgl_box_3d<double> box, float p_threshold,
                                        std::ofstream &output_file)
 
 {

--- a/contrib/brl/bseg/bstm/cpp/algo/bstm_analyze_coherency_function.h
+++ b/contrib/brl/bseg/bstm/cpp/algo/bstm_analyze_coherency_function.h
@@ -31,7 +31,7 @@ class bstm_analyze_coherency_function
 
    //: "default" constructor does all the work
    bstm_analyze_coherency_function(bstm_block* blk, bstm_block_metadata blk_data, bstm_time_block* blk_t, bstm_data_traits<BSTM_MOG6_VIEW_COMPACT>::datatype *app,
-                                       bstm_data_traits<BSTM_ALPHA>::datatype * alpha, double init_local_time, double end_local_time, vgl_box_3d<double> box,
+                                       const bstm_data_traits<BSTM_ALPHA>::datatype * alpha, double init_local_time, double end_local_time, vgl_box_3d<double> box,
                                        float p_threshold, std::ofstream & output_file);
 
 };

--- a/contrib/brl/bseg/sdet/sdet_nms.cxx
+++ b/contrib/brl/bseg/sdet/sdet_nms.cxx
@@ -305,7 +305,7 @@ void sdet_nms::get_relative_corner_coordinates(int face_num, int *corners)
   }
 }
 
-double sdet_nms::subpixel_s(double *s, double *f, double &max_f, double &max_d)
+double sdet_nms::subpixel_s(const double *s, const double *f, double &max_f, double &max_d)
 {
   //double A = f[2] / ((s[2]-s[0])*(s[2]-s[1]));
   //double B = f[1] / ((s[1]-s[0])*(s[1]-s[2]));

--- a/contrib/brl/bseg/sdet/sdet_nms.h
+++ b/contrib/brl/bseg/sdet/sdet_nms.h
@@ -146,7 +146,7 @@ class sdet_nms
   // get the corners related to the given face
   void get_relative_corner_coordinates(int face_num, int *corners);
   // used for 3 points parabola fit
-  double subpixel_s(double *s, double *f, double & max_f, double &max_d);
+  double subpixel_s(const double *s, const double *f, double & max_f, double &max_d);
   // used for 9 points parabola fit
   double subpixel_s(int x, int y, const vgl_vector_2d<double>& direction, double &max_f);
   void find_distance_s_and_f_for_point(int x, int y, vgl_homg_line_2d<double> line,

--- a/contrib/brl/bseg/sdet/sdet_nonmax_suppression.cxx
+++ b/contrib/brl/bseg/sdet/sdet_nonmax_suppression.cxx
@@ -401,7 +401,7 @@ void sdet_nonmax_suppression::get_relative_corner_coordinates(int face_num, int 
   }
 }
 
-double sdet_nonmax_suppression::subpixel_s(double *s, double *f)
+double sdet_nonmax_suppression::subpixel_s(const double *s, const double *f)
 {
   double A = f[2] / ((s[2]-s[0])*(s[2]-s[1]));
   double B = f[1] / ((s[1]-s[0])*(s[1]-s[2]));

--- a/contrib/brl/bseg/sdet/sdet_nonmax_suppression.h
+++ b/contrib/brl/bseg/sdet/sdet_nonmax_suppression.h
@@ -109,7 +109,7 @@ class sdet_nonmax_suppression : public sdet_nonmax_suppression_params
   // get the corners related to the given face
   void get_relative_corner_coordinates(int face_num, int *corners);
   // used for 3 points parabola fit
-  double subpixel_s(double *s, double *f);
+  double subpixel_s(const double *s, const double *f);
   // used for 9 points parabola fit
   double subpixel_s(int x, int y, vgl_vector_2d<double> direction);
   void find_distance_s_and_f_for_point(int x, int y, vgl_homg_line_2d<double> line,

--- a/contrib/gel/gevd/gevd_float_operators.cxx
+++ b/contrib/gel/gevd/gevd_float_operators.cxx
@@ -2101,7 +2101,7 @@ gevd_float_operators::ShrinkBy2AlongX_D(const gevd_bufferxy& from,
                                         int from_sizeX,
                                         int sizeX,
                                         int y,
-                                        float kernel[],
+                                        const float kernel[],
                                         float no_value,
                                         float* yline,
                                         float* wline )

--- a/contrib/gel/gevd/gevd_float_operators.h
+++ b/contrib/gel/gevd/gevd_float_operators.h
@@ -329,7 +329,7 @@ class gevd_float_operators
                                float* yline, const int len,
                                const float ka, const float kb, const float kc);
   static void ShrinkBy2AlongX_D( const gevd_bufferxy& from, int from_sizeX,
-                                 int sizeX, int y, float kernel[],
+                                 int sizeX, int y, const float kernel[],
                                  float no_value, float* yline, float* wline );
   static float ExpandBy2AlongX(const gevd_bufferxy& cfrom, const int y,
                                float* yline, const int len,

--- a/contrib/gel/gevd/gevd_memory_mixin.cxx
+++ b/contrib/gel/gevd/gevd_memory_mixin.cxx
@@ -129,7 +129,7 @@ gevd_memory_mixin::ReadBytes(void* ib, int b, int loc)
 }
 
 int
-gevd_memory_mixin::ReadBytes(void* ib, int b, int* mapping)
+gevd_memory_mixin::ReadBytes(void* ib, int b, const int* mapping)
 {
   if ((ib == VXL_NULLPTR) || !(GetStatusCode()&MM_READ))
     return 0;
@@ -150,7 +150,7 @@ gevd_memory_mixin::ReadBytes(void* ib, int b, int* mapping)
 //: Read b bytes from loc to ib, thru mapping.  New @ 6/11/91 gbs
 //====================================================================
 int
-gevd_memory_mixin::ReadBytes(void* ib, int b, int loc, int* mapping)
+gevd_memory_mixin::ReadBytes(void* ib, int b, int loc, const int* mapping)
 {
   if ((ib == VXL_NULLPTR) || !(GetStatusCode()&MM_READ))
     return 0;

--- a/contrib/gel/gevd/gevd_memory_mixin.h
+++ b/contrib/gel/gevd/gevd_memory_mixin.h
@@ -117,8 +117,8 @@ class gevd_memory_mixin : public gevd_status_mixin
   //
   int  ReadBytes(void* ib, int b);
   int  ReadBytes(void* ib, int b, int loc);
-  int  ReadBytes(void* ib, int b, int* mapping);
-  int  ReadBytes(void* ib, int b, int loc, int* mapping);
+  int  ReadBytes(void* ib, int b, const int* mapping);
+  int  ReadBytes(void* ib, int b, int loc, const int* mapping);
   int  WriteBytes(const void* ib, int b);
   int  WriteBytes(const void* ib, int b, int loc);
   void Clear();

--- a/contrib/mul/vil3d/tests/test_save_load_image.cxx
+++ b/contrib/mul/vil3d/tests/test_save_load_image.cxx
@@ -32,7 +32,7 @@
 template <class T>
 bool test_image_equal(char const* type_name,
                       vil3d_image_view<T> const & image,
-                      float voxel_size[3],
+                      const float voxel_size[3],
                       vil3d_image_resource_sptr const& pimage2,
                       bool exact = true)
 {

--- a/contrib/oxl/osl/osl_canny_ox.cxx
+++ b/contrib/oxl/osl/osl_canny_ox.cxx
@@ -496,7 +496,7 @@ int osl_canny_ox::Get_n_edgels_hysteresisOX(osl_edgel_chain *&edgels_NMS,
 void osl_canny_ox::Get_hysteresis_edgelsOX(osl_edgel_chain *& edgels_NMS,
                                            int *&status,
                                            osl_edgel_chain *& edgels_Hysteresis,
-                                           int *x_, int *y_)
+                                           const int *x_, const int *y_)
 {
   // Initialise thin_ to zero's
   osl_canny_base_fill_raw_image(thin_, xsize_, ysize_, 0.0f);

--- a/contrib/oxl/osl/osl_canny_ox.h
+++ b/contrib/oxl/osl/osl_canny_ox.h
@@ -65,7 +65,7 @@ class osl_canny_ox : public osl_canny_base
   void Add_linkOX(int,int,osl_LINK *[]);
   void Link_edgelsOX(std::vector<unsigned> const &, std::vector<unsigned> const &,osl_LINK *[]);
   int Get_n_edgels_hysteresisOX(osl_edgel_chain *&,int *&);
-  void Get_hysteresis_edgelsOX(osl_edgel_chain *&,int *&, osl_edgel_chain *&, int *x_, int *y_);
+  void Get_hysteresis_edgelsOX(osl_edgel_chain *&,int *&, osl_edgel_chain *&, const int *x_, const int *y_);
   void Delete_linksOX(osl_LINK **, int);
   osl_edge *NO_FollowerOX(osl_edgel_chain *);
 

--- a/core/vgl/algo/tests/test_h_matrix_3d.cxx
+++ b/core/vgl/algo/tests/test_h_matrix_3d.cxx
@@ -28,7 +28,7 @@
 #include <vgl/algo/vgl_h_matrix_3d_compute_affine.h>
 #include <vnl/vnl_det.h>
 
-static bool equals(double x[16], double y[16])
+static bool equals(const double x[16], const double y[16])
 {
   for (int i=0; i<12; ++i) if (x[i] != y[i]) return false;
   return true;

--- a/core/vgl/algo/tests/test_p_matrix.cxx
+++ b/core/vgl/algo/tests/test_p_matrix.cxx
@@ -30,7 +30,7 @@ static double d(double x0, double x1, double y0, double y1)
   return std::sqrt((x0-x1)*(x0-x1) + (y0-y1)*(y0-y1));
 }
 
-static bool equals(double x[12], double y[12])
+static bool equals(const double x[12], const double y[12])
 {
   for (int i=0; i<12; ++i) if (x[i] != y[i]) return false;
   return true;

--- a/core/vgui/internals/trackball.c
+++ b/core/vgui/internals/trackball.c
@@ -304,7 +304,7 @@ normalize_quat(float q[4])
  *
  */
 void
-build_rotmatrix(float m[4][4], float q[4])
+build_rotmatrix(float m[4][4], const float q[4])
 {
     m[0][0] = 1.0f - 2.0f * (q[1] * q[1] + q[2] * q[2]);
     m[0][1] = 2.0f * (q[0] * q[1] - q[2] * q[3]);

--- a/core/vgui/internals/trackball.h
+++ b/core/vgui/internals/trackball.h
@@ -72,7 +72,7 @@ add_quats(const float *q1, const float *q2, float *dest);
  * given quaternion.
  */
 void
-build_rotmatrix(float m[4][4], float q[4]);
+build_rotmatrix(float m[4][4], const float q[4]);
 
 /*
  * This function computes a quaternion based on an axis (defined by

--- a/core/vil/file_formats/vil_tiff.cxx
+++ b/core/vil/file_formats/vil_tiff.cxx
@@ -1033,7 +1033,7 @@ bool vil_tiff_image::write_block_to_file(unsigned bi, unsigned bj,
 // Just support packing of bool data for now
 // ultimately we need the opposite of maybe_byte_align_data
 void vil_tiff_image::bitpack_block(unsigned bytes_per_block,
-                                   vxl_byte* in_block_buf,
+                                   const vxl_byte* in_block_buf,
                                    vxl_byte* out_block_buf)
 {
   unsigned bytes_per_bool = sizeof(bool);

--- a/core/vil/file_formats/vil_tiff.h
+++ b/core/vil/file_formats/vil_tiff.h
@@ -309,7 +309,7 @@ class vil_tiff_image : public vil_blocked_image_resource
                             vxl_byte*& block_buf);
 
   void bitpack_block(unsigned bytes_per_block,
-                     vxl_byte* in_block_buf,
+                     const vxl_byte* in_block_buf,
                      vxl_byte* out_block_buf);
 
   bool write_block_to_file(unsigned bi, unsigned bj,

--- a/core/vil/vil_stream_url.cxx
+++ b/core/vil/vil_stream_url.cxx
@@ -46,7 +46,7 @@ char base64_encoding[]=
 
 static char out_buf[4];
 
-static const char * encode_triplet(char data[3], unsigned n)
+static const char * encode_triplet(const char data[3], unsigned n)
 {
   assert (n>0 && n <4);
   out_buf[0] = base64_encoding[(data[0] & 0xFC) >> 2];

--- a/core/vnl/algo/vnl_lsqr.cxx
+++ b/core/vnl/algo/vnl_lsqr.cxx
@@ -88,7 +88,7 @@ vnl_lsqr::~vnl_lsqr()
 }
 
 // Requires number_of_residuals() of workspace in rw.
-int vnl_lsqr::aprod_(long* mode, long* m, long* n, double* x, double* y, long* /*leniw*/, long* /*lenrw*/, long* /*iw*/, double* rw, void* userdata)
+int vnl_lsqr::aprod_(const long* mode, const long* m, const long* n, double* x, double* y, long* /*leniw*/, long* /*lenrw*/, long* /*iw*/, double* rw, void* userdata)
 {
   //
   // THIS CODE IS DEPRECATED

--- a/core/vnl/algo/vnl_lsqr.h
+++ b/core/vnl/algo/vnl_lsqr.h
@@ -74,7 +74,7 @@ class VNL_ALGO_EXPORT vnl_lsqr
   double result_norm_;
   long return_code_;
 
-  static int aprod_(long* mode, long* m, long* n, double* x, double* y,
+  static int aprod_(const long* mode, const long* m, const long* n, double* x, double* y,
                     long* leniw, long* lenrw, long* iw, double* rw,
                     void* userdata);
 };

--- a/core/vnl/tests/basic_operation_timings.cxx
+++ b/core/vnl/tests/basic_operation_timings.cxx
@@ -17,7 +17,7 @@
 const unsigned nstests = 10;
 
 
-void fill_with_rng(double * begin, double * end, double a, double b, vnl_random &rng)
+void fill_with_rng(double * begin, const double * end, double a, double b, vnl_random &rng)
 {
   while (begin != end)
   {
@@ -26,7 +26,7 @@ void fill_with_rng(double * begin, double * end, double a, double b, vnl_random 
   }
 }
 
-void fill_with_rng(float * begin, float * end, float a, float b, vnl_random &rng)
+void fill_with_rng(float * begin, const float * end, float a, float b, vnl_random &rng)
 {
   while (begin != end)
   {

--- a/core/vnl/tests/test_matlab.cxx
+++ b/core/vnl/tests/test_matlab.cxx
@@ -32,7 +32,7 @@
 // get a byte-swapped file, short of reading in a native file and swapping it
 // and writing it back out, and that isn't any easier.
 void matlab_write_swapped(std::ostream &f,
-                          float *array,
+                          const float *array,
                           unsigned size,
                           char const *name)
 {

--- a/core/vnl/vnl_random.cxx
+++ b/core/vnl/vnl_random.cxx
@@ -89,7 +89,7 @@ void vnl_random::reseed(unsigned long seed)
   for (int j=0;j<1000;j++) lrand32();
 }
 
-void vnl_random::reseed(unsigned long seed[vnl_random_array_size])
+void vnl_random::reseed(const unsigned long seed[vnl_random_array_size])
 {
   mz_array_position = 0UL;
   mz_borrow = 0L;

--- a/core/vnl/vnl_random.h
+++ b/core/vnl/vnl_random.h
@@ -81,7 +81,7 @@ class VNL_EXPORT vnl_random
     void reseed(unsigned long);
 
     //: Starts a new deterministic sequence from an already declared generator using the provided seed.
-    void reseed(unsigned long[vnl_random_array_size]);
+    void reseed(const unsigned long[vnl_random_array_size]);
 
     //: This restarts the sequence of random numbers.
     //  Restarts so that it repeats

--- a/core/vul/vul_psfile.cxx
+++ b/core/vul/vul_psfile.cxx
@@ -227,7 +227,7 @@ void vul_psfile::set_min_max_xy(int x, int y)
 //-----------------------------------------------------------------------------
 //: Write 8 bit grey scale image.
 //-----------------------------------------------------------------------------
-void vul_psfile::print_greyscale_image(unsigned char* buffer, int sizex, int sizey)
+void vul_psfile::print_greyscale_image(const unsigned char* buffer, int sizex, int sizey)
 {
   if (debug)
     std::cout << "vul_psfile::print_greyscale_image, width = " << sizex
@@ -326,7 +326,7 @@ void vul_psfile::print_greyscale_image(unsigned char* buffer, int sizex, int siz
 //-----------------------------------------------------------------------------
 //: Write 24 bit colour image.
 //-----------------------------------------------------------------------------
-void vul_psfile::print_color_image(unsigned char* data, int sizex, int sizey)
+void vul_psfile::print_color_image(const unsigned char* data, int sizex, int sizey)
 {
   if (debug)
     std::cout << "vul_psfile::print_color_image, width = " << sizex

--- a/core/vul/vul_psfile.h
+++ b/core/vul/vul_psfile.h
@@ -54,9 +54,9 @@ class vul_psfile: public std::ofstream
   float line_width() const { return line_width_; }
 
   //: Write 8 bit grey scale image.
-  void print_greyscale_image(unsigned char* data, int sizex, int sizey);
+  void print_greyscale_image(const unsigned char* data, int sizex, int sizey);
   //: Write 24 bit colour image.
-  void print_color_image(unsigned char* data, int sizex, int sizey);
+  void print_color_image(const unsigned char* data, int sizex, int sizey);
 
   //:  Add a line between the given points to the Postscript file.
   void line(float x1, float y1, float x2, float y2);


### PR DESCRIPTION
Passing pointers that are not changed in a function should use the const version of the pointer.

When const is used properly, many mistakes can be avoided. Advantages
    when using const properly:
    
     * prevent unintentional modification of data;
     * get additional warnings such as using uninitialized data;
     * make it easier for developers to see possible side effects.
