### PR TITLE
TO VXL: VGUI GTK2: right library variable

### DIFF
--- a/core/vgui/CMakeLists.txt
+++ b/core/vgui/CMakeLists.txt
@@ -429,7 +429,7 @@ if(GTK2_FOUND)
     if (GTKGL2_FOUND)
       list(APPEND GTK2_INCLUDE_DIRS ${GTKGL2_INCLUDE_DIRS})
       list(REMOVE_DUPLICATES GTK2_INCLUDE_DIRS)
-      list(APPEND GTK2_LIBRARIES ${GTKGL2_LIBRARIES})
+      list(APPEND GTK2_LIBRARIES ${GTKGL2_LINK_LIBRARIES})
       list(REMOVE_DUPLICATES GTK2_LIBRARIES)
       # TODO: libraries are not full paths, a known limitation of pkg_*_module.
       # If a GTK library is installed on a non-standard path, this will fail.


### PR DESCRIPTION
(cherry picked from commit lemsvpe@c60fe131579a2e7ce2b87bb7ece49c4d575382ed)

This allowed me to compile in Mac OS 10.14.2 Mojave. It is the correct solution.