### PR TITLE
Options to help create a single VXL library file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,3 +283,5 @@ configure_file( ${VXL_CMAKE_DIR}/CTestCustom.cmake
 if(NOT VXL_NO_EXPORT)
   include(${CMAKE_CURRENT_LIST_DIR}/config/cmake/export/VXLCreateProject.cmake)
 endif()
+
+option(VXL_BUILD_OBJECT_LIBRARIES "Build object libraries (to enable all in a single library)?" OFF)

--- a/contrib/mul/mbl/CMakeLists.txt
+++ b/contrib/mul/mbl/CMakeLists.txt
@@ -129,3 +129,7 @@ if(BUILD_MUL_TOOLS)
   add_subdirectory(tools)
   add_subdirectory(examples)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(mbl-obj OBJECT ${mbl_sources})
+endif()

--- a/contrib/mul/mcal/CMakeLists.txt
+++ b/contrib/mul/mcal/CMakeLists.txt
@@ -28,4 +28,6 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-#add_subdirectory(tools)
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(mcal-obj OBJECT ${mcal_sources})
+endif()

--- a/contrib/mul/msm/CMakeLists.txt
+++ b/contrib/mul/msm/CMakeLists.txt
@@ -54,3 +54,7 @@ endif()
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(msm-obj OBJECT ${msm_sources})
+endif()

--- a/contrib/mul/vimt/CMakeLists.txt
+++ b/contrib/mul/vimt/CMakeLists.txt
@@ -50,3 +50,7 @@ endif()
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vimt-obj OBJECT ${vimt_sources})
+endif()

--- a/contrib/mul/vimt/algo/CMakeLists.txt
+++ b/contrib/mul/vimt/algo/CMakeLists.txt
@@ -16,3 +16,7 @@ target_link_libraries( vimt_algo vimt ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX
 if( BUILD_TESTING )
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vimt_algo-obj OBJECT ${vimt_algo_sources})
+endif()

--- a/core/examples/CMakeLists.txt
+++ b/core/examples/CMakeLists.txt
@@ -1,6 +1,10 @@
-add_executable(  example_create_image_vil
-   create_image_vil.cxx
-)
-target_link_libraries( example_create_image_vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vil )
+if (VXL_VIL_INCLUDE_IMAGE_IO)
+  add_executable( example_create_image_vil create_image_vil.cxx )
+  target_link_libraries( example_create_image_vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vil )
+endif ()
 
 add_subdirectory(vnl_calc)
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_subdirectory(merge_libs)
+endif ()

--- a/core/examples/merge_libs/CMakeLists.txt
+++ b/core/examples/merge_libs/CMakeLists.txt
@@ -1,0 +1,27 @@
+# core/examples/merge_libs
+
+# Create a single library containing targets from (most) core vxl libraries
+add_library(all_vxl_libs $<TARGET_OBJECTS:vcl-obj>
+                     $<TARGET_OBJECTS:vsl-obj>
+                     $<TARGET_OBJECTS:vbl-obj>
+                     $<TARGET_OBJECTS:vbl_io-obj>
+                     $<TARGET_OBJECTS:vgl-obj>
+                     $<TARGET_OBJECTS:vgl_io-obj>
+                     $<TARGET_OBJECTS:vgl_algo-obj>
+                     $<TARGET_OBJECTS:v3p_netlib-obj>
+                     $<TARGET_OBJECTS:vnl-obj>
+                     $<TARGET_OBJECTS:vnl_algo-obj>
+                     $<TARGET_OBJECTS:vnl_io-obj>
+                     $<TARGET_OBJECTS:vul-obj>
+                     $<TARGET_OBJECTS:vil-obj>
+                     $<TARGET_OBJECTS:vil_io-obj>
+                     $<TARGET_OBJECTS:vil_algo-obj>
+                     )
+
+# Check that program that uses a range of vxl classes links using just all_vxl_libs:
+if (NOT VXL_VIL_INCLUDE_IMAGE_IO)
+  # This assumes that no image file format readers (e.g. png, jpg etc) are required,
+  # as they are not currently listed within all_vxl_libs
+  add_executable(example_test_link_all_vxl test_link_all_vxl.cxx)
+  target_link_libraries(example_test_link_all_vxl all_vxl_libs)
+endif ()

