### PR TITLE
mbl_cloneables_factory: split into def and implementaiton

### DIFF
--- a/contrib/mul/clsfy/Templates/mbl_cloneables_factory+clsfy_builder_1d-.cxx
+++ b/contrib/mul/clsfy/Templates/mbl_cloneables_factory+clsfy_builder_1d-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <clsfy/clsfy_builder_1d.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(clsfy_builder_1d);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/clsfy/Templates/mbl_cloneables_factory+clsfy_builder_base-.cxx
+++ b/contrib/mul/clsfy/Templates/mbl_cloneables_factory+clsfy_builder_base-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <clsfy/clsfy_builder_base.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(clsfy_builder_base);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mbl/CMakeLists.txt
+++ b/contrib/mul/mbl/CMakeLists.txt
@@ -84,6 +84,7 @@ set(mbl_sources
   mbl_chord.h
   mbl_chord_3d.h
   mbl_cloneable_ptr.h
+  mbl_cloneables_factory_def.h
   mbl_cloneables_factory.h
   mbl_combination.h
   mbl_draw_line.h

--- a/contrib/mul/mbl/mbl_cloneables_factory.h
+++ b/contrib/mul/mbl/mbl_cloneables_factory.h
@@ -1,117 +1,43 @@
 // This is mul/mbl/mbl_cloneables_factory.h
 #ifndef mbl_cloneables_factory_h
 #define mbl_cloneables_factory_h
-//:
-//  \file
-// \brief A general factory pattern.
-// \author Ian Scott.
 
-#include <iostream>
-#include <map>
-#include <vcl_memory.h>
-#include <string>
-#include <sstream>
-#include <vcl_compiler.h>
-#include <mbl/mbl_exception.h>
-#include <mbl/mbl_cloneable_ptr.h>
-#include <mbl/mbl_export.h>
-
-//=======================================================================
-//: A general factory pattern.
-// After templating this on a base class, and loading in
-// a bunch of concrete instantiations of the derived classes,
-// you can create any of the derived classes simply from
-// the class's name.
-//
-// BASE must define a clone() and is_a() members
-// \code
-// class BASE
-// {
-//   ...
-// public:
-//   virtual BASE* clone() const=0; // Derived classes must copy themselves.
-//   virtual std::string BASE::is_a() const; {
-//     return "BASE";} // Derived classes need unique names.
-// }
-// \endcode
-//
-// Example:
-// \code
-// mbl_cloneables_factory<vimt_image>::add(vimt_image_2d());
-// mbl_cloneables_factory<vimt_image>::add(vimt_image_3d());
-//
-// vcl_unique_ptr<vimt_image> p = mbl_cloneables_factory<vimt_image>::get_clone("vimt_image_2d()");
-// assert(dynamic_cast<vimt_image_2d>(p));
-// \endcode
-
+#include "mbl_cloneables_factory_def.h"
 
 template <class BASE>
-class mbl_cloneables_factory
+void mbl_cloneables_factory<BASE>::add(const BASE & object)
 {
- private:
-  //: Singleton array of names, and association concrete instantiations of BASE.
-  typedef std::map<std::string, mbl_cloneable_ptr<BASE> > MAP;
+  add(object, object.is_a());
+}
 
- private:
+template <class BASE>
+void mbl_cloneables_factory<BASE>::add(const BASE & object, const std::string & name)
+{
+  objects()[name] = object;
+}
 
-  //: Get singleton instance.
-  static MAP &objects();
+template <class BASE>
+vcl_unique_ptr<BASE > mbl_cloneables_factory<BASE>::get_clone(const std::string & name)
+{
+  typedef typename MAP::const_iterator IT;
 
- public:
+  IT found = objects().find(name);
+  const IT end = objects().end();
 
-  //: Add an object for later cloning by the factory.
-  // Use the object's class name via the is_a() member.
-  static void add(const BASE & object) { add(object, object.is_a()); }
-
-  //: Add an object for later cloning by the factory.
-  // If there already is an object called name, it will
-  // be overwritten.
-  static void add(const BASE & object, const std::string & name)
+  if (found == end)
   {
-    objects()[name] = object;
-  }
-
-  //: Get a pointer to a new copy of the object identified by name.
-  // An exception will be thrown if name does not exist.
-  static vcl_unique_ptr<BASE > get_clone(const std::string & name)
-  {
-    typedef typename MAP::const_iterator IT;
-
-    IT found = objects().find(name);
-    const IT end = objects().end();
-
-    if (found == end)
+    std::ostringstream ss;
+    IT it = objects().begin();
+    if (!objects().empty())
     {
-      std::ostringstream ss;
-      IT it = objects().begin();
-      if (!objects().empty())
-      {
-        ss << it->first;
-        while ( ++it != end)
-          ss << ", " << it->first;
-      }
-      mbl_exception_error(mbl_exception_no_name_in_factory(name, ss.str()));
-      return vcl_unique_ptr<BASE >();
+      ss << it->first;
+      while ( ++it != end)
+        ss << ", " << it->first;
     }
-    return vcl_unique_ptr<BASE >(found->second->clone());
+    mbl_exception_error(mbl_exception_no_name_in_factory(name, ss.str()));
+    return vcl_unique_ptr<BASE >();
   }
-};
-
-// Macro to instantiate template, and initialise singleton data item.
-// Should only be called once in any library suite - usually near where
-// the baseclass (T) is defined.
-// Arrange that the static objects_ thing only exists in the one place this
-// is called.
-#define MBL_CLONEABLES_FACTORY_INSTANTIATE(T) \
-template class mbl_cloneables_factory< T >; \
-template<>\
-  std::map<std::string, mbl_cloneable_ptr<T > >& mbl_cloneables_factory< T >::objects() \
-  { \
-    static vcl_unique_ptr<std::map<std::string, mbl_cloneable_ptr<T > > > objects_; \
-    if (objects_.get() == VXL_NULLPTR) \
-      objects_.reset(new MAP); \
-    return *objects_; \
-  }
-
+  return vcl_unique_ptr<BASE >(found->second->clone());
+}
 
 #endif  // mbl_cloneables_factory_h

