### PR TITLE
COMP: proper fix of warning regarding CMP0075

### DIFF
--- a/config/cmake/config/VXLIntrospectionConfig.cmake
+++ b/config/cmake/config/VXLIntrospectionConfig.cmake
@@ -651,7 +651,7 @@ endif()
 
 # Tests of math.h may need math library on UNIX.
 if(UNIX)
-  set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES};m")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES m)
 endif()
 
 # Check C++ <cmath> first, where the C++11 standard says these must be.
@@ -671,6 +671,10 @@ PERFORM_C_CHECK_FUNCTION(finite "ieeefp.h" VXL_IEEEFP_HAS_FINITE)
 PERFORM_C_CHECK_FUNCTION(lrand48 "stdlib.h" VXL_STDLIB_HAS_LRAND48)
 PERFORM_C_CHECK_FUNCTION(drand48 "stdlib.h" VXL_STDLIB_HAS_DRAND48)
 PERFORM_C_CHECK_FUNCTION(srand48 "stdlib.h" VXL_STDLIB_HAS_SRAND48)
+
+if(UNIX)
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES m)
+endif()
 
 TEST_BIG_ENDIAN(VXL_BIG_ENDIAN)
 SET_INVERT(VXL_LITTLE_ENDIAN "${VXL_BIG_ENDIAN}")


### PR DESCRIPTION
Complete error message as it appears in ITK upon
first configuration in a clean build directory:

CMake Warning (dev) at /Applications/CMake.app/Contents/share/cmake-3.12/Modules/CheckIncludeFile.cmake:70 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    ;m

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  /Applications/CMake.app/Contents/share/cmake-3.12/Modules/CheckTypeSize.cmake:225 (check_include_file)
  /Applications/CMake.app/Contents/share/cmake-3.12/Modules/TestBigEndian.cmake:32 (CHECK_TYPE_SIZE)
  Modules/ThirdParty/VNL/src/vxl/config/cmake/config/VXLIntrospectionConfig.cmake:675 (TEST_BIG_ENDIAN)
  Modules/ThirdParty/VNL/src/vxl/CMakeLists.txt:211 (include)