--- a/core/examples/merge_libs/merging_libraries.txt
+++ b/core/examples/merge_libs/merging_libraries.txt
@@ -1,0 +1,37 @@
+This directory gives an example of creating a single library file (all_vxl_libs) from multiple individual libraries.
+
+This is useful for creating API's to pass to third parties, in which you need only send a single library file (rather than many individual library files).
+
+It makes use of the options within CMake for OBJECT libraries.
+See: https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/Object-Library
+
+The basic idea is that in the CMakeLists.txt file for each library (say, vbl), you add lines such as:
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vbl-obj OBJECT ${vbl_sources})
+endif ()
+
+You can then combine multiple libraries into one using a CMake command like:
+
+add_library(all_vxl_libs $<TARGET_OBJECTS:vcl-obj>
+                     $<TARGET_OBJECTS:vsl-obj>
+                     $<TARGET_OBJECTS:vbl-obj>
+                     $<TARGET_OBJECTS:vbl_io-obj>
+                     $<TARGET_OBJECTS:vgl-obj> )
+
+
+In the CMakeLists.txt in this directory we combine most of the core libraries into a single library.
+We demonstrate that it works by linking a test programme: test_link_all_vxl.cxx, which calls functions in several of the libraries.
+
+Note: Since the list of libraries doesn't include any image IO libraries (e.g. png, jpg etc) [yet], the test will only compile/link if the flag VXL_VIL_INCLUDE_IMAGE_IO is set to false (OFF).
+
+When the flag is off, vil does not include any of the image loading/saving using standard libraries.
+This simplifies things, and is useful for APIs where all the image I/O will be handled by the caller, outside the API library.
+
+To test this, ensure the following flag settings when you set up the system.
+
+BUILD_SHARED_LIBS:BOOL=OFF
+VXL_VIL_INCLUDE_IMAGE_IO:BOOL=OFF
+VXL_BUILD_OBJECT_LIBRARIES:BOOL=ON
+
+The approach can be extended to include all the libraries one needs for a particular API.

--- a/core/examples/merge_libs/test_link_all_vxl.cxx
+++ b/core/examples/merge_libs/test_link_all_vxl.cxx
@@ -1,0 +1,85 @@
+//:
+// \file
+// \brief Test program using elements of several core libraries.
+// \author Tim Cootes
+
+// Aims to check that everything links properly from a
+// single library containing most vxl/core libraries.
+// (see associated CMakeLists.txt)
+
+#include <iostream>
+#include <vector>
+
+#include <vgl/vgl_point_2d.h>
+#include <vgl/vgl_vector_2d.h>
+#include <vgl/vgl_triangle_3d.h>
+
+#include <vnl/vnl_vector.h>
+#include <vnl/vnl_matrix.h>
+#include <vnl/vnl_inverse.h>
+#include <vnl/algo/vnl_svd.h>
+
+#include <vil/vil_image_view.h>
+#include <vil/vil_transpose.h>
+#include <vxl_config.h>
+#include <vil/algo/vil_histogram.h>
+
+
+int main(int argc, char** argv)
+{
+  std::cout<<"Test elements from vcl (std)"<<std::endl;
+  std::vector<int> a(10);
+  a[3]=7;
+
+  // ========================================================
+  {
+    std::cout<<"Test elements from vgl."<<std::endl;
+
+    vgl_point_2d<double> p(3,7);
+    vgl_vector_2d<double> v(1,2);
+    vgl_point_2d<double> q=p+v;
+
+    // Use the following function as it is not templated (so must be in the library).
+    vgl_point_3d<double> a1(0,0,0), a2(1,0,0), a3(0,1,0);
+
+    double ar=vgl_triangle_3d_aspect_ratio(a1,a2,a3);
+  }
+
+  // ========================================================
+  std::cout<<"Test elements from vnl, vnl_algo"<<std::endl;
+
+  vnl_vector<double> x(10);
+  x.fill(1.0);
+
+  std::cout<<"Sum of elements: "<<x.sum()<<std::endl;
+
+  vnl_matrix<double> A(2,2);
+  A(0,0)=1; A(0,1)=2;
+  A(1,0)=4; A(1,1)=3;
+  std::cout<<"A: \n"<<A<<std::endl;
+
+
+  std::cout<<"Inverse of A: \n"<<vnl_inverse(A)<<std::endl;
+
+  vnl_svd<double> svd(A);
+  std::cout<<"SVD: U\n"<<svd.U()<<std::endl;
+
+  // ========================================================
+  std::cout<<"Test elements from vil, vil_algo"<<std::endl;
+  vil_image_view<float> image(10,10);
+  image.fill(1.0f);
+  image(5,5)=0.5f;
+
+  vil_image_view<float> image2=vil_transpose(image);
+
+  vil_image_view<vxl_byte> image3(20,20);
+  for (unsigned j=0;j<20;++j)
+    for (unsigned i=0;i<20;++i)
+      image3(i,j)=i+j;
+
+  std::vector<double> histo;
+  vil_histogram(image3,histo,0,255,20);
+
+
+  return 0;
+}