--- a/contrib/mul/mbl/mbl_cloneables_factory_def.h
+++ b/contrib/mul/mbl/mbl_cloneables_factory_def.h
@@ -1,0 +1,93 @@
+// This is mul/mbl/mbl_cloneables_factory_def.h
+#ifndef mbl_cloneables_factory_def_h
+#define mbl_cloneables_factory_def_h
+//:
+//  \file
+// \brief A general factory pattern.
+// \author Ian Scott.
+
+#include <iostream>
+#include <map>
+#include <vcl_memory.h>
+#include <string>
+#include <sstream>
+#include <vcl_compiler.h>
+#include <mbl/mbl_exception.h>
+#include <mbl/mbl_cloneable_ptr.h>
+#include <mbl/mbl_export.h>
+
+//=======================================================================
+//: A general factory pattern.
+// After templating this on a base class, and loading in
+// a bunch of concrete instantiations of the derived classes,
+// you can create any of the derived classes simply from
+// the class's name.
+//
+// BASE must define a clone() and is_a() members
+// \code
+// class BASE
+// {
+//   ...
+// public:
+//   virtual BASE* clone() const=0; // Derived classes must copy themselves.
+//   virtual std::string BASE::is_a() const; {
+//     return "BASE";} // Derived classes need unique names.
+// }
+// \endcode
+//
+// Example:
+// \code
+// mbl_cloneables_factory<vimt_image>::add(vimt_image_2d());
+// mbl_cloneables_factory<vimt_image>::add(vimt_image_3d());
+//
+// vcl_unique_ptr<vimt_image> p = mbl_cloneables_factory<vimt_image>::get_clone("vimt_image_2d()");
+// assert(dynamic_cast<vimt_image_2d>(p));
+// \endcode
+
+
+template <class BASE>
+class mbl_cloneables_factory
+{
+ private:
+  //: Singleton array of names, and association concrete instantiations of BASE.
+  typedef std::map<std::string, mbl_cloneable_ptr<BASE> > MAP;
+
+ private:
+
+  //: Get singleton instance.
+  static MAP &objects();
+
+ public:
+
+  //: Add an object for later cloning by the factory.
+  // Use the object's class name via the is_a() member.
+  static void add(const BASE & object);
+
+  //: Add an object for later cloning by the factory.
+  // If there already is an object called name, it will
+  // be overwritten.
+  static void add(const BASE & object, const std::string & name);
+
+  //: Get a pointer to a new copy of the object identified by name.
+  // An exception will be thrown if name does not exist.
+  static vcl_unique_ptr<BASE > get_clone(const std::string & name);
+};
+
+// Macro to instantiate template, and initialise singleton data item.
+// Should only be called once in any library suite - usually near where
+// the baseclass (T) is defined.
+// Arrange that the static objects_ thing only exists in the one place this
+// is called.
+#define MBL_CLONEABLES_FACTORY_INSTANTIATE(T) \
+template class mbl_cloneables_factory< T >; \
+template<>\
+  std::map<std::string, mbl_cloneable_ptr<T > >& mbl_cloneables_factory< T >::objects() \
+  { \
+    static vcl_unique_ptr<std::map<std::string, mbl_cloneable_ptr<T > > > objects_; \
+    if (objects_.get() == VXL_NULLPTR) \
+      objects_.reset(new MAP); \
+    return *objects_; \
+  }
+
+
+#endif  // mbl_cloneables_factory_def_h

