### PR TITLE
COMP: Set CMP0074 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ foreach(p
     ##----- Policies Introduced by CMake 3.4
     CMP0065  #: Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property.
     CMP0064  #: Support new TEST if() operator.
+    ##----- Policies Introduced by CMake 3.4
+    CMP0074  #:.`find_package()`` uses ``<PackageName>_ROOT`` variables.
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
To address in the ITKExamples Superbuild:

  CMake Warning (dev) at Modules/ThirdParty/VNL/src/vxl/config/cmake/Modules/FindZLIB.cmake:20 (find_package):

  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable ZLIB_ROOT is set to:

    /.../ITKEx-bld/zlib-install

  For compatibility, CMake is ignoring the variable.
Call Stack (most recent call first):