### PR TITLE
COMP: Simplify compiler compatiblility checking

### DIFF
--- a/contrib/mul/vil3d/vil3d_print.h
+++ b/contrib/mul/vil3d/vil3d_print.h
@@ -13,7 +13,7 @@
 #include <vil3d/vil3d_image_view.h>
 #include <vcl_compiler.h>
 
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 #  pragma warning( push )
 #  pragma warning( disable: 4244 )  // conversion from ptrdiff_t to int, possible loss of data
 #endif
@@ -50,7 +50,7 @@ inline void vil3d_print_all(std::ostream& os,const vil3d_image_view<T>& view)
   }
 }
 
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 #  pragma warning( pop )
 #endif
 

--- a/contrib/rpl/rgrl/rgrl_macros.h
+++ b/contrib/rpl/rgrl/rgrl_macros.h
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <vcl_compiler.h>
 
-#if defined(VCL_VC_DOTNET) || defined(VCL_GCC)
+#if defined(VCL_VC) || defined(VCL_GCC)
 # define RGRL_HERE __FUNCTION__
 #else
 # define RGRL_HERE __FILE__

--- a/core/doc/book/appendix_build.texi
+++ b/core/doc/book/appendix_build.texi
@@ -459,7 +459,7 @@ are in @file{$VXLSRC/config/cmake/Modules/}.
 @itemx @bullet{} Preprocessor: @code{VCL_WIN32} (@file{vcl_compiler.h}, included by each @file{vcl_*.h} file)
 The Windows API is available.  Keep in mind that @code{WIN32} is
 defined under Cygwin, so it does not imply use of MSVC++.  Make sure
-you don't really want @code{HAS_MFC} or @code{VCL_VC} (@code{VCL_VC_DOTNET}) instead.
+you don't really want @code{HAS_MFC} or @code{VCL_VC} instead.
 
 @item  @bullet{} CMake: @code{UNIX} (defined by CMake, not in a file)
 @itemx @bullet{} Preprocessor: system dependent

