### PR TITLE
COMP: fixing warning CMAKE_REQUIRED_LIBRARIES is set to: ;m

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,9 @@ foreach(p
     ## Only policies introduced after the cmake_minimum_required
     ## version need to explicitly be set to NEW.
 
-    ##----- Policies Introduced by CMake 3.10¶
+    ##----- Policies Introduced by CMake 3.12
+    CMP0075  #: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
+    ##----- Policies Introduced by CMake 3.10
     CMP0071  #: Let AUTOMOC and AUTOUIC process GENERATED files.
     CMP0070  #: Define file(GENERATE) behavior for relative paths.
     ##----- Policies Introduced by CMake 3.9


### PR DESCRIPTION
Excerpt from configure log with CMake 3.12.0:

Looking for srand48
Looking for srand48 - found
Check if the system is big endian
Searching 16 bit integer
Looking for sys/types.h
CMake Warning (dev) at /usr/local/share/cmake-3.12/Modules/CheckIncludeFile.cmake:70 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    ;m

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.12/Modules/CheckTypeSize.cmake:225 (check_include_file)
  /usr/local/share/cmake-3.12/Modules/TestBigEndian.cmake:32 (CHECK_TYPE_SIZE)
  config/cmake/config/VXLIntrospectionConfig.cmake:675 (TEST_BIG_ENDIAN)
  CMakeLists.txt:209 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

Looking for sys/types.h - found
Looking for stdint.h
Looking for stdint.h - found