--- a/contrib/mul/mbl/tests/test_cloneables_factory.cxx
+++ b/contrib/mul/mbl/tests/test_cloneables_factory.cxx
@@ -1,5 +1,5 @@
 // This is mul/mbl/tests/test_cloneables_factory.cxx
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <testlib/testlib_test.h>
 
 
@@ -29,6 +29,7 @@ class mbl_test_cf_B : public mbl_test_cf_base
 
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mbl_test_cf_base);
 
+#include <mbl/mbl_cloneables_factory.h>
 
 void test_cloneables_factory()
 {

--- a/contrib/mul/mcal/Templates/mbl_cloneables_factory+mcal_component_analyzer-.cxx
+++ b/contrib/mul/mcal/Templates/mbl_cloneables_factory+mcal_component_analyzer-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mcal/mcal_component_analyzer.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mcal_component_analyzer);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mcal/Templates/mbl_cloneables_factory+mcal_single_basis_cost-.cxx
+++ b/contrib/mul/mcal/Templates/mbl_cloneables_factory+mcal_single_basis_cost-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mcal/mcal_single_basis_cost.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mcal_single_basis_cost);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_point_finder-.cxx
+++ b/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_point_finder-.cxx
@@ -1,3 +1,4 @@
 #include <mfpf/mfpf_point_finder.h>
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mfpf_point_finder);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_point_finder_builder-.cxx
+++ b/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_point_finder_builder-.cxx
@@ -1,4 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mfpf/mfpf_point_finder_builder.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mfpf_point_finder_builder);
-
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_region_definer-.cxx
+++ b/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_region_definer-.cxx
@@ -1,4 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mfpf/mfpf_region_definer.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mfpf_region_definer);
-
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_vec_cost_builder-.cxx
+++ b/contrib/mul/mfpf/Templates/mbl_cloneables_factory+mfpf_vec_cost_builder-.cxx
@@ -1,4 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mfpf/mfpf_vec_cost_builder.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mfpf_vec_cost_builder);
-
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mipa/Templates/mbl_cloneables_factory+mipa_vector_normaliser-.cxx
+++ b/contrib/mul/mipa/Templates/mbl_cloneables_factory+mipa_vector_normaliser-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mipa/mipa_vector_normaliser.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mipa_vector_normaliser);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/mmn/Templates/mbl_cloneables_factory+mmn_solver-.cxx
+++ b/contrib/mul/mmn/Templates/mbl_cloneables_factory+mmn_solver-.cxx
@@ -1,4 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <mmn/mmn_solver.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(mmn_solver);
-
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/msm/Templates/mbl_cloneables_factory+msm_aligner-.cxx
+++ b/contrib/mul/msm/Templates/mbl_cloneables_factory+msm_aligner-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <msm/msm_aligner.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(msm_aligner);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/msm/Templates/mbl_cloneables_factory+msm_param_limiter-.cxx
+++ b/contrib/mul/msm/Templates/mbl_cloneables_factory+msm_param_limiter-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <msm/msm_param_limiter.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(msm_param_limiter);
+#include <mbl/mbl_cloneables_factory.h>

--- a/contrib/mul/vpdfl/Templates/mbl_cloneables_factory+vpdfl_builder_base-.cxx
+++ b/contrib/mul/vpdfl/Templates/mbl_cloneables_factory+vpdfl_builder_base-.cxx
@@ -1,3 +1,4 @@
-#include <mbl/mbl_cloneables_factory.h>
+#include <mbl/mbl_cloneables_factory_def.h>
 #include <vpdfl/vpdfl_builder_base.h>
 MBL_CLONEABLES_FACTORY_INSTANTIATE(vpdfl_builder_base);
+#include <mbl/mbl_cloneables_factory.h>


### PR DESCRIPTION
The use of the MBL_CLONEABLES_FACTORY_INSTANTIATE() macro after the
implementation of mbl_cloneables_factory was causing the compilation error
"error: explicit specialization of 'objects' after instantiation". Breaking
the definition and implementation into two files fixes this issue.