### PR TITLE
vpgl: geo cam, affine cam, lvcs

### DIFF
--- a/core/vpgl/algo/tests/test_ray.cxx
+++ b/core/vpgl/algo/tests/test_ray.cxx
@@ -6,8 +6,10 @@
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_point_3d.h>
 #include <vgl/vgl_plane_3d.h>
+#include <vgl/vgl_closest_point.h>
 #include <vgl/vgl_vector_3d.h>
 #include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/vpgl_affine_camera.h>
 #include <vpgl/vpgl_lvcs.h>
 #include <vpgl/algo/vpgl_ray.h>
 
@@ -82,6 +84,22 @@ static void test_ray()
   vpgl_ray::plane_ray(lrcam,impt1,impt2,outp);
   err=dot_product<double>(outp.normal(),dir);
   TEST_NEAR("test local rational plane", err, 0.0, 1e-8);
+
+  // test ray for affine camera
+  vnl_vector_fixed<double, 4> row1, row2;
+  row1[0]=1.3483235713495938; row1[1]= 0.0038174980872772743; row1[2]= 0.27647870881886161; row1[3] = 8.8599950663932052;
+  row2[0] = 0.21806927892797245; row2[1] = -0.92631091145800215; row2[2] = -1.0010535330976205; row2[3] = 538.93376518200034;
+  vpgl_affine_camera<double> row_cam(row1, row2);
+  row_cam.set_viewing_distance( 9325.6025071654913);
+  vgl_point_3d<double> wrld_pt(274.30804459155252,85.614875071463018,-35.273309156122778);
+  vgl_ray_3d<double> affine_ray;
+   good = vpgl_ray::ray(row_cam, wrld_pt, affine_ray);
+  vgl_homg_point_2d<double> img_pt(369.28342202880049, 554.72813713086771);
+  vgl_ray_3d<double> gt_ray = row_cam.backproject_ray(img_pt);
+  double dir_dist = (affine_ray.direction() - gt_ray.direction()).length();
+  vgl_point_3d<double> cp = vgl_closest_point(affine_ray, wrld_pt);
+  double gnd_pt_dist = (cp - wrld_pt).length();
+  TEST_NEAR("affine ray ", dir_dist + gnd_pt_dist, 0.0, 1e-5);
 }
 
 TESTMAIN(test_ray);

--- a/core/vpgl/algo/vpgl_ray.cxx
+++ b/core/vpgl/algo/vpgl_ray.cxx
@@ -249,6 +249,13 @@ bool vpgl_ray::principal_ray(vpgl_proj_camera<double> const& cam,
   pray = vgl_ray_3d<double>(cent, cent + dir);
   return true;
 }
+bool vpgl_ray::ray(vpgl_affine_camera<double> const& cam,
+                   vgl_point_3d<double> const& world_pt,
+                   vgl_ray_3d<double>& ray){
+  vgl_point_2d<double> p2d = cam.project(world_pt);
+  ray = cam.backproject_ray(vgl_homg_point_2d<double>(p2d));
+  return true;
+}
 
 bool vpgl_ray::ray(vpgl_perspective_camera<double> const& cam,
                    vgl_point_3d<double> const& world_pt,

--- a/core/vpgl/algo/vpgl_ray.h
+++ b/core/vpgl/algo/vpgl_ray.h
@@ -11,6 +11,8 @@
 #include <vgl/algo/vgl_rotation_3d.h>
 #include <vpgl/vpgl_local_rational_camera.h>
 #include <vpgl/vpgl_perspective_camera.h>
+#include <vpgl/vpgl_proj_camera.h>
+#include <vpgl/vpgl_affine_camera.h>
 #include <vpgl/vpgl_generic_camera.h>
 #include <vnl/vnl_double_3.h>
 #include <vgl/vgl_point_3d.h>
@@ -98,6 +100,13 @@ class vpgl_ray
 
   static bool principal_ray(vpgl_proj_camera<double> const& cam,
                             vgl_ray_3d<double>& pray);
+
+ // ====== affine camera =====
+  static bool ray(vpgl_affine_camera<double> const& cam,
+                  vgl_point_3d<double> const& world_pt,
+                  vgl_ray_3d<double>& ray);
+
+
 
   // ====== perspective camera =====
   static bool ray(vpgl_perspective_camera<double> const& cam,

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -48,10 +48,6 @@ bool vpgl_geo_camera::init_geo_camera(vil_image_resource_sptr const& geotiff_img
       std::cerr << "vpgl_geo_camera::init_geo_camera : Error casting vil_image_resource to a tiff image.\n";
       return false;
   }
-  if (!geotiff_tiff->get_geotiff_header()) {
-    std::cerr << "no geotiff header!\n";
-    return false;
-  }
 
   // check if the tiff file is geotiff
   if (!geotiff_tiff->is_GEOTIFF()) {
@@ -59,7 +55,13 @@ bool vpgl_geo_camera::init_geo_camera(vil_image_resource_sptr const& geotiff_img
     return false;
   }
 
+  // retrieve header
   vil_geotiff_header* gtif = geotiff_tiff->get_geotiff_header();
+  if (!gtif) {
+    std::cerr << "vpgl_geo_camera::init_geo_camera -- no geotiff header!\n";
+    return false;
+  }
+
   int utm_zone;
   vil_geotiff_header::GTIF_HEMISPH h;
 

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -82,6 +82,7 @@ class vpgl_lvcs : public vbl_ref_count
             AngUnits ang_unit=DEG, LenUnits elev_unit=METERS);
 
   vpgl_lvcs(const vpgl_lvcs&);
+  ~vpgl_lvcs() = default;
   vpgl_lvcs& operator=(const vpgl_lvcs&);
 
 


### PR DESCRIPTION
vpgl updates:
- retrieve geotiff header only once during vpgl_geo_camera
- add vpgl_ray method for the affine camera
- default vpgl_lvcs destructor
