### PR TITLE
heightmap_from_disparity adaptor

### DIFF
--- a/contrib/brl/bbas/volm/pro/processes/volm_combine_height_map_process.cxx
+++ b/contrib/brl/bbas/volm/pro/processes/volm_combine_height_map_process.cxx
@@ -299,7 +299,7 @@ bool volm_combine_height_map_process2(bprb_func_process& pro)
     {
       std::vector<float> pixel_values;
       for (auto & in_img : in_imgs)
-        if ( (in_img(i,j)-threshold)*(in_img(i,j)-threshold) > 1E-5 )
+        if (in_img(i,j) > threshold)
           pixel_values.push_back( in_img(i,j) );
       float median_value = median(pixel_values);
       (*out_img)(i,j) = median_value;
@@ -317,7 +317,7 @@ float volm_combine_height_map_process2_globals::median(std::vector<float> values
   std::sort(values.begin(), values.end());
   int size = values.size();
   int s2 = size / 2;
-  return size == 0 ? 0.0 : size%2 ? values[s2] : (values[s2]+values[s2-1])*0.5;
+  return size == 0 ? -9999.0 : size%2 ? values[s2] : (values[s2]+values[s2-1])*0.5;
 }
 
 

--- a/contrib/brl/bpro/core/bbas_pro/CMakeLists.txt
+++ b/contrib/brl/bpro/core/bbas_pro/CMakeLists.txt
@@ -21,7 +21,7 @@ aux_source_directory(Templates bbas_pro_sources)
 aux_source_directory(processes bbas_pro_sources)
 
 vxl_add_library(LIBRARY_NAME bbas_pro LIBRARY_SOURCES ${bbas_pro_sources})
-target_link_libraries(bbas_pro bprb brdb brad brad_io bsta_io bsta ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vsl imesh depth_map)
+target_link_libraries(bbas_pro bprb brdb brad brad_io bsta_io bsta ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vil_io ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}vsl imesh depth_map bpgl_algo)
 
 
 if( BUILD_TESTING )

--- a/contrib/brl/bpro/core/bbas_pro/bbas_processes.h
+++ b/contrib/brl/bpro/core/bbas_pro/bbas_processes.h
@@ -21,5 +21,6 @@ DECLARE_FUNC_CONS(bsl_fusion_process);
 
 DECLARE_FUNC_CONS(imesh_ply_bbox_process);
 DECLARE_FUNC_CONS(bpgl_generate_depth_maps_process);
+DECLARE_FUNC_CONS(bpgl_heightmap_from_disparity_process);
 
 #endif // bbas_processes_h_

--- a/contrib/brl/bpro/core/bbas_pro/bbas_register.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/bbas_register.cxx
@@ -28,4 +28,5 @@ void bbas_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bsl_fusion_process, "bslFusionProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, imesh_ply_bbox_process, "imeshPlyBboxProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bpgl_generate_depth_maps_process, "bpglGenerateDepthMapsProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bpgl_heightmap_from_disparity_process, "bpglHeightmapFromDisparityProcess");
 }

