### PR TITLE
BUG: Function signature must match default value

### DIFF
--- a/config/cmake/config/vxl_platform_tests.cxx
+++ b/config/cmake/config/vxl_platform_tests.cxx
@@ -100,10 +100,10 @@ int main() { return 0; }
 // VCL_DEFAULT_VALUE(x) will be set to "= x" if this test fails, to "" otherwise
 
 // declaration
-void function(int x, char *ptr = "foo");
+char function(int x, const char *ptr = "foo");
 
 // definition
-void function(int x, char *ptr) { ++ ptr[x]; }
+char function(int x, const char *ptr) { return ptr[x]; }
 
 int main() { return 0; }
 #endif // VCL_DEFAULT_VALUE


### PR DESCRIPTION
This issue found with permissive- by msvc on windows.
The default value of "foo" is not allowed to change.

resolves #480 issue