### PR TITLE
Fix missing gates for BUILD_TESTING

### DIFF
--- a/contrib/brl/bbas/bmsh3d/CMakeLists.txt
+++ b/contrib/brl/bbas/bmsh3d/CMakeLists.txt
@@ -38,7 +38,11 @@ target_link_libraries( bmsh3d ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vgl_algo ${V
 add_subdirectory(algo)
 add_subdirectory(pro)
 add_subdirectory(vis)
-add_subdirectory(tests)
-add_subdirectory(examples)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 #install the .h .hxx and libs

--- a/contrib/prip/vdtop/CMakeLists.txt
+++ b/contrib/prip/vdtop/CMakeLists.txt
@@ -29,6 +29,6 @@ set(vdtop_sources
 vxl_add_library(LIBRARY_NAME vdtop LIBRARY_SOURCES ${vdtop_sources})
 target_link_libraries(vdtop vmap ${VXL_LIB_PREFIX}vil)
 
-#if(BUILD_TESTING)
+if(BUILD_TESTING)
   add_subdirectory(tests)
-#endif()
+endif()


### PR DESCRIPTION
A few tests were still being setup with `BUILD_TESTING` off