--- a/core/vbl/CMakeLists.txt
+++ b/core/vbl/CMakeLists.txt
@@ -54,3 +54,7 @@ endif()
 if( BUILD_TESTING )
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vbl-obj OBJECT ${vbl_sources})
+endif()

--- a/core/vbl/io/CMakeLists.txt
+++ b/core/vbl/io/CMakeLists.txt
@@ -22,3 +22,7 @@ target_link_libraries( ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PR
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vbl_io-obj OBJECT ${vbl_io_sources})
+endif()

--- a/core/vgl/CMakeLists.txt
+++ b/core/vgl/CMakeLists.txt
@@ -117,3 +117,7 @@ endif()
 if( BUILD_TESTING )
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vgl-obj OBJECT ${vgl_sources})
+endif()

--- a/core/vgl/algo/CMakeLists.txt
+++ b/core/vgl/algo/CMakeLists.txt
@@ -52,3 +52,7 @@ target_link_libraries( ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_
 if( BUILD_TESTING )
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vgl_algo-obj OBJECT ${vgl_algo_sources})
+endif()

--- a/core/vgl/io/CMakeLists.txt
+++ b/core/vgl/io/CMakeLists.txt
@@ -34,3 +34,7 @@ target_link_libraries( ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PR
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vgl_io-obj OBJECT ${vgl_io_sources})
+endif()

