### PR TITLE
unique_ptr for brdb_database_manager

### DIFF
--- a/contrib/brl/bseg/boxm2/vecf/view/boxm2_ocl_articulated_render_tableau.cxx
+++ b/contrib/brl/bseg/boxm2/vecf/view/boxm2_ocl_articulated_render_tableau.cxx
@@ -323,7 +323,7 @@ float boxm2_ocl_articulated_render_tableau::render_frame()
     unsigned int time_id = 0;
     good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-    brdb_selection_sptr S = DATABASE->select("float_data", Q);
+    brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
     if (S->size()!=1){
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
             << " no selections\n";

--- a/contrib/brl/bseg/boxm2/view/boxm2_ocl_change_tableau.cxx
+++ b/contrib/brl/bseg/boxm2/view/boxm2_ocl_change_tableau.cxx
@@ -156,7 +156,7 @@ float boxm2_ocl_change_tableau::change_detect(int frame)
   unsigned int time_id = 0;
   good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-  brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+  brdb_selection_sptr S = DATABASE->select("vil_image_view_base_sptr_data", std::move(Q));
   if (S->size()!=1){
       std::cout << "in bprb_batch_process_manager (from ocl_change_tableau)::set_input_from_db(.) -"
                << " no selections\n";
@@ -194,7 +194,7 @@ float boxm2_ocl_change_tableau::change_detect(int frame)
   unsigned int change_id = 0;
   good = good && bprb_batch_process_manager::instance()->commit_output(0, change_id);
   Q = brdb_query_comp_new("id", brdb_query::EQ, change_id);
-  S = DATABASE->select("vil_image_view_base_sptr_data", Q);
+  S = DATABASE->select("vil_image_view_base_sptr_data", std::move(Q));
   if (S->size()!=1){
       std::cout << "in bprb_batch_process_manager (from ocl_change_tableau)::set_input_from_db(.) -"
                << " no selections\n";

--- a/contrib/brl/bseg/boxm2/view/boxm2_ocl_render_tableau.cxx
+++ b/contrib/brl/bseg/boxm2/view/boxm2_ocl_render_tableau.cxx
@@ -258,7 +258,7 @@ float boxm2_ocl_render_tableau::render_frame()
     unsigned int time_id = 0;
     good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-    brdb_selection_sptr S = DATABASE->select("float_data", Q);
+    brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
     if (S->size()!=1){
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
             << " no selections\n";

--- a/contrib/brl/bseg/boxm2/view/boxm2_ocl_render_trajectory_tableau.cxx
+++ b/contrib/brl/bseg/boxm2/view/boxm2_ocl_render_trajectory_tableau.cxx
@@ -203,7 +203,7 @@ float boxm2_ocl_render_trajectory_tableau::render_frame()
     unsigned int time_id = 0;
     good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-    brdb_selection_sptr S = DATABASE->select("float_data", Q);
+    brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
     if (S->size()!=1){
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
             << " no selections\n";

--- a/contrib/brl/bseg/brec/pro/tests/test_brec_create_mog_image_process.cxx
+++ b/contrib/brl/bseg/brec/pro/tests/test_brec_create_mog_image_process.cxx
@@ -142,7 +142,7 @@ static void test_brec_create_mog_image_process()
   good = good && bprb_batch_process_manager::instance()->commit_output(1, id_mog);
   TEST("run create mog image process", good ,true);
   brdb_query_aptr Q_img1 = brdb_query_comp_new("id", brdb_query::EQ, id_mog);
-  brdb_selection_sptr S_img1 = DATABASE->select("bbgm_image_sptr_data", Q_img1);
+  brdb_selection_sptr S_img1 = DATABASE->select("bbgm_image_sptr_data", std::move(Q_img1));
   TEST("output image is in db", S_img1->size(), 1);
   brdb_value_sptr value_img1;
   TEST("output image is in db", S_img1->get_value(std::string("value"), value_img1), true);
@@ -176,7 +176,7 @@ static void test_brec_create_mog_image_process()
 
     unsigned id_mean; bprb_batch_process_manager::instance()->commit_output(0, id_mean);
     Q_img1 = brdb_query_comp_new("id", brdb_query::EQ, id_mean);
-    S_img1 = DATABASE->select("vil_image_view_base_sptr_data", Q_img1);
+    S_img1 = DATABASE->select("vil_image_view_base_sptr_data", std::move(Q_img1));
     S_img1->get_value(std::string("value"), value_img1);
     result = static_cast<brdb_value_t<vil_image_view_base_sptr>* >(value_img1.ptr());
 
@@ -200,7 +200,7 @@ static void test_brec_create_mog_image_process()
 
     bprb_batch_process_manager::instance()->commit_output(0, id_mean);
     Q_img1 = brdb_query_comp_new("id", brdb_query::EQ, id_mean);
-    S_img1 = DATABASE->select("vil_image_view_base_sptr_data", Q_img1);
+    S_img1 = DATABASE->select("vil_image_view_base_sptr_data", std::move(Q_img1));
     S_img1->get_value(std::string("value"), value_img1);
     result = static_cast<brdb_value_t<vil_image_view_base_sptr>* >(value_img1.ptr());
 

--- a/contrib/brl/bseg/bstm/view/bstm_ocl_multi_render_tableau.cxx
+++ b/contrib/brl/bseg/bstm/view/bstm_ocl_multi_render_tableau.cxx
@@ -224,7 +224,7 @@ float bstm_ocl_multi_render_tableau::render_frame()
   unsigned int time_id = 0;
   good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
   brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-  brdb_selection_sptr S = DATABASE->select("float_data", Q);
+  brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
   if (S->size()!=1){
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
           << " no selections\n";

--- a/contrib/brl/bseg/bstm/view/bstm_ocl_render_tableau.cxx
+++ b/contrib/brl/bseg/bstm/view/bstm_ocl_render_tableau.cxx
@@ -176,7 +176,7 @@ float bstm_ocl_render_tableau::render_frame()
     unsigned int time_id = 0;
     good = good && bprb_batch_process_manager::instance()->commit_output(0, time_id);
     brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, time_id);
-    brdb_selection_sptr S = DATABASE->select("float_data", Q);
+    brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
     if (S->size()!=1){
         std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
             << " no selections\n";

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_rpc_registration_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_rpc_registration_process.cxx
@@ -104,7 +104,7 @@ static void test_bvxm_rpc_registration_process()
 
   // check if the results are in DB
 //  brdb_query_aptr Q = brdb_query_comp_new("id", brdb_query::EQ, id_n_normal);
-//  brdb_selection_sptr S = DATABASE->select("float_data", Q);
+//  brdb_selection_sptr S = DATABASE->select("float_data", std::move(Q));
 //  if (S->size()!=1) {
 //    std::cout << "in bprb_batch_process_manager::set_input_from_db(.) - no selections\n";
 //  }

--- a/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_update_lidar_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/tests/test_bvxm_update_lidar_process.cxx
@@ -143,7 +143,7 @@ static void test_bvxm_update_lidar_process()
 
     //retrieve world
     brdb_query_aptr Q_world = brdb_query_comp_new("id", brdb_query::EQ, id_world);
-    brdb_selection_sptr S_world = DATABASE->select("bvxm_voxel_world_sptr_data", Q_world);
+    brdb_selection_sptr S_world = DATABASE->select("bvxm_voxel_world_sptr_data", std::move(Q_world));
     if (S_world->size()!=1) {
       std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
                << " no selections\n";
@@ -368,7 +368,7 @@ static void test_bvxm_update_lidar_process()
 
   //retrieve camera
   brdb_query_aptr Q_img = brdb_query_comp_new("id", brdb_query::EQ, id_img);
-  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", Q_img);
+  brdb_selection_sptr S_img = DATABASE->select("vil_image_view_base_sptr_data", std::move(Q_img));
   if (S_img->size()!=1) {
     std::cout << "in bprb_batch_process_manager::set_input_from_db(.) -"
              << " no selections\n";


### PR DESCRIPTION
2nd arguments to brdb_database_manager->select operations must be wrapped in std::move, as a unique_ptr cannot be copied.  