### PR TITLE
COMP: BRL shared lib inconsistency

### DIFF
--- a/contrib/brl/bbas/brad/CMakeLists.txt
+++ b/contrib/brl/bbas/brad/CMakeLists.txt
@@ -48,7 +48,7 @@
   aux_source_directory(Templates brad_sources)
   vxl_add_library(LIBRARY_NAME brad LIBRARY_SOURCES ${brad_sources} )
 
-  target_link_libraries(brad brip bsta bsta_algo ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}vul )
+  target_link_libraries(brad bsta bsta_algo ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}vul )
 
   add_subdirectory(io)
 

--- a/contrib/brl/bseg/betr/CMakeLists.txt
+++ b/contrib/brl/bseg/betr/CMakeLists.txt
@@ -30,7 +30,7 @@ aux_source_directory(Templates betr_sources)
 
 vxl_add_library(LIBRARY_NAME betr LIBRARY_SOURCES  ${betr_sources})
 
-target_link_libraries(betr ${VXL_LIB_PREFIX}vsph ${VXL_LIB_PREFIX}vsol ${VXL_LIB_PREFIX}bmsh3d ${VXL_LIB_PREFIX}bmsh3d_algo ${VXL_LIB_PREFIX}sdet ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}vdgl ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vcsl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}baml ${VXL_LIB_PREFIX}bjson ${VXL_LIB_PREFIX}vpl )
+target_link_libraries(betr bbas_pro ${VXL_LIB_PREFIX}vsph ${VXL_LIB_PREFIX}vsol ${VXL_LIB_PREFIX}bmsh3d ${VXL_LIB_PREFIX}bmsh3d_algo ${VXL_LIB_PREFIX}sdet ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}vdgl ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vcsl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}baml ${VXL_LIB_PREFIX}bjson ${VXL_LIB_PREFIX}vpl )
 
 add_subdirectory(pro)
 

--- a/contrib/brl/bseg/brip/CMakeLists.txt
+++ b/contrib/brl/bseg/brip/CMakeLists.txt
@@ -45,7 +45,7 @@ aux_source_directory(Templates brip_sources)
 
 vxl_add_library(LIBRARY_NAME brip LIBRARY_SOURCES ${brip_sources})
 
-target_link_libraries(brip gevd bsta bsol vsol ${VXL_LIB_PREFIX}vil1 ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vpgl bil_algo)
+target_link_libraries(brip brad gevd bsta bsol vsol ${VXL_LIB_PREFIX}vil1 ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vpgl bil_algo)
 
 add_subdirectory(app)
 

--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -8,7 +8,7 @@ set(bsgm_sources
 
 vxl_add_library(LIBRARY_NAME bsgm LIBRARY_SOURCES ${bsgm_sources})
 
-target_link_libraries( bsgm ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vcl)
+target_link_libraries( bsgm vidl_pro ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vcl)
 
 add_subdirectory( app )
 

--- a/contrib/brl/bseg/bstm/pro/CMakeLists.txt
+++ b/contrib/brl/bseg/bstm/pro/CMakeLists.txt
@@ -7,7 +7,7 @@ set(bstm_pro_sources
 aux_source_directory(processes bstm_pro_sources)
 vxl_add_library(LIBRARY_NAME bstm_pro LIBRARY_SOURCES  ${bstm_pro_sources})
 
-target_link_libraries(bstm_pro bprb boxm2_util bstm bstm_io bstm_util boxm2_basic boct brdb ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vcl)
+target_link_libraries(bstm_pro bprb boxm2_util bstm bstm_io bstm_util boxm2_basic boct brdb ${VXL_LIB_PREFIX}vpgl_pro ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vcl)
 
 if( BUILD_TESTING )
   add_subdirectory(tests)

--- a/contrib/brl/bseg/bstm_multi/CMakeLists.txt
+++ b/contrib/brl/bseg/bstm_multi/CMakeLists.txt
@@ -41,7 +41,9 @@ subdirs(basic)
 subdirs(io)
 
 #c plus plus library
-subdirs(cpp)
+# Missing functions that prevent building with shared Libs:
+# bstm_multi_cpp_bstm_to_bstm_multi_scene_process
+# NOT SUPPORTED OR TESTED subdirs(cpp)  -- Does not compile with shared libs due to many missing function definitions.
 
 # #opencl section
 #subdirs(ocl)
@@ -53,7 +55,12 @@ subdirs(cpp)
 #subdirs(util)
 
 #processes
-subdirs(pro)
+# Missing functions that prevent building with shared Libs:
+#  bstm_multi_bundle_to_scene_process,
+#  bstm_multi_boxm2_scene_to_bstm_multi_process,
+#  bstm_multi_scene_lvcs_process,
+#  bstm_multi_scene_bbox_process,
+# NOT SUPPORTED OR TESTED subdirs(pro)  -- Does not compile with shared libs due to many missing function definitions.
 
 else()
   message(STATUS "Skipping contrib/brl/bseg/bstm_multi: requires geotiff")


### PR DESCRIPTION
There were two unrelated problems that caused
shared library building with BRL libraries.

1) Two submodules that were not used external to the unit test for
   those submodules had untested function references (OK for static libs,
   but caused linkage failure for shared libs).
	contrib/brl/bseg/bstm_multi/pro unused/incomplete lib not compiled
        contrib/brl/bseg/bstm_multi/cpp unused/incomplete lib not compiled

2) A circular dependancy where the bbrad and brip libraries depended on each other
   unnecessarily.  By forcing brip to depend on brad only (i.e. removing the dependancy
   from brad to brip) and adding a few missing library dependancies, the
   shared library builds of BRL are working agian.

Resolves #508