--- a/core/vgl/xio/CMakeLists.txt
+++ b/core/vgl/xio/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries( ${VXL_LIB_PREFIX}vgl_xio ${VXL_LIB_PREFIX}vgl ${VXL_LIB_P
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vgl_xio-obj OBJECT ${vgl_xio_sources})
+endif()

--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -7,7 +7,17 @@ doxygen_add_library(core/vil
   DESCRIPTION "Core image library"
 )
 
+# By default, vil contains wrappers around various image readers.
+# Setting this flag to OFF enables a version to be built which
+# does not include any third-party I/O functions.
+# This is useful when building APIs where the caller is responsible
+# for loading/saving images, reducing the number of dependencies of the library.
+option(VXL_VIL_INCLUDE_IMAGE_IO "Include image file format readers?" ON)
+
+
 # List of all file_format reader sources.
+# Collected into one list so that we can easily build a version
+# without any image I/O if required (by setting the VXL_VIL_INCLUDE_IMAGE_IO to OFF)
 set( vil_ff_sources
   # file format readers/writers (see below for conditional ones)
   file_formats/vil_pnm.cxx              file_formats/vil_pnm.h
@@ -194,7 +204,6 @@ endif()
 vxl_configure_file( ${CMAKE_CURRENT_LIST_DIR}/vil_config.h.in
                     ${PROJECT_BINARY_DIR}/vil_config.h include/vxl/core/vil)
 
-option(VXL_VIL_INCLUDE_IMAGE_IO "Include image file format readers?" ON)
 
 # Create empty list
 set( vil_sources )

--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -7,161 +7,9 @@ doxygen_add_library(core/vil
   DESCRIPTION "Core image library"
 )
 
-# avoid undefined macro in subsequent SETs:
-set( vil_sources)
-
-include(${VXL_CMAKE_DIR}/FindPNG.cmake)
-if(PNG_FOUND)
-  include_directories( ${PNG_INCLUDE_DIR})
-  add_definitions( ${PNG_DEFINITIONS} )
-  set( HAS_PNG 1 )
-  set( vil_sources ${vil_sources}
-    file_formats/vil_png.cxx file_formats/vil_png.h
-  )
-else()
-  set( HAS_PNG 0 )
-endif()
-
-include(${VXL_CMAKE_DIR}/FindJPEG.cmake)
-if(JPEG_FOUND)
-  include_directories( ${JPEG_INCLUDE_DIR} )
-  set( HAS_JPEG 1 )
-  set( vil_sources ${vil_sources}
-    file_formats/vil_jpeglib.h
-    file_formats/vil_jpeg.cxx                 file_formats/vil_jpeg.h
-    file_formats/vil_jpeg_source_mgr.cxx      file_formats/vil_jpeg_source_mgr.h
-    file_formats/vil_jpeg_decompressor.cxx    file_formats/vil_jpeg_decompressor.h
-    file_formats/vil_jpeg_destination_mgr.cxx file_formats/vil_jpeg_destination_mgr.h
-    file_formats/vil_jpeg_compressor.cxx      file_formats/vil_jpeg_compressor.h
-  )
-else()
-  set( HAS_JPEG 0 )
-endif()
-
-################################
-# JPEG 2000
-################################
-include( ${VXL_CMAKE_DIR}/NewCMake/FindECW.cmake )
-if(ECW_FOUND)
-  set( vil_sources ${vil_sources}
-    file_formats/vil_j2k_image.h           file_formats/vil_j2k_image.cxx
-    file_formats/NCSJPCVilIOStream.h       file_formats/NCSJPCVilIOStream.cxx
-    file_formats/vil_j2k_nitf2_pyramid_image_resource.h
-    file_formats/vil_j2k_nitf2_pyramid_image_resource.cxx
-    file_formats/vil_j2k_pyramid_image_resource.h
-    file_formats/vil_j2k_pyramid_image_resource.cxx
-  )
-  include_directories(${ECW_INCLUDE_DIR})
-  set( HAS_J2K 1 )
-else()
-  set( HAS_J2K 0 )
-endif()
-
-##############################
-# JPEG2000 via OpenJPEG
-##############################
-include( ${VXL_CMAKE_DIR}/FindOpenJPEG2.cmake )
-if(OPENJPEG2_FOUND)
-  include_directories(${OPENJPEG2_INCLUDE_DIR})
-  add_definitions( ${OPENJPEG2_DEFINITIONS} )
-  set( vil_sources ${vil_sources}
-    file_formats/vil_openjpeg.h  file_formats/vil_openjpeg.cxx
-    file_formats/vil_openjpeg_pyramid_image_resource.h
-    file_formats/vil_openjpeg_pyramid_image_resource.cxx
-  )
-  add_definitions( ${OPENJPEG2_DEFINITIONS} )
-  set( HAS_OPENJPEG2 1 )
-else()
-  set( HAS_OPENJPEG2 0 )
-endif()
-
-set( HAS_TIFF 0 )
-set( HAS_GEOTIFF 0 )
-include(${VXL_CMAKE_DIR}/FindTIFF.cmake)
-if(TIFF_FOUND)
-  include_directories(${TIFF_INCLUDE_DIR})
-  set( HAS_TIFF 1 )
-  set( vil_sources ${vil_sources}
-    file_formats/vil_tiff.cxx file_formats/vil_tiff.h
-    file_formats/vil_tiff_header.cxx file_formats/vil_tiff_header.h
-  )
-
-  option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" True)
-  include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)
-  if(GEOTIFF_FOUND)
-    set(HAS_GEOTIFF 1 )
-    include_directories(${GEOTIFF_INCLUDE_DIR})
-    set( vil_sources ${vil_sources}
-      file_formats/vil_geotiff_header.cxx file_formats/vil_geotiff_header.h
-    )
-  endif()
-endif()
-
-# Let users decide if they should include DCMTK since we don't build against all versions.
-option(VXL_USE_DCMTK "" TRUE)
-set( HAS_DCMTK 0 )
-if (VXL_USE_DCMTK)
-  include(${VXL_CMAKE_DIR}/FindDCMTK.cmake)
-  if(DCMTK_FOUND)
-    include_directories(${DCMTK_INCLUDE_DIR})
-    set( HAS_DCMTK 1 )
-    set( vil_sources ${vil_sources}
-      file_formats/vil_dicom.cxx        file_formats/vil_dicom.h
-      file_formats/vil_dicom_stream.cxx file_formats/vil_dicom_stream.h
-      file_formats/vil_dicom_header.cxx file_formats/vil_dicom_header.h
-      )
-  endif()
-endif()
-
-option(VIL_CONFIG_ENABLE_SSE2_ROUNDING
-       "Enable Streaming SIMD Extensions 2 implementation of rounding (hardware dependant)."
-       ${VXL_HAS_SSE2_HARDWARE_SUPPORT} )
-if( VIL_CONFIG_ENABLE_SSE2_ROUNDING )
-  if( NOT VXL_HAS_SSE2_HARDWARE_SUPPORT )
-    if( VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE )
-      message( ${VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE_HELP} )
-    endif()
-    message( SEND_ERROR "Cannot have VIL_CONFIG_ENABLE_SSE2_ROUNDING because"
-                        " there is no SSE2 hardware or no compiler support enabled" )
-    set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 0)
-  endif()
-endif()
-
-
-if(VIL_CONFIG_ENABLE_SSE2_ROUNDING)
-  set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 1)
-else()
-  set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 0)
-endif()
-
-
-# Store the external library configurations in to the config file
-vxl_configure_file( ${CMAKE_CURRENT_LIST_DIR}/vil_config.h.in
-                    ${PROJECT_BINARY_DIR}/vil_config.h include/vxl/core/vil)
-
-set( vil_sources ${vil_sources}
-
-  # basic things
-  vil_memory_chunk.cxx                  vil_memory_chunk.h
-  vil_image_view_base.h
-  vil_chord.h
-  vil_image_view.h                      vil_image_view.hxx
-  vil_image_resource.cxx                vil_image_resource.h
-                                        vil_image_resource_sptr.h
-  vil_blocked_image_resource.cxx        vil_blocked_image_resource.h
-                                        vil_blocked_image_resource_sptr.h
-  vil_blocked_image_facade.cxx          vil_blocked_image_facade.h
-  vil_file_format.cxx                   vil_file_format.h
-  vil_memory_image.cxx                  vil_memory_image.h
-  vil_block_cache.cxx                   vil_block_cache.h
-  vil_cached_image_resource.cxx         vil_cached_image_resource.h
-  vil_pyramid_image_resource.cxx        vil_pyramid_image_resource.h
-                                        vil_pyramid_image_resource_sptr.h
-  vil_pyramid_image_view.hxx            vil_pyramid_image_view.h
-  vil_image_list.cxx                    vil_image_list.h
-  # file format readers/writers (see above for conditional ones)
-
-
+# List of all file_format reader sources.
+set( vil_ff_sources
+  # file format readers/writers (see below for conditional ones)
   file_formats/vil_pnm.cxx              file_formats/vil_pnm.h
 
   file_formats/vil_bmp_file_header.cxx  file_formats/vil_bmp_file_header.h
@@ -215,6 +63,166 @@ set( vil_sources ${vil_sources}
   file_formats/vil_nitf2_typed_field_formatter.h    file_formats/vil_nitf2_typed_field_formatter.cxx
 
   file_formats/vil_pyramid_image_list.h             file_formats/vil_pyramid_image_list.cxx
+)
+
+include(${VXL_CMAKE_DIR}/FindPNG.cmake)
+if(PNG_FOUND)
+  include_directories( ${PNG_INCLUDE_DIR})
+  add_definitions( ${PNG_DEFINITIONS} )
+  set( HAS_PNG 1 )
+  set( vil_ff_sources ${vil_ff_sources}
+    file_formats/vil_png.cxx file_formats/vil_png.h
+  )
+else()
+  set( HAS_PNG 0 )
+endif()
+
+include(${VXL_CMAKE_DIR}/FindJPEG.cmake)
+if(JPEG_FOUND)
+  include_directories( ${JPEG_INCLUDE_DIR} )
+  set( HAS_JPEG 1 )
+  set( vil_ff_sources ${vil_ff_sources}
+    file_formats/vil_jpeglib.h
+    file_formats/vil_jpeg.cxx                 file_formats/vil_jpeg.h
+    file_formats/vil_jpeg_source_mgr.cxx      file_formats/vil_jpeg_source_mgr.h
+    file_formats/vil_jpeg_decompressor.cxx    file_formats/vil_jpeg_decompressor.h
+    file_formats/vil_jpeg_destination_mgr.cxx file_formats/vil_jpeg_destination_mgr.h
+    file_formats/vil_jpeg_compressor.cxx      file_formats/vil_jpeg_compressor.h
+  )
+else()
+  set( HAS_JPEG 0 )
+endif()
+
+################################
+# JPEG 2000
+################################
+include( ${VXL_CMAKE_DIR}/NewCMake/FindECW.cmake )
+if(ECW_FOUND)
+  set( vil_ff_sources ${vil_ff_sources}
+    file_formats/vil_j2k_image.h           file_formats/vil_j2k_image.cxx
+    file_formats/NCSJPCVilIOStream.h       file_formats/NCSJPCVilIOStream.cxx
+    file_formats/vil_j2k_nitf2_pyramid_image_resource.h
+    file_formats/vil_j2k_nitf2_pyramid_image_resource.cxx
+    file_formats/vil_j2k_pyramid_image_resource.h
+    file_formats/vil_j2k_pyramid_image_resource.cxx
+  )
+  include_directories(${ECW_INCLUDE_DIR})
+  set( HAS_J2K 1 )
+else()
+  set( HAS_J2K 0 )
+endif()
+
+##############################
+# JPEG2000 via OpenJPEG
+##############################
+include( ${VXL_CMAKE_DIR}/FindOpenJPEG2.cmake )
+if(OPENJPEG2_FOUND)
+  include_directories(${OPENJPEG2_INCLUDE_DIR})
+  add_definitions( ${OPENJPEG2_DEFINITIONS} )
+  set( vil_ff_sources ${vil_ff_sources}
+    file_formats/vil_openjpeg.h  file_formats/vil_openjpeg.cxx
+    file_formats/vil_openjpeg_pyramid_image_resource.h
+    file_formats/vil_openjpeg_pyramid_image_resource.cxx
+  )
+  add_definitions( ${OPENJPEG2_DEFINITIONS} )
+  set( HAS_OPENJPEG2 1 )
+else()
+  set( HAS_OPENJPEG2 0 )
+endif()
+
+set( HAS_TIFF 0 )
+set( HAS_GEOTIFF 0 )
+include(${VXL_CMAKE_DIR}/FindTIFF.cmake)
+if(TIFF_FOUND)
+  include_directories(${TIFF_INCLUDE_DIR})
+  set( HAS_TIFF 1 )
+  set( vil_ff_sources ${vil_ff_sources}
+    file_formats/vil_tiff.cxx file_formats/vil_tiff.h
+    file_formats/vil_tiff_header.cxx file_formats/vil_tiff_header.h
+  )
+
+  option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" True)
+  include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)
+  if(GEOTIFF_FOUND)
+    set(HAS_GEOTIFF 1 )
+    include_directories(${GEOTIFF_INCLUDE_DIR})
+    set( vil_ff_sources ${vil_ff_sources}
+      file_formats/vil_geotiff_header.cxx file_formats/vil_geotiff_header.h
+    )
+  endif()
+endif()
+
+# Let users decide if they should include DCMTK since we don't build against all versions.
+option(VXL_USE_DCMTK "" TRUE)
+set( HAS_DCMTK 0 )
+if (VXL_USE_DCMTK)
+  include(${VXL_CMAKE_DIR}/FindDCMTK.cmake)
+  if(DCMTK_FOUND)
+    include_directories(${DCMTK_INCLUDE_DIR})
+    set( HAS_DCMTK 1 )
+    set( vil_ff_sources ${vil_ff_sources}
+      file_formats/vil_dicom.cxx        file_formats/vil_dicom.h
+      file_formats/vil_dicom_stream.cxx file_formats/vil_dicom_stream.h
+      file_formats/vil_dicom_header.cxx file_formats/vil_dicom_header.h
+      )
+  endif()
+endif()
+
+option(VIL_CONFIG_ENABLE_SSE2_ROUNDING
+       "Enable Streaming SIMD Extensions 2 implementation of rounding (hardware dependant)."
+       ${VXL_HAS_SSE2_HARDWARE_SUPPORT} )
+if( VIL_CONFIG_ENABLE_SSE2_ROUNDING )
+  if( NOT VXL_HAS_SSE2_HARDWARE_SUPPORT )
+    if( VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE )
+      message( ${VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE_HELP} )
+    endif()
+    message( SEND_ERROR "Cannot have VIL_CONFIG_ENABLE_SSE2_ROUNDING because"
+                        " there is no SSE2 hardware or no compiler support enabled" )
+    set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 0)
+  endif()
+endif()
+
+
+if(VIL_CONFIG_ENABLE_SSE2_ROUNDING)
+  set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 1)
+else()
+  set(VIL_CONFIG_ENABLE_SSE2_ROUNDING 0)
+endif()
+
+
+# Store the external library configurations in to the config file
+vxl_configure_file( ${CMAKE_CURRENT_LIST_DIR}/vil_config.h.in
+                    ${PROJECT_BINARY_DIR}/vil_config.h include/vxl/core/vil)
+
+option(VXL_VIL_INCLUDE_IMAGE_IO "Include image file format readers?" ON)
+
+# Create empty list
+set( vil_sources )
+
+if (VXL_VIL_INCLUDE_IMAGE_IO)
+  set( vil_sources ${vil_ff_sources} )
+endif()
+
+set( vil_sources ${vil_sources}
+  # Basic things
+  vil_memory_chunk.cxx                  vil_memory_chunk.h
+  vil_image_view_base.h
+  vil_chord.h
+  vil_image_view.h                      vil_image_view.hxx
+  vil_image_resource.cxx                vil_image_resource.h
+                                        vil_image_resource_sptr.h
+  vil_blocked_image_resource.cxx        vil_blocked_image_resource.h
+                                        vil_blocked_image_resource_sptr.h
+  vil_blocked_image_facade.cxx          vil_blocked_image_facade.h
+  vil_file_format.cxx                   vil_file_format.h
+  vil_memory_image.cxx                  vil_memory_image.h
+  vil_block_cache.cxx                   vil_block_cache.h
+  vil_cached_image_resource.cxx         vil_cached_image_resource.h
+  vil_pyramid_image_resource.cxx        vil_pyramid_image_resource.h
+                                        vil_pyramid_image_resource_sptr.h
+  vil_pyramid_image_view.hxx            vil_pyramid_image_view.h
+  vil_image_list.cxx                    vil_image_list.h
+
   # image operations
   vil_crop.cxx                          vil_crop.h
   vil_clamp.cxx                         vil_clamp.h
@@ -357,9 +365,14 @@ if(OPENJPEG2_FOUND)
   target_link_libraries( ${VXL_LIB_PREFIX}vil ${OPENJPEG2_LIBRARIES} )
 endif()
 
-if( BUILD_EXAMPLES )
+# Examples and tests use a lot of image I/O
+if( BUILD_EXAMPLES AND VXL_VIL_INCLUDE_IMAGE_IO)
   add_subdirectory(examples)
 endif()
-if( BUILD_TESTING )
+if( BUILD_TESTING AND VXL_VIL_INCLUDE_IMAGE_IO)
   add_subdirectory(tests)
+endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vil-obj OBJECT ${vil_sources})
 endif()

