### PR TITLE
TO VXL: COMP: duplicate instantiation removed

### DIFF
--- a/contrib/brl/bbas/imesh/algo/imesh_imls_surface.cxx
+++ b/contrib/brl/bbas/imesh/algo/imesh_imls_surface.cxx
@@ -980,8 +980,3 @@ bool snap_to_surface(const imesh_imls_surface& f,
 
   return true;
 }
-
-// Explicit instantiation needed in the implementations in this file:
-#include <imesh/algo/imesh_imls_surface.hxx>
-IMESH_IMLS_SURFACE_INSTANTATE(vgl_vector_2d<double>,vgl_point_3d<double>);
-IMESH_IMLS_SURFACE_INSTANTATE(imesh_imls_surface::integral_data,vgl_point_3d<double>);


### PR DESCRIPTION
(cherry picked from commit lemsvpe@44421a58010410cf6ec4dd514f109d51fbd26df9)

This solved some duplicate symbol errors in some compilers (tested with GCC 5.5.0 under Mac OS)