### PR TITLE
COMP: Remove `register` keyword from v3p_f2c.h

### DIFF
--- a/v3p/netlib/v3p_f2c.h
+++ b/v3p/netlib/v3p_f2c.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 #include "v3p_f2c_original.h"
 char *F77_aloc(integer Len, char *whence);
-void sig_die(register char *s, int kill);
+void sig_die(char *s, int kill);
 integer i_dnnt(doublereal *x);
 double f__cabs(double real_value, double imag_value);
 void exit_(integer *rc);


### PR DESCRIPTION
`register` is an optional hint to the compiler to put a variable in a
register.

This addresses the warning:

  /home/matt/src/vxl/v3p/netlib/v3p_f2c.h:29:14: warning: 'register'
  storage class specifier is deprecated and incompatible with C++17
  [-Wdeprecated-register]