--- a/core/vil/algo/CMakeLists.txt
+++ b/core/vil/algo/CMakeLists.txt
@@ -60,9 +60,13 @@ vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vil_algo LIBRARY_SOURCES ${vil_alg
 
 target_link_libraries( ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vcl )
 
-if( BUILD_EXAMPLES )
+if( BUILD_EXAMPLES AND VXL_VIL_INCLUDE_IMAGE_IO)
   add_subdirectory(examples)
 endif()
-if( BUILD_TESTING )
+if( BUILD_TESTING AND VXL_VIL_INCLUDE_IMAGE_IO)
   add_subdirectory(tests)
+endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vil_algo-obj OBJECT ${vil_algo_sources})
 endif()

--- a/core/vil/io/CMakeLists.txt
+++ b/core/vil/io/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries( ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil ${VXL_LIB_PR
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vil_io-obj OBJECT ${vil_io_sources})
+endif ()

--- a/core/vnl/CMakeLists.txt
+++ b/core/vnl/CMakeLists.txt
@@ -304,3 +304,7 @@ add_subdirectory(algo)
 if( BUILD_EXAMPLES )
   add_subdirectory(examples)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vnl-obj OBJECT ${vnl_sources})
+endif()

--- a/core/vnl/algo/CMakeLists.txt
+++ b/core/vnl/algo/CMakeLists.txt
@@ -124,4 +124,8 @@ if(NETLIB_FOUND)
   if( BUILD_TESTING )
     add_subdirectory(tests)
   endif()
