### PR TITLE
COMP to VXL: nullptr instead of 0 or NULL @ bgui3d

### DIFF
--- a/contrib/brl/bbas/bgui3d/bgui3d_tableau.cxx
+++ b/contrib/brl/bbas/bgui3d/bgui3d_tableau.cxx
@@ -293,7 +293,7 @@ bgui3d_tableau::set_camera(const vpgl_proj_camera<double>& /*camera*/)
 std::unique_ptr<vpgl_proj_camera<double> >
 bgui3d_tableau::camera() const
 {
-  return std::unique_ptr<vpgl_proj_camera<double> >(NULL);
+  return std::unique_ptr<vpgl_proj_camera<double> >(nullptr);
 }
 
 

--- a/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.cxx
+++ b/contrib/brl/bbas/bgui3d/bgui3d_viewer_tableau.cxx
@@ -230,7 +230,7 @@ std::unique_ptr<vpgl_proj_camera<double> >
 bgui3d_viewer_tableau::camera() const
 {
   if (!scene_camera_)
-    return std::unique_ptr<vpgl_proj_camera<double> >(NULL);
+    return std::unique_ptr<vpgl_proj_camera<double> >(nullptr);
 
   const SbVec3f& t_vec = scene_camera_->position.getValue();
   vnl_double_3 t(t_vec[0], t_vec[1], t_vec[2]);
@@ -267,10 +267,10 @@ bgui3d_viewer_tableau::camera() const
     double h = cam->height.getValue();
 #endif // 0
     std::cerr << "WARNING: not implemented yet\n";
-    return std::unique_ptr<vpgl_proj_camera<double> >(NULL);
+    return std::unique_ptr<vpgl_proj_camera<double> >(nullptr);
    default:
     std::cerr << "WARNING: no such camera_type_\n";
-    return std::unique_ptr<vpgl_proj_camera<double> >(NULL);
+    return std::unique_ptr<vpgl_proj_camera<double> >(nullptr);
   }
 }
 


### PR DESCRIPTION
Remaining case of changing null pointer constants (eg. NULL, 0) to use the new C++11 nullptr keyword.

(cherry picked from commit lemsvpe@287ab89282f57af6636cb4158dc46a21e69d8f0b)