--- a/contrib/brl/bpro/core/bbas_pro/processes/bpgl_heightmap_from_disparity_process.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/processes/bpgl_heightmap_from_disparity_process.cxx
@@ -1,0 +1,106 @@
+//This is brl/bpro/core/bbas_pro/processes/bpgl_heightmap_from_disparity_process.cxx
+#include <string>
+#include <iostream>
+#include <bprb/bprb_func_process.h>
+#include <bprb/bprb_parameters.h>
+
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <vpgl/vpgl_camera_double_sptr.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vil/vil_image_view_base.h>
+#include <vil/vil_image_view.h>
+#include <vil/vil_convert.h>
+#include <vgl/vgl_box_3d.h>
+
+#include <bpgl/algo/bpgl_heightmap_from_disparity.h>
+
+
+//: process to convert heightmap to disparity
+// template<class CAM_T>
+// vil_image_view<float>
+// bpgl_heightmap_from_disparity(CAM_T const& cam1, CAM_T const& cam2,
+//                               vil_image_view<float> disparity, vgl_box_3d<double> heightmap_bounds,
+//                               double ground_sample_distance);
+
+namespace bpgl_heightmap_from_disparity_process_globals
+{
+  unsigned n_inputs_  = 5;
+  unsigned n_outputs_ = 1;
+}
+
+
+bool bpgl_heightmap_from_disparity_process_cons(bprb_func_process& pro)
+{
+  using namespace bpgl_heightmap_from_disparity_process_globals;
+
+  std::vector<std::string> input_types_;
+  input_types_.emplace_back("vpgl_camera_double_sptr"); // vpgl_affine_camera<double> camera 1
+  input_types_.emplace_back("vpgl_camera_double_sptr"); // vpgl_affine_camera<double> camera 2
+  input_types_.emplace_back("vil_image_view_base_sptr"); // vil_image_view<float> disparity
+  input_types_.emplace_back("double"); // min point x (e.g. lower left corner of a scene bbox)
+  input_types_.emplace_back("double"); // min point y
+  input_types_.emplace_back("double"); // min point z
+  input_types_.emplace_back("double"); // max point x (e.g. upper right corner of a scene bbox)
+  input_types_.emplace_back("double"); // max point y
+  input_types_.emplace_back("double"); // max point z
+  input_types_.emplace_back("double"); // ground sample distance
+
+  std::vector<std::string> output_types_;
+  output_types_.emplace_back("vil_image_view_base_sptr"); // vil_image_view<float> heightmap
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+
+bool bpgl_heightmap_from_disparity_process(bprb_func_process& pro)
+{
+  using namespace bpgl_heightmap_from_disparity_process_globals;
+
+  // sanity check
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": wrong inputs!!!\n";
+    return false;
+  }
+
+  // get inputs
+  unsigned i = 0;
+  vpgl_camera_double_sptr camera1_sptr = pro.get_input<vpgl_camera_double_sptr>(i++);
+  vpgl_camera_double_sptr camera2_sptr = pro.get_input<vpgl_camera_double_sptr>(i++);
+  vil_image_view_base_sptr disparity_sptr = pro.get_input<vil_image_view_base_sptr>(i++);
+  auto min_x = pro.get_input<double>(i++);
+  auto min_y = pro.get_input<double>(i++);
+  auto min_z = pro.get_input<double>(i++);
+  auto max_x = pro.get_input<double>(i++);
+  auto max_y = pro.get_input<double>(i++);
+  auto max_z = pro.get_input<double>(i++);
+  auto gsd = pro.get_input<double>(i++);
+
+  // convert cameras
+  auto* camera1 = dynamic_cast<vpgl_affine_camera<double>*> (camera1_sptr.as_pointer());
+  if (!camera1) {
+    std::cerr << pro.name() << " :-- camera 1 is not affine" << std::endl;
+    return false;
+  }
+  auto* camera2 = dynamic_cast<vpgl_affine_camera<double>*> (camera2_sptr.as_pointer());
+  if (!camera2) {
+    std::cerr << pro.name() << " :-- camera 2 is not affine" << std::endl;
+    return false;
+  }
+
+  // convert image
+  vil_image_view<float> disparity = *vil_convert_cast(float(), disparity_sptr);
+
+  // bounding box
+  vgl_box_3d<double> heightmap_bounds(min_x,min_y,min_z, max_x,max_y,max_z);
+
+  // process
+  vil_image_view<float> heightmap = bpgl_heightmap_from_disparity(
+      camera1, camera2, disparity, heightmap_bounds, gsd);
+
+  // return
+  pro.set_output_val<vil_image_view_base_sptr>(0, new vil_image_view<float>(heightmap));
+  return true;
+}