+
+  if (VXL_BUILD_OBJECT_LIBRARIES)
+    add_library(vnl_algo-obj OBJECT ${vnl_algo_sources})
+  endif()
 endif()

--- a/core/vnl/io/CMakeLists.txt
+++ b/core/vnl/io/CMakeLists.txt
@@ -34,3 +34,7 @@ target_link_libraries(${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PRE
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vnl_io-obj OBJECT ${vnl_io_sources})
+endif()

--- a/core/vnl/xio/CMakeLists.txt
+++ b/core/vnl/xio/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries(${VXL_LIB_PREFIX}vnl_xio ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PR
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vnl_xio-obj OBJECT ${vnl_xio_sources})
+endif()

--- a/core/vpl/CMakeLists.txt
+++ b/core/vpl/CMakeLists.txt
@@ -34,3 +34,7 @@ endif()
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vpl-obj OBJECT ${vpl_sources})
+endif()

--- a/core/vsl/CMakeLists.txt
+++ b/core/vsl/CMakeLists.txt
@@ -49,3 +49,7 @@ set_vxl_library_properties(
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vsl-obj OBJECT ${vsl_sources})
+endif()

--- a/core/vul/CMakeLists.txt
+++ b/core/vul/CMakeLists.txt
@@ -94,3 +94,7 @@ endif()
 if( BUILD_TESTING )
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vul-obj OBJECT ${vul_sources})
+endif()

