### PR TITLE
ENH: compile VXL in parallel on Visual Studio

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -92,6 +92,9 @@ macro( vxl_add_library )
   list(LENGTH lib_srcs num_src_files)
   if( ${num_src_files} GREATER 0 )
     add_library(${lib_name} ${lib_srcs} )
+    if(MSVC) # This enables object-level build parallelism in VNL libraries for MSVC
+      target_compile_definitions(${lib_name} PRIVATE " /MP ")
+    endif()
 
     set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES ${lib_name})
     if(VXL_LIBRARY_PROPERTIES)

--- a/core/vnl/Templates/vnl_complex_ops+double-.cxx
+++ b/core/vnl/Templates/vnl_complex_ops+double-.cxx
@@ -1,3 +1,2 @@
 #include <vnl/vnl_complex_ops.hxx>
-
 VNL_COMPLEX_OPS_INSTANTIATE(double);

--- a/core/vnl/algo/vnl_fft_base.h
+++ b/core/vnl/algo/vnl_fft_base.h
@@ -16,7 +16,7 @@
 //: Base class for in-place ND fast Fourier transform.
 
 template <int D, class T>
-struct vnl_fft_base
+struct VNL_ALGO_EXPORT vnl_fft_base
 {
   vnl_fft_base() = default;
 

--- a/core/vnl/algo/vnl_svd.h
+++ b/core/vnl/algo/vnl_svd.h
@@ -60,7 +60,7 @@
 //  eigensystems, which cannot be members of just one matrix.
 
 template <class T>
-class vnl_svd
+class VNL_ALGO_EXPORT vnl_svd
 {
  public:
   //: The singular values of a matrix of complex<T> are of type T, not complex<T>

--- a/core/vnl/vnl_trace.h
+++ b/core/vnl/vnl_trace.h
@@ -18,7 +18,7 @@
 
 //: Calculate trace of a matrix
 // \relatesalso vnl_matrix
-template <class T> VNL_EXPORT
+template <class T>
 T vnl_trace(vnl_matrix<T> const& M)
 {
   T sum(0);
@@ -30,7 +30,7 @@ T vnl_trace(vnl_matrix<T> const& M)
 
 //: Calculate trace of a matrix
 // \relatesalso vnl_matrix_fixed
-template <class T, unsigned int N1, unsigned int N2> VNL_EXPORT
+template <class T, unsigned int N1, unsigned int N2>
 T vnl_trace(vnl_matrix_fixed<T,N1,N2> const& M)
 {
   T sum(0);

--- a/v3p/netlib/triangle.c
+++ b/v3p/netlib/triangle.c
@@ -6958,7 +6958,7 @@ struct badtriang *badtri;
     length *= multiplier;
   }
   /* `length' is approximately squareroot(2.0) to what exponent? */
-  exponent = 2.0 * exponent + (length > SQUAREROOTTWO);
+  exponent = (int) ( 2.0 * exponent + (length > SQUAREROOTTWO) );
   /* `exponent' is now in the range 0...2047 for IEEE double precision.   */
   /*   Choose a queue in the range 0...4095.  The shortest edges have the */
   /*   highest priority (queue 4095).                                     */


### PR DESCRIPTION
If VXL is modified, the incremental build becomes sequential during
compilation of VXL.  This enables object-level compile parallelism
in VXL libraries.