--- a/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
@@ -372,3 +372,25 @@ def generate_depth_maps(depth_scene_file, output_folder, output_name_prefix, dow
     batch.set_input_string(2, output_folder)
     batch.set_input_string(3, output_name_prefix)
     batch.run_process()
+
+
+def heightmap_from_disparity(camera1, camera2, disparity,
+                             min_x, min_y, min_z, max_x, max_y, max_x,
+                             gsd):
+    batch.init_process("bpglHeightmapFromDisparityProcess")
+    batch.set_input_from_db(0, camera1)
+    batch.set_input_from_db(1, camera2)
+    batch.set_input_string(2, disparity)
+    batch.set_input_double(3, min_x)
+    batch.set_input_double(4, min_y)
+    batch.set_input_double(5, min_z)
+    batch.set_input_double(6, max_x)
+    batch.set_input_double(7, max_y)
+    batch.set_input_double(8, max_z)
+    batch.set_input_double(9, gsd)
+    if batch.run_process():
+        (id, type) = batch.commit_output(0)
+        heightmap = dbvalue(id, type)
+        return heightmap
+    else:
+        raise Exception("bpgl heightmap from disparity failed")

--- a/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
@@ -376,7 +376,8 @@ def generate_depth_maps(depth_scene_file, output_folder, output_name_prefix, dow
 
 def heightmap_from_disparity(camera1, camera2, disparity,
                              min_x, min_y, min_z, max_x, max_y, max_z,
-                             gsd, min_disparity):
+                             gsd, min_disparity,
+                             z_offset = 0):
     batch.init_process("bpglHeightmapFromDisparityProcess")
     batch.set_input_from_db(0, camera1)
     batch.set_input_from_db(1, camera2)
@@ -389,6 +390,7 @@ def heightmap_from_disparity(camera1, camera2, disparity,
     batch.set_input_double(8, max_z)
     batch.set_input_double(9, gsd)
     batch.set_input_double(10, min_disparity)
+    batch.set_input_double(11, z_offset)
     if batch.run_process():
         (id, type) = batch.commit_output(0)
         heightmap = dbvalue(id, type)

--- a/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
@@ -375,12 +375,12 @@ def generate_depth_maps(depth_scene_file, output_folder, output_name_prefix, dow
 
 
 def heightmap_from_disparity(camera1, camera2, disparity,
-                             min_x, min_y, min_z, max_x, max_y, max_x,
-                             gsd):
+                             min_x, min_y, min_z, max_x, max_y, max_z,
+                             gsd, min_disparity):
     batch.init_process("bpglHeightmapFromDisparityProcess")
     batch.set_input_from_db(0, camera1)
     batch.set_input_from_db(1, camera2)
-    batch.set_input_string(2, disparity)
+    batch.set_input_from_db(2, disparity)
     batch.set_input_double(3, min_x)
     batch.set_input_double(4, min_y)
     batch.set_input_double(5, min_z)
@@ -388,6 +388,7 @@ def heightmap_from_disparity(camera1, camera2, disparity,
     batch.set_input_double(7, max_y)
     batch.set_input_double(8, max_z)
     batch.set_input_double(9, gsd)
+    batch.set_input_double(10, min_disparity)
     if batch.run_process():
         (id, type) = batch.commit_output(0)
         heightmap = dbvalue(id, type)

--- a/contrib/brl/bpro/core/pyscripts/bsgm_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bsgm_adaptor.py
@@ -8,8 +8,8 @@ dbvalue = brl_init.DummyBatch()
 
 
 def sgm_matching_stereo(rect_img_1, rect_img_2, min_disparity, num_disparity,
-                        out_disp_txt, num_active_disparity=40,
-                        error_check_mode=1, multi_scale_mode=1, shadow_intensity = 0):
+                        out_disp_txt="", num_active_disparity=40,
+                        error_check_mode=1, multi_scale_mode=1, shadow_thres = 0):
     batch.init_process("bsgmMatchingStereoProcess")
     batch.set_input_from_db(0, rect_img_1)
     batch.set_input_from_db(1, rect_img_2)
@@ -19,7 +19,7 @@ def sgm_matching_stereo(rect_img_1, rect_img_2, min_disparity, num_disparity,
     batch.set_input_int(5, error_check_mode)
     batch.set_input_int(6, multi_scale_mode)
     batch.set_input_string(7, out_disp_txt)
-    batch.set_input_unsigned(8, shadow_intensity)
+    batch.set_input_unsigned(8, shadow_thres)
     status = batch.run_process()
     if status:
         (id, type) = batch.commit_output(0)

--- a/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
@@ -1108,7 +1108,7 @@ def construct_height_map_from_disparity(img1, img1_disp, min_disparity, local_ra
     batch.init_process("vpglConstructHeightMapProcess")
     batch.set_input_from_db(0, img1)
     batch.set_input_from_db(1, local_rational_cam1)
-    batch.set_input_string(2, img1_disp)
+    batch.set_input_from_db(2, img1_disp)
     batch.set_input_float(3, min_disparity)
     batch.set_input_from_db(4, img2)
     batch.set_input_from_db(5, local_rational_cam2)

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rectify_images_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rectify_images_process.cxx
@@ -482,7 +482,7 @@ bool vpgl_construct_height_map_process_cons(bprb_func_process& pro)
   std::vector<std::string> input_types;
   input_types.emplace_back("vil_image_view_base_sptr");  // image1
   input_types.emplace_back("vpgl_camera_double_sptr");  // camera1 local rational
-  input_types.emplace_back("vcl_string");
+  input_types.emplace_back("vil_image_view_base_sptr");  // disparity image
   input_types.emplace_back("float");
   input_types.emplace_back("vil_image_view_base_sptr");  // image2
   input_types.emplace_back("vpgl_camera_double_sptr");  // camera2 local rational
@@ -517,8 +517,7 @@ bool vpgl_construct_height_map_process(bprb_func_process& pro)
   unsigned i = 0;
   vil_image_view_base_sptr img1_sptr = pro.get_input<vil_image_view_base_sptr>(i++);
   vpgl_camera_double_sptr cam1_rational = pro.get_input<vpgl_camera_double_sptr>(i++);
-  //vil_image_view_base_sptr img1_disp_sptr = pro.get_input<vil_image_view_base_sptr>(i++);
-  std::string disp_name = pro.get_input<std::string>(i++);
+  vil_image_view_base_sptr img1_disp_sptr = pro.get_input<vil_image_view_base_sptr>(i++);
   auto min_disparity = pro.get_input<float>(i++);
   vil_image_view_base_sptr img2_sptr = pro.get_input<vil_image_view_base_sptr>(i++);
   vpgl_camera_double_sptr cam2_rational = pro.get_input<vpgl_camera_double_sptr>(i++);
@@ -542,25 +541,9 @@ bool vpgl_construct_height_map_process(bprb_func_process& pro)
   std::cout << "read H1:\n " << H1 << "\n H2:\n " << H2 << "\n";
 
   vil_image_view<float> img1 = *vil_convert_cast(float(), img1_sptr);
-
-  std::ifstream ifsd(disp_name.c_str());
-  if (!ifsd) {
-    std::cerr << "In vpgl_construct_height_map_process() -- cannot open disparity file: " << disp_name << std::endl;
-    return false;
-  }
-  unsigned ni, nj;
-  ifsd >> nj; ifsd >> ni;
-  vil_image_view<float> img1_disp(ni, nj);
-  for (unsigned j = 0; j < nj; j++) {
-    for (unsigned i = 0; i < ni; i++) {
-      float val;
-      ifsd >> val;
-      img1_disp(i,j) = val;
-    }
-  }
-  ifsd.close();
-
+  vil_image_view<float> img1_disp = *vil_convert_cast(float(), img1_disp_sptr);
   vil_image_view<float> img2 = *vil_convert_cast(float(), img2_sptr);
+  
   double width = max_x-min_x;
   double depth = max_y-min_y;
   double height = max_z - min_z;

--- a/contrib/brl/bseg/bsgm/pro/processes/bsgm_matching_stereo_process.cxx
+++ b/contrib/brl/bseg/bsgm/pro/processes/bsgm_matching_stereo_process.cxx
@@ -143,17 +143,19 @@ bool bsgm_matching_stereo_process(bprb_func_process& pro)
   bsgm_invert_disparities( disp_r, invalid_disp_inv, invalid_disp );
 
   // convert a text file to save all disparity value
-  std::ofstream ofs(out_disparity_txt.c_str());
-  std::cout << "disparity size row: " << disp_r.nj() << ", cols: " << disp_r.ni() << std::endl;
-  ofs << disp_r.nj() << " " << disp_r.ni() << std::endl;
-  for (unsigned row_id = 0; row_id < disp_r.nj(); row_id++) {
-    for (unsigned col_id = 0; col_id < disp_r.ni(); col_id++) {
-      ofs << disp_r(col_id, row_id) << " ";
+  if (!out_disparity_txt.empty()) {
+    std::ofstream ofs(out_disparity_txt.c_str());
+    std::cout << "disparity size row: " << disp_r.nj() << ", cols: " << disp_r.ni() << std::endl;
+    ofs << disp_r.nj() << " " << disp_r.ni() << std::endl;
+    for (unsigned row_id = 0; row_id < disp_r.nj(); row_id++) {
+      for (unsigned col_id = 0; col_id < disp_r.ni(); col_id++) {
+        ofs << disp_r(col_id, row_id) << " ";
+      }
+      ofs << std::endl;
     }
     ofs << std::endl;
+    ofs.close();
   }
-  ofs << std::endl;
-  ofs.close();
 
   // convert floating point image to byte for visualization/saving
   vil_image_view<vxl_byte> disp_r_8u;


### PR DESCRIPTION
* bpgl_heightmap_from_disparity python adaptor
* volm_combine_height_map_process.cxx: direct threshold for median filter, return "-9999.0" as invalid value
* bsgm_matching_stereo_process.cxx: optional text file output
* vpgl_rectify_images_process accepts dispairty image directly