--- a/core/vul/io/CMakeLists.txt
+++ b/core/vul/io/CMakeLists.txt
@@ -10,3 +10,7 @@ target_link_libraries(${VXL_LIB_PREFIX}vul_io ${VXL_LIB_PREFIX}vul ${VXL_LIB_PRE
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vul_io-obj OBJECT ${vul_io_sources})
+endif()

--- a/v3p/netlib/CMakeLists.txt
+++ b/v3p/netlib/CMakeLists.txt
@@ -448,3 +448,7 @@ endif()
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(v3p_netlib-obj OBJECT ${v3p_netlib_sources})
+endif()

--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -217,3 +217,7 @@ endif()
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()
+
+if (VXL_BUILD_OBJECT_LIBRARIES)
+  add_library(vcl-obj OBJECT ${vcl_sources})
+endif()


### PR DESCRIPTION
A number of people have asked whether it is possible to create a single library file containing VXL, rather than the multiple individual libraries that are the default.

CMake does provide a mechanism for this, using OBJECT libraries.
See: https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/Object-Library

To use this, one has to add a bit of extra code to each library CMakeLists.txt. 
So for vbl, one adds:

if (VXL_BUILD_OBJECT_LIBRARIES)
  add_library(vbl-obj OBJECT ${vbl_sources})
endif ()

The VXL_BUILD_OBJECT_LIBRARIES is a new flag (default value OFF), added to the root CMakeLists.txt

One can then create a single library from multiple library sources using a CMake command like this:

add_library(all_vxl_libs $<TARGET_OBJECTS:vcl-obj>
                     $<TARGET_OBJECTS:vsl-obj>
                     $<TARGET_OBJECTS:vbl-obj>
                     $<TARGET_OBJECTS:vbl_io-obj>
                     $<TARGET_OBJECTS:vgl-obj> )

In this branch I've added the three lines defining the library files to each of the core v?l libraries, and demonstrated creating a new monolithic library within:

core/examples/merge_libs

- there is also a file (merging_libraries.txt) describing how to compile such an example.

These changes are all protected so should make no difference to normal compilation.
I've used this approach (using this branch) to build a single library containing core VXL and MUL elements.  
Hopefully others will also find it useful.