--- a/core/tests/make_test_config.pl
+++ b/core/tests/make_test_config.pl
@@ -167,25 +167,9 @@ for $var_exp (
   'VXL_UNISTD_USLEEP_IS_VOID',
   'VXL_HAS_IEEEFP_H',
 
-  # from vcl_compiler.h
-  'VCL_GCC',
-  'VCL_GCC_4',
-  'VCL_GCC_40',
-  'VCL_GCC_41',
-  'VCL_GCC_5',
-  'VCL_GCC_50',
-  'VCL_GCC_51',
-  'VCL_GCC_52',
-  'VCL_GCC_53',
-  'VCL_GCC_6',
-  'VCL_GCC_60',
-  'VCL_GCC_61',
-  'VCL_GCC_62',
-  'VCL_GCC_63',
   'VCL_ICC',
   'VCL_WIN32',
   'VCL_VC',
-  'VCL_VC_DOTNET',
 
   # from VXL CMake configuration files
   'VXL_WARN_DEPRECATED',

--- a/core/tests/test_config.cxx
+++ b/core/tests/test_config.cxx
@@ -918,110 +918,6 @@ void test_config()
 #endif
   std::cout << std::endl;
 
-  std::cout << "VCL_GCC_4 ";
-#ifdef VCL_GCC_4
-  std::cout << "is set to " << quote(VCL_GCC_4);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_40 ";
-#ifdef VCL_GCC_40
-  std::cout << "is set to " << quote(VCL_GCC_40);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_41 ";
-#ifdef VCL_GCC_41
-  std::cout << "is set to " << quote(VCL_GCC_41);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_5 ";
-#ifdef VCL_GCC_5
-  std::cout << "is set to " << quote(VCL_GCC_5);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_50 ";
-#ifdef VCL_GCC_50
-  std::cout << "is set to " << quote(VCL_GCC_50);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_51 ";
-#ifdef VCL_GCC_51
-  std::cout << "is set to " << quote(VCL_GCC_51);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_52 ";
-#ifdef VCL_GCC_52
-  std::cout << "is set to " << quote(VCL_GCC_52);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_53 ";
-#ifdef VCL_GCC_53
-  std::cout << "is set to " << quote(VCL_GCC_53);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_6 ";
-#ifdef VCL_GCC_6
-  std::cout << "is set to " << quote(VCL_GCC_6);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_60 ";
-#ifdef VCL_GCC_60
-  std::cout << "is set to " << quote(VCL_GCC_60);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_61 ";
-#ifdef VCL_GCC_61
-  std::cout << "is set to " << quote(VCL_GCC_61);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_62 ";
-#ifdef VCL_GCC_62
-  std::cout << "is set to " << quote(VCL_GCC_62);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_GCC_63 ";
-#ifdef VCL_GCC_63
-  std::cout << "is set to " << quote(VCL_GCC_63);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
   std::cout << "VCL_ICC ";
 #ifdef VCL_ICC
   std::cout << "is set to " << quote(VCL_ICC);
@@ -1041,14 +937,6 @@ void test_config()
   std::cout << "VCL_VC ";
 #ifdef VCL_VC
   std::cout << "is set to " << quote(VCL_VC);
-#else
-  std::cout << "is not set";
-#endif
-  std::cout << std::endl;
-
-  std::cout << "VCL_VC_DOTNET ";
-#ifdef VCL_VC_DOTNET
-  std::cout << "is set to " << quote(VCL_VC_DOTNET);
 #else
   std::cout << "is not set";
 #endif

--- a/core/vgl/Templates/vgl_homg_point_2d+uint-.cxx
+++ b/core/vgl/Templates/vgl_homg_point_2d+uint-.cxx
@@ -1,9 +1,9 @@
 // Disable warning
 #include <vcl_compiler.h>
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 // Instantiation of vgl_homg_point_2d<unsigned>
 #include <vgl/vgl_homg_point_2d.hxx>

--- a/core/vgl/Templates/vgl_point_2d+uint-.cxx
+++ b/core/vgl/Templates/vgl_point_2d+uint-.cxx
@@ -1,9 +1,9 @@
 // Disable warning
 #include <vcl_compiler.h>
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 // Instantiation of vgl_point_2d<unsigned>
 #include <vgl/vgl_point_2d.hxx>

--- a/core/vgl/Templates/vgl_vector_2d+uint-.cxx
+++ b/core/vgl/Templates/vgl_vector_2d+uint-.cxx
@@ -1,9 +1,9 @@
 // Disable warning
 #include <vcl_compiler.h>
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 // Instantiation of vgl_vector_2d<unsigned int>
 #include <vgl/vgl_vector_2d.hxx>

--- a/core/vgl/Templates/vgl_vector_3d+uint-.cxx
+++ b/core/vgl/Templates/vgl_vector_3d+uint-.cxx
@@ -1,9 +1,9 @@
 // Disable warning
 #include <vcl_compiler.h>
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 // Instantiation of vgl_vector_3d<unsigned int>
 #include <vgl/vgl_vector_3d.hxx>

--- a/core/vnl/Templates/vnl_c_vector+uchar-.cxx
+++ b/core/vnl/Templates/vnl_c_vector+uchar-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_c_vector.h>
 #include <vnl/vnl_c_vector.hxx>

--- a/core/vnl/Templates/vnl_c_vector+uint-.cxx
+++ b/core/vnl/Templates/vnl_c_vector+uint-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_c_vector.h>
 #include <vnl/vnl_c_vector.hxx>

--- a/core/vnl/Templates/vnl_c_vector+ulong-.cxx
+++ b/core/vnl/Templates/vnl_c_vector+ulong-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_c_vector.h>
 #include <vnl/vnl_c_vector.hxx>

--- a/core/vnl/Templates/vnl_c_vector+ulonglong-.cxx
+++ b/core/vnl/Templates/vnl_c_vector+ulonglong-.cxx
@@ -1,10 +1,10 @@
 #include <vcl_compiler.h>
 #if VCL_HAS_LONG_LONG
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_c_vector.h>
 #include <vnl/vnl_c_vector.hxx>

--- a/core/vnl/Templates/vnl_matrix+uchar-.cxx
+++ b/core/vnl/Templates/vnl_matrix+uchar-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_matrix.hxx>
 VNL_MATRIX_INSTANTIATE(unsigned char);

--- a/core/vnl/Templates/vnl_matrix+uint-.cxx
+++ b/core/vnl/Templates/vnl_matrix+uint-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_matrix.hxx>
 VNL_MATRIX_INSTANTIATE(unsigned int);

--- a/core/vnl/Templates/vnl_matrix+ulong-.cxx
+++ b/core/vnl/Templates/vnl_matrix+ulong-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_matrix.hxx>
 VNL_MATRIX_INSTANTIATE(unsigned long);

--- a/core/vnl/Templates/vnl_matrix+ulonglong-.cxx
+++ b/core/vnl/Templates/vnl_matrix+ulonglong-.cxx
@@ -1,10 +1,10 @@
 #include <vcl_compiler.h>
 #if VCL_HAS_LONG_LONG
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_matrix.hxx>
 VNL_MATRIX_INSTANTIATE(unsigned long long);

--- a/core/vnl/Templates/vnl_vector+uchar-.cxx
+++ b/core/vnl/Templates/vnl_vector+uchar-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_vector.hxx>
 VNL_VECTOR_INSTANTIATE(unsigned char);

--- a/core/vnl/Templates/vnl_vector+uint-.cxx
+++ b/core/vnl/Templates/vnl_vector+uint-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_vector.hxx>
 VNL_VECTOR_INSTANTIATE(unsigned int);

--- a/core/vnl/Templates/vnl_vector+ulong-.cxx
+++ b/core/vnl/Templates/vnl_vector+ulong-.cxx
@@ -1,9 +1,9 @@
 #include <vcl_compiler.h>
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_vector.hxx>
 VNL_VECTOR_INSTANTIATE(unsigned long);

--- a/core/vnl/Templates/vnl_vector+ulonglong-.cxx
+++ b/core/vnl/Templates/vnl_vector+ulonglong-.cxx
@@ -1,10 +1,10 @@
 #include <vcl_compiler.h>
 #if VCL_HAS_LONG_LONG
 // Disable warning
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 // 4146: unary minus operator applied to unsigned type, result still unsigned
 # pragma warning(disable:4146)
-#endif //VCL_VC_DOTNET
+#endif //VCL_VC
 
 #include <vnl/vnl_vector.hxx>
 VNL_VECTOR_INSTANTIATE(unsigned long long);

--- a/core/vsl/vsl_binary_io.h
+++ b/core/vsl/vsl_binary_io.h
@@ -318,7 +318,7 @@ inline void vsl_print_summary(std::ostream& os, const char* s )
 //             to be used. A new version of MS .NET compiler required this change.
 //             Add compilers as needed. This could be moved to vcl_compiler.h.
 //             [Nils Krahnstoever]
-#ifdef VCL_VC_DOTNET
+#ifdef VCL_VC
 # define VCL_64BIT_ATTR __w64
 #else
 # define VCL_64BIT_ATTR /* */

--- a/vcl/tests/test_preprocessor.cxx
+++ b/vcl/tests/test_preprocessor.cxx
@@ -13,57 +13,6 @@ int test_preprocessor_main(int /*argc*/,char* /*argv*/[])
   ++compiler_count;
 #endif
 
-#ifdef VCL_GCC_4
-  ++major_count;
-#endif
-#ifdef VCL_GCC_40
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_41
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_42
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_43
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_44
-  ++minor_count;
-#endif
-
-#ifdef VCL_GCC_5
-  ++major_count;
-#endif
-#ifdef VCL_GCC_50
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_51
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_52
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_53
-  ++minor_count;
-#endif
-
-#ifdef VCL_GCC_6
-  ++major_count;
-#endif
-#ifdef VCL_GCC_60
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_61
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_62
-  ++minor_count;
-#endif
-#ifdef VCL_GCC_63
-  ++minor_count;
-#endif
-
 #ifdef VCL_VC
   ++compiler_count;
 #endif

--- a/vcl/vcl_compiler.h
+++ b/vcl/vcl_compiler.h
@@ -7,12 +7,6 @@
 // It's much better to determine the compiler automatically here than to depend
 // on command-line flags being set.
 //
-// Be careful when modifying this file. In general, you need to make
-// sure that exactly one of the preprocessor flags is defined. For
-// example, if the compiler is GCC 5.3.0, then VCL_GCC should be
-// defined, VCL_GCC_5 should be defined, and VCL_GCC_53 should be
-// defined. Others, like VCL_GCC_51 *should not* be defined.
-//
 // Note that this is most commonly implemented using a cascade of if
 // statements. Be careful to add your statements to the correct place
 // in the cascade list.
@@ -45,80 +39,41 @@
 #if defined(__GNUC__) && !defined(__ICC) // icc 8.0 defines __GNUC__
 # define VCL_GCC
 # if (__GNUC__ < 4)
-#  error "forget it."
-# elif (__GNUC__==4)
-#  define VCL_GCC_4
-#  if (__GNUC_MINOR__ > 0 )
-#   define VCL_GCC_41
-#  else
-#   define VCL_GCC_40
-#  endif
-# elif (__GNUC__==5)
-#  define VCL_GCC_5
-#  if (__GNUC_MINOR__ > 2 )
-#   define VCL_GCC_53
-#  elif (__GNUC_MINOR__ > 1 )
-#   define VCL_GCC_52
-#  elif (__GNUC_MINOR__ > 0 )
-#   define VCL_GCC_51
-#  else
-#   define VCL_GCC_50
-#  endif
-# elif (__GNUC__==6)
-#  define VCL_GCC_6
-#  if (__GNUC_MINOR__ > 2 )
-#   define VCL_GCC_63
-#  elif (__GNUC_MINOR__ > 1 )
-#   define VCL_GCC_62
-#  elif (__GNUC_MINOR__ > 0 )
-#   define VCL_GCC_61
-#  else
-#   define VCL_GCC_60
-#  endif
-# elif (__GNUC__==7)
-#  define VCL_GCC_7
-#  if (__GNUC_MINOR__ > 2 )
-#   define VCL_GCC_73
-#  elif (__GNUC_MINOR__ > 1 )
-#   define VCL_GCC_72
-#  elif (__GNUC_MINOR__ > 0 )
-#   define VCL_GCC_71
-#  else
-#   define VCL_GCC_70
-#  endif
-# elif (__GNUC__==8)
-#  define VCL_GCC_8
-#  if (__GNUC_MINOR__ > 2 )
-#   define VCL_GCC_83
-#  elif (__GNUC_MINOR__ > 1 )
-#   define VCL_GCC_82
-#  elif (__GNUC_MINOR__ > 0 )
-#   define VCL_GCC_81
-#  else
-#   define VCL_GCC_80
-#  endif
-# else
-#  error "Dunno about this gcc"
+#  error "Invalid VCL_GCC version not supported."
 # endif
+#define VCL_GCC_4  "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_40 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_41 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_42 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_43 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_5  "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_50 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_51 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_52 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_53 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_6  "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_60 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_61 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_62 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_63 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_7  "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_70  "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_71 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_GCC_72 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
 #endif
 
 #if defined(_WIN32) || defined(WIN32)
 # define VCL_WIN32
 # if defined(_MSC_VER)
 #  define VCL_VC
-#  define VCL_VC_DOTNET 1 // VC is at least version >= 7.0
-
-// In future use VCL_VC_13_1 for 13.1, etc.
-#  if _MSC_VER >= 1700     // Visual Studio 2011 = Version 11.x
-#   define VCL_VC_11
-#  elif _MSC_VER >= 1600     // Visual Studio 2010 = Version 10.x
-#   define VCL_VC_10
-#  elif _MSC_VER >= 1500     // Visual Studio 2008 = Version 9.x
-#   define VCL_VC_9
-#  else
+#  if _MSC_VER < 1500     // Visual Studio 2008 = Version 9.x
 #   error "Invalid VCL_VC version"
 #  endif
 # endif
+#define VCL_VC_DOTNET "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_VC_9 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_VC_10 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
+#define VCL_VC_11 "VXL no longer supplies aliases for compiler versions, use the compiler defines directly"
 #endif
 
 // win32 or vc++ ?


### PR DESCRIPTION
VXL compiler version checking required that each compiler version
be independantly added to an explicit list approved compilers.

Additionally a set of unused defines for each known version of
the compiler was created.

This patch simplifies the maintenance of VXL by only listing
compilers versions that are known to not work (i.e. do not provide
sufficient language feature support).

Unused defines are re-purposed to explicitly cause compiler errors
if incorrectly by third party developers.