### PR TITLE
COMP: fixing compile errors on Ubuntu 16.04 with GCC 5.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 2.0.1.0
+    VERSION 2.0.1.1
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vnl/vnl_error.cxx
+++ b/core/vnl/vnl_error.cxx
@@ -15,6 +15,8 @@
 
 #include <iostream>
 
+#include "vnl/vnl_error.h"
+
 //: Raise exception for invalid index.
 void vnl_error_vector_index (char const* fcn, int index)
 {

--- a/core/vnl/vnl_rotation_matrix.cxx
+++ b/core/vnl/vnl_rotation_matrix.cxx
@@ -1,5 +1,6 @@
 // This is core/vnl/vnl_rotation_matrix.cxx
 #include <cmath>
+#include "vnl_rotation_matrix.h"
 
 bool vnl_rotation_matrix(double const x[3], double **R)
 {

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -13,7 +13,7 @@
 //   Oct.2010 - Peter Vanroose - mutators and setters now return *this
 // \endverbatim
 #include <iosfwd>
-# include <vnl/vnl_error.h>
+#include <vnl/vnl_error.h>
 
 #include <vcl_compiler.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
Example error messages:

vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
vxl/core/vnl/vnl_matrix.h:688: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
vxl/core/vnl/vnl_matrix.h:690: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
vxl/core/vnl/vnl_matrix.h:688: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
vxl/core/vnl/vnl_matrix.h:690: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
vxl/core/vnl/vnl_matrix_fixed.h:201: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
vxl/core/vnl/vnl_matrix_fixed.h:203: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
vxl/core/vnl/vnl_matrix_fixed.h:201: error: undefined reference to 'vnl_error_matrix_row_index(char const*, int)'
vxl/core/vnl/vnl_matrix_fixed.h:203: error: undefined reference to 'vnl_error_matrix_col_index(char const*, int)'
vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
vxl/core/vnl/vnl_vector.h:419: error: undefined reference to 'vnl_error_vector_index(char const*, int)'
vxl/core/vnl/tests/test_matrix_exp.cxx:26: error: undefined reference to 'vnl_rotation_matrix(vnl_vector_fixed<double, 3u> const&)'
vxl/core/vnl/tests/test_quaternion.cxx:132: error: undefined reference to 'vnl_rotation_matrix(vnl_vector_fixed<double, 3u> const&)'
vxl/core/vnl/tests/test_quaternion.cxx:154: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
vxl/core/vnl/tests/test_quaternion.cxx:155: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
vxl/core/vnl/tests/test_quaternion.cxx:156: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
vxl/core/vnl/vnl_vector.h:484: error: undefined reference to 'vnl_error_vector_dimension(char const*, int, int)'
vxl/core/vnl/tests/test_rotation_matrix.cxx:87: error: undefined reference to 'vnl_rotation_matrix(vnl_vector<double> const&)'
vxl/core/vnl/vnl_vector.h:484: error: undefined reference to 'vnl_error_vector_dimension(char const*, int, int)'

Co-authored-by: Dženan Zukić <dzenan.zukic@kitware.com>