### PR TITLE
Update remaining references to clipper.h

### DIFF
--- a/config/cmake/Modules/FindClipper.cmake
+++ b/config/cmake/Modules/FindClipper.cmake
@@ -30,7 +30,7 @@ if( NOT CLIPPER_FOUND )
   # exist.
   #
   if( NOT CLIPPER_FOUND )
-    if(EXISTS ${VXL_ROOT_SOURCE_DIR}/v3p/clipper/clipper.h)
+    if(EXISTS ${VXL_ROOT_SOURCE_DIR}/v3p/clipper/clipper.hxx)
       set( CLIPPER_FOUND "YES" )
       set( CLIPPER_INCLUDE_DIR ${clipper_BINARY_DIR} ${clipper_SOURCE_DIR})
       set( CLIPPER_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_DIR}/include/vxl/v3p/clipper)

--- a/core/vgl/vgl_clip.hxx
+++ b/core/vgl/vgl_clip.hxx
@@ -142,7 +142,7 @@ namespace {
 
 #elif HAS_CLIPPER
 
-#include <clipper.h>
+#include <clipper.hxx>
 
 namespace {
   //: Creates a Clipper polygon from a vgl_polygon.


### PR DESCRIPTION
As per commits 90d6285 and 206f426, clipper.h was renamed to clipper.hxx.  Change remaining clipper.h references to clipper.hxx. 