### PR TITLE
BRL contrib updates

### DIFF
--- a/contrib/brl/bbas/brad/brad_image_metadata.cxx
+++ b/contrib/brl/bbas/brad/brad_image_metadata.cxx
@@ -584,7 +584,7 @@ bool brad_image_metadata::parse_from_imd_only(std::string const& filename)
       linestr >> band_str;
       if (band_str.find('P') != std::string::npos) {
         band_ = "PAN";
-      } else if (band_str.find('S') != std::string::npos) {
+      } else if (band_str.find("All-S") != std::string::npos) {
         band_ = "SWIR";
       } else
         band_ = "MULTI";

--- a/contrib/brl/bbas/brad/brad_image_metadata.cxx
+++ b/contrib/brl/bbas/brad/brad_image_metadata.cxx
@@ -1031,8 +1031,12 @@ bool brad_image_metadata::parse_from_txt(std::string const& filename)
     return false;
   }
   n_bands_ = 0;
-  lower_left_.set(181, 91, 10000);
-  upper_right_.set(-181,-91, -10000);
+
+  vgl_point_3d<double> lower_left_local(181, 91, 10000);  // x is lon, y is lat 
+  vgl_point_3d<double> upper_right_local(-181,-91, -10000);
+  bool parsed_llx = false, parsed_lly = false, parsed_llz = false;
+  bool parsed_urx = false, parsed_ury = false, parsed_urz = false;
+
   double val;
 
   bool parsed_gain_offset = false, parsed_sun_irradiance = false;
@@ -1101,33 +1105,39 @@ bool brad_image_metadata::parse_from_txt(std::string const& filename)
     }
     if (tag.compare("LLLat") == 0) {
       linestr >> val;
-      lower_left_.set(lower_left_.x(), val, lower_left_.z());
+      lower_left_local.set(lower_left_.x(), val, lower_left_.z());
+      parsed_lly = true;
       continue;
     }
     if (tag.compare("LLLon") == 0) {
       linestr >> val;
-      lower_left_.set(val, lower_left_.y(), lower_left_.z());
+      lower_left_local.set(val, lower_left_.y(), lower_left_.z());
+      parsed_llx = true;
       continue;
     }
     if (tag.compare("LLHAE") == 0) {
       linestr >> val;
-      lower_left_.set(lower_left_.x(), lower_left_.y(), val);
+      lower_left_local.set(lower_left_.x(), lower_left_.y(), val);
+      parsed_llz = true;
       continue;
     }
 
     if (tag.compare("URLat") == 0) {
       linestr >> val;
-      upper_right_.set(upper_right_.x(), val, upper_right_.z());
+      upper_right_local.set(upper_right_.x(), val, upper_right_.z());
+      parsed_ury = true;
       continue;
     }
     if (tag.compare("URLon") == 0) {
       linestr >> val;
-      upper_right_.set(val, upper_right_.y(), upper_right_.z());
+      upper_right_local.set(val, upper_right_.y(), upper_right_.z());
+      parsed_urx = true;
       continue;
     }
     if (tag.compare("URHAE") == 0) {
       linestr >> val;
-      upper_right_.set(upper_right_.x(), upper_right_.y(), val);
+      upper_right_local.set(upper_right_.x(), upper_right_.y(), val);
+      parsed_urz = true;
       continue;
     }
     if (tag.compare("numberOfSpectralBands") == 0) {
@@ -1197,6 +1207,15 @@ bool brad_image_metadata::parse_from_txt(std::string const& filename)
     if(verbose_)
       std::cout << "cloud coverage percentage : " << cloud_coverage_percentage_ << " band: " << band_ << " number of bands: " << n_bands_ << std::endl;
   }
+
+  if (parsed_llx && parsed_lly && parsed_llz) {
+    lower_left_.set(lower_left_local.x(), lower_left_local.y(), lower_left_local.z());
+  }
+
+  if (parsed_urx && parsed_ury && parsed_urz) {
+    upper_right_.set(upper_right_local.x(), upper_right_local.y(), upper_right_local.z());
+  }
+
 
   return true;
 }

--- a/contrib/brl/bbas/brdb/brdb_query.h
+++ b/contrib/brl/bbas/brdb/brdb_query.h
@@ -21,7 +21,7 @@
 class brdb_query
 {
  protected:
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
   friend std::unique_ptr<brdb_query>;
 #else
   friend class std::unique_ptr<brdb_query>;

--- a/contrib/brl/bbas/bwm/bwm_observer_img.cxx
+++ b/contrib/brl/bbas/bwm/bwm_observer_img.cxx
@@ -310,6 +310,25 @@ void bwm_observer_img::clear_objects()
   }
   vert_list.clear();
 }
+bool bwm_observer_img::get_selected_line(bgui_vsol_soview2D_line_seg* &line)
+{
+  bgui_vsol_soview2D_line_seg* lseg = (bgui_vsol_soview2D_line_seg*)get_selected_object(LINE_SEG_TYPE);
+  if (lseg) {
+    line = lseg;
+    return true;
+  }
+  return false;
+}
+void bwm_observer_img::print_selected_line(){
+  bgui_vsol_soview2D_line_seg* line_seg;
+  if(!get_selected_line(line_seg))
+    std::cout << "No selected line segment" << std::endl;
+  else{
+    vsol_point_2d_sptr p0 = line_seg->sptr()->p0();
+    vsol_point_2d_sptr p1 = line_seg->sptr()->p1();
+    std::cout << "sel line seg: " << vgl_point_2d<double>(p0->x(), p0->y()) << " -> " << vgl_point_2d<double>(p1->x(), p1->y()) << std::endl;
+  }
+}
 
 bool bwm_observer_img::get_selected_box(bgui_vsol_soview2D_polygon* &box)
 {
@@ -705,6 +724,8 @@ void bwm_observer_img::lines_vd()
        lit != lines.end(); ++lit)
   {
     bgui_vsol_soview2D_line_seg* line = this->add_vsol_line_2d(*lit);
+    // store in object list in order to save later if desired
+    obj_list[line->get_id()] = line;
     // Gamze - do not add the lines one by one: create a vector and map it to the box
     soviews.push_back(line);
   }

--- a/contrib/brl/bbas/bwm/bwm_observer_img.h
+++ b/contrib/brl/bbas/bwm/bwm_observer_img.h
@@ -30,6 +30,7 @@
 #include <bvgl/bvgl_changes_sptr.h>
 
 #define VERTEX_TYPE "bwm_soview2D_vertex"
+#define LINE_SEG_TYPE "bgui_vsol_soview2D_line_seg"
 #define POLYLINE_TYPE "bgui_vsol_soview2D_polyline"
 #define POLYGON_TYPE "bgui_vsol_soview2D_polygon"
 #define POINT_TYPE "bgui_vsol_soview2D_point"
@@ -76,12 +77,18 @@ class bwm_observer_img : public bgui_vsol2D_tableau
 
   unsigned create_point(vsol_point_2d_sptr);
 
+  void add_obj(bgui_vsol_soview2D* obj){
+    if(!obj) return;
+    obj_list[obj->get_id()] = obj;
+  }
   void copy();
 
   void paste(float x, float y);
 
   void clear_objects();
   //: various types of selected objects
+  bool get_selected_line(bgui_vsol_soview2D_line_seg* &line);
+  void print_selected_line();
   bool get_selected_box(bgui_vsol_soview2D_polygon* &box);
   bool get_selected_poly(bgui_vsol_soview2D_polygon* &poly);
 

--- a/contrib/brl/bbas/bwm/bwm_observer_vgui.cxx
+++ b/contrib/brl/bbas/bwm/bwm_observer_vgui.cxx
@@ -452,6 +452,7 @@ void bwm_observer_vgui::delete_all()
     }
   }
   objects_.clear();
+  this->clear_objects();
 }
 
 void bwm_observer_vgui::set_corr(float x, float y)

--- a/contrib/brl/bbas/bwm/bwm_popup_menu.cxx
+++ b/contrib/brl/bbas/bwm/bwm_popup_menu.cxx
@@ -80,6 +80,15 @@ void bwm_popup_menu::get_menu(vgui_menu &menu)
   submenu.add( "Load Pointset 2D (ascii)",
                new vgui_command_simple<bwm_tableau_img>(img_tab,
                                                         &bwm_tableau_img::load_pointset_2d_ascii));
+  submenu.add( "Print Selected Line Seg",
+               new vgui_command_simple<bwm_tableau_img>(img_tab,
+                                                        &bwm_tableau_img::print_selected_line));
+  submenu.add( "Save vgl line segs 2d (ascii)",
+               new vgui_command_simple<bwm_tableau_img>(img_tab,
+                                                        &bwm_tableau_img::save_lines_vgl_ascii));
+  submenu.add( "Load vgl line segs 2d (ascii)",
+               new vgui_command_simple<bwm_tableau_img>(img_tab,
+                                                        &bwm_tableau_img::load_lines_vgl_ascii));
   submenu.add( "Load bounding boxes (ascii)",
              new vgui_command_simple<bwm_tableau_img>(img_tab,
                                                       &bwm_tableau_img::load_bounding_boxes_2d_ascii));

--- a/contrib/brl/bbas/bwm/bwm_tableau_img.h
+++ b/contrib/brl/bbas/bwm/bwm_tableau_img.h
@@ -96,10 +96,14 @@ class bwm_tableau_img : public bwm_tableau, public bgui_picker_tableau
   //: utilities
   void save_spatial_objects_2d();
   void load_spatial_objects_2d();
+  void save_lines_vgl_ascii();
+  void load_lines_vgl_ascii();
+  void load_spatial_objects_2d_ascii();
   void load_pointset_2d_ascii();
   void save_pointset_2d_ascii();
   void load_bounding_boxes_2d_ascii();
   void load_oriented_boxes_2d_ascii();
+  void print_selected_line();
   //: internal detail
   void set_viewer(vgui_viewer2D_tableau_sptr viewer) { my_observer_->set_viewer(viewer); }
 

--- a/contrib/brl/bbas/imesh/CMakeLists.txt
+++ b/contrib/brl/bbas/imesh/CMakeLists.txt
@@ -22,7 +22,7 @@ aux_source_directory(Templates imesh_sources)
 
 vxl_add_library(LIBRARY_NAME imesh LIBRARY_SOURCES  ${imesh_sources})
 
-target_link_libraries(imesh ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vul brdb ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl)
+target_link_libraries(imesh ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vbl_io ${VXL_LIB_PREFIX}vbl)
 
 # Algorithms
 add_subdirectory(algo)

--- a/contrib/brl/bpro/core/brad_pro/brad_processes.h
+++ b/contrib/brl/bpro/core/brad_pro/brad_processes.h
@@ -48,5 +48,6 @@ DECLARE_FUNC_CONS(brad_estimate_shadows_process);
 DECLARE_FUNC_CONS(brad_get_meta_data_info_process);
 DECLARE_FUNC_CONS(brad_get_cloud_coverage_process);
 DECLARE_FUNC_CONS(brad_get_image_coverage_process);
+DECLARE_FUNC_CONS(brad_get_image_footprint_process);
 DECLARE_FUNC_CONS(brad_compute_appearance_index_process);
 #endif

--- a/contrib/brl/bpro/core/brad_pro/brad_register.cxx
+++ b/contrib/brl/bpro/core/brad_pro/brad_register.cxx
@@ -54,5 +54,6 @@ void brad_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, brad_get_meta_data_info_process, "bradGetMetaDataInfoProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, brad_get_cloud_coverage_process, "bradGetCloudCoverageProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, brad_get_image_coverage_process, "bradGetImageCoverageProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, brad_get_image_footprint_process, "bradGetImageFootprintProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, brad_compute_appearance_index_process, "bradComputeAppearanceIndexProcess");
 }

--- a/contrib/brl/bpro/core/brad_pro/processes/brad_get_image_footprint_process.cxx
+++ b/contrib/brl/bpro/core/brad_pro/processes/brad_get_image_footprint_process.cxx
@@ -1,0 +1,79 @@
+// This is brl/bpro/core/brad_pro/processes/brad_get_image_footprint_process.cxx
+//:
+// \file
+//     get the footprint (array of 4 corners) of the satellite image
+//
+#include <bprb/bprb_func_process.h>
+#include <brad/brad_image_metadata.h>
+
+#include <vgl/vgl_polygon.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_unsigned.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_double.h>
+
+namespace brad_get_image_footprint_process_globals
+{
+  const unsigned n_inputs_  = 1;
+  const unsigned n_outputs_ = 3;
+}
+
+bool brad_get_image_footprint_process_cons(bprb_func_process& pro)
+{
+  using namespace brad_get_image_footprint_process_globals;
+
+  std::vector<std::string> input_types_(n_inputs_);
+  input_types_[0] = "brad_image_metadata_sptr"; // image metadata
+
+  std::vector<std::string> output_types_(n_outputs_);
+  output_types_[0] = "unsigned"; // number of sheets in polygon
+  output_types_[1] = "bbas_1d_array_unsigned_sptr"; // number of vertices in each polygon sheet
+  output_types_[2] = "bbas_1d_array_double_sptr";    // polygon vertices
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+bool brad_get_image_footprint_process(bprb_func_process& pro)
+{
+  using namespace brad_get_image_footprint_process_globals;
+
+  if (!pro.verify_inputs()) {
+    std::cout << pro.name() << ": WRONG inputs!!!" << std::endl;
+    return false;
+  }
+
+  //get the input(s)
+  brad_image_metadata_sptr meta = pro.get_input<brad_image_metadata_sptr>(0);
+
+  // vectorize footprint for output
+  vgl_polygon<double> footprint = meta->footprint_;
+  unsigned int nsheets = footprint.num_sheets();
+  std::vector<unsigned> nverts;
+  std::vector<double> verts;
+
+  for (unsigned int s = 0; s < nsheets; ++s) {
+    nverts.push_back(footprint[s].size());
+    for (unsigned int p = 0; p < footprint[s].size(); ++p) {
+      verts.push_back(footprint[s][p].x());
+      verts.push_back(footprint[s][p].y());
+    }
+  }
+
+  // fill out bbas_1d arrays
+  bbas_1d_array_unsigned_sptr poly_nverts = new bbas_1d_array_unsigned(nverts.size());
+  unsigned nv = 0;
+  for(std::vector<unsigned>::iterator nit = nverts.begin(); nit != nverts.end(); ++nit, ++nv)
+    poly_nverts->data_array[nv]=*nit;
+
+  bbas_1d_array_double_sptr poly_verts = new bbas_1d_array_double(verts.size());
+  unsigned iv = 0;
+  for(std::vector<double>::iterator vit = verts.begin(); vit != verts.end(); ++vit, ++iv)
+    poly_verts->data_array[iv]=*vit;
+
+  // generate output
+  unsigned i = 0;
+  pro.set_output_val<unsigned int>(i++, nsheets);
+  pro.set_output_val<bbas_1d_array_unsigned_sptr>(i++, poly_nverts);
+  pro.set_output_val<bbas_1d_array_double_sptr>(i++, poly_verts);
+
+  return true;
+}
+

--- a/contrib/brl/bpro/core/bvgl_pro/bvgl_processes.h
+++ b/contrib/brl/bpro/core/bvgl_pro/bvgl_processes.h
@@ -11,4 +11,7 @@ DECLARE_FUNC_CONS(bvgl_set_change_type_process);
 DECLARE_FUNC_CONS(bvgl_2d_box_intersection_process);
 DECLARE_FUNC_CONS(bvgl_geo_index_region_resource_process);
 DECLARE_FUNC_CONS(bvgl_geo_index_region_poly_resource_process);
+DECLARE_FUNC_CONS(bvgl_geo_index_region_overlap_process);
+DECLARE_FUNC_CONS(bvgl_geo_index_region_distance_process);
+DECLARE_FUNC_CONS(bvgl_geo_index_extent_process);
 #endif

--- a/contrib/brl/bpro/core/bvgl_pro/bvgl_register.cxx
+++ b/contrib/brl/bpro/core/bvgl_pro/bvgl_register.cxx
@@ -17,4 +17,7 @@ void bvgl_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_2d_box_intersection_process, "bvgl2DBoxIntersectionProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_geo_index_region_resource_process, "bvglGeoIndexRegionResourceProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_geo_index_region_poly_resource_process, "bvglGeoIndexRegionPolyResourceProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_geo_index_region_overlap_process, "bvglGeoIndexRegionOverlapProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_geo_index_region_distance_process, "bvglGeoIndexRegionDistanceProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bvgl_geo_index_extent_process, "bvglGeoIndexExtentProcess");
 }

--- a/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_extent_process.cxx
+++ b/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_extent_process.cxx
@@ -1,0 +1,83 @@
+// This is brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_extent_process.cxx
+#include <iostream>
+#include <complex>
+#include <cmath>
+#include <bprb/bprb_func_process.h>
+//:
+// \file
+// process to get geospatial extents of geo index leaves
+#include <vul/vul_file.h>
+#include <bvgl/algo/bvgl_2d_geo_index.h>
+#include <bvgl/algo/bvgl_2d_geo_index_sptr.h>
+#include <vcl_compiler.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_double.h>
+
+
+//: process to get geospatial extents of geo index leaves
+namespace bvgl_geo_index_extent_process_globals
+{
+  unsigned n_inputs_  = 1;
+  unsigned n_outputs_ = 1;
+}
+
+bool bvgl_geo_index_extent_process_cons(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_extent_process_globals;
+
+  std::vector<std::string> input_types_(n_inputs_);
+  input_types_[0] = "vcl_string";    // input geo index text file
+
+  std::vector<std::string> output_types_(n_outputs_);
+  output_types_[0] = "bbas_1d_array_double_sptr";   // flattened geospatial extents
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+bool bvgl_geo_index_extent_process(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_extent_process_globals;
+
+  // sanity check
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": Wrong Inputs!!!\n";
+    return false;
+  }
+
+  // general iterator
+  unsigned i = 0;
+
+  // get input
+  std::string geo_index_txt = pro.get_input<std::string>(0);
+
+  // read the tree
+  // since we are interested only for the structure, type of the tree doesn't matter here
+  if (!vul_file::exists(geo_index_txt)) {
+    std::cerr << pro.name() << ": can not find geo index file " << geo_index_txt << "!\n";
+    return false;
+  }
+  double min_size;
+  bvgl_2d_geo_index_node_sptr root = bvgl_2d_geo_index::read_and_construct<float>(geo_index_txt, min_size);
+  std::vector<bvgl_2d_geo_index_node_sptr> leaves;
+  bvgl_2d_geo_index::get_leaves(root, leaves);
+  unsigned nleaves = leaves.size();
+
+  // save extents in flattened array
+  std::vector<double> extent(4*nleaves, 0);
+  for (i=0; i < nleaves; i++) {
+    vgl_box_2d<double> box = leaves[i]->extent_;
+    extent[4*i+0] = box.min_x(); //ll_lon
+    extent[4*i+1] = box.min_y(); //ll_lat
+    extent[4*i+2] = box.max_x(); //ur_lon
+    extent[4*i+3] = box.max_y(); //ur_lon
+  }
+
+  // fill out bbas_1d array
+  bbas_1d_array_double_sptr extent_bbas = new bbas_1d_array_double(extent.size());
+  i = 0;
+  for(std::vector<double>::iterator it = extent.begin(); it != extent.end(); ++it, ++i)
+    extent_bbas->data_array[i] = *it;
+
+  // generate output
+  pro.set_output_val<bbas_1d_array_double_sptr>(0, extent_bbas);
+  return true;
+}

--- a/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_distance_process.cxx
+++ b/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_distance_process.cxx
@@ -1,0 +1,137 @@
+// This is brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_distance_process.cxx
+#include <iostream>
+#include <complex>
+#include <cmath>
+#include <bprb/bprb_func_process.h>
+//:
+// \file
+// process to generate distance of leaves to given geolocation
+#include <vul/vul_file.h>
+#include <vpgl/vpgl_lvcs.h>
+#include <bvgl/algo/bvgl_2d_geo_index.h>
+#include <bvgl/algo/bvgl_2d_geo_index_sptr.h>
+#include <vcl_compiler.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_double.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_unsigned.h>
+
+
+//: process to get leaf distance to given lon/lat location
+// returns approximate meter distance between centroid of leaf extent
+// and input lon/lat location
+namespace bvgl_geo_index_region_distance_process_globals
+{
+  unsigned n_inputs_  = 4;
+  unsigned n_outputs_ = 2;
+}
+
+bool bvgl_geo_index_region_distance_process_cons(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_region_distance_process_globals;
+
+  std::vector<std::string> input_types_(n_inputs_);
+  input_types_[0] = "vcl_string";    // input geo index text file
+  input_types_[1] = "double";        // longitude
+  input_types_[2] = "double";        // latitude
+  input_types_[3] = "unsigned";      // max nodes for distance calc
+
+  std::vector<std::string> output_types_(n_outputs_);
+  output_types_[0] = "bbas_1d_array_double_sptr";    // distance of unique nodes to lon/lat
+  output_types_[1] = "bbas_1d_array_unsigned_sptr";  // per-leaf index into unique node list
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+bool bvgl_geo_index_region_distance_process(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_region_distance_process_globals;
+
+  // sanity check
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": Wrong Inputs!!!\n";
+    return false;
+  }
+
+  // general iterator
+  unsigned i = 0;
+
+  // get inputs
+  i = 0;
+  std::string geo_index_txt = pro.get_input<std::string>(i++);
+  double lon = pro.get_input<double>(i++);
+  double lat = pro.get_input<double>(i++);
+  unsigned max_nodes = pro.get_input<unsigned>(i++);
+
+  // read the tree
+  if (!vul_file::exists(geo_index_txt)) {
+    std::cerr << pro.name() << ": can not find geo index file " << geo_index_txt << "!\n";
+    return false;
+  }
+  double min_size;
+  bvgl_2d_geo_index_node_sptr root = bvgl_2d_geo_index::read_and_construct<float>(geo_index_txt, min_size);
+
+  // get all tree leaves
+  std::vector<bvgl_2d_geo_index_node_sptr> nodes;
+  bvgl_2d_geo_index::get_leaves(root, nodes);
+  unsigned n_leaves = nodes.size();
+  std::cout << "n_leaves = " << n_leaves << std::endl;
+
+  // traverse hierarchy upwards until number of unique nodes is less
+  // than the maximum number of nodes
+  unsigned n_nodes = n_leaves;
+  if (max_nodes>0) {
+    while (n_nodes > max_nodes && n_nodes != 1) {
+
+      // set every node to its parent
+      for (i = 0; i < n_leaves; i++)
+        nodes[i] = nodes[i]->parent_;
+
+      // count unique nodes
+      n_nodes = 1;
+      for (i = 1; i < n_leaves; i++)
+        if (nodes[i] != nodes[i-1]) {n_nodes++;}
+
+      std::cout << "move to parent, n_nodes = " << n_nodes << std::endl;
+
+    }
+  }
+
+  // unique nodes & leaf indices into unique nodes
+  std::vector<bvgl_2d_geo_index_node_sptr> nodes_unique;
+  std::vector<unsigned> indices(n_leaves,0);
+
+  for (i = 0; i < n_leaves; i++) {
+    if (i==0 || nodes[i]!=nodes[i-1])
+      nodes_unique.push_back(nodes[i]);
+    indices[i] = nodes_unique.size()-1;
+  }
+
+  // LVCS for input location
+  vpgl_lvcs lvcs(lat, lon, 0.0, vpgl_lvcs::wgs84, vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+
+  // distance of each unique node to lvcs origin
+  std::vector<double> distance(n_nodes,0.0);
+  for (i = 0; i < n_nodes; i++) {
+    vgl_point_2d<double> xy = nodes_unique[i]->extent_.centroid();
+    double lx, ly, lz;
+    lvcs.global_to_local(xy.x(),xy.y(),0.0,
+                         vpgl_lvcs::wgs84, lx,ly,lz,
+                         vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+    distance[i] = std::sqrt(lx*lx + ly*ly);
+  }
+
+  // fill out bbas_1d arrays
+  bbas_1d_array_double_sptr distance_bbas = new bbas_1d_array_double(distance.size());
+  i = 0;
+  for(std::vector<double>::iterator it = distance.begin(); it != distance.end(); ++it, ++i)
+    distance_bbas->data_array[i] = *it;
+
+  bbas_1d_array_unsigned_sptr indices_bbas = new bbas_1d_array_unsigned(indices.size());
+  i = 0;
+  for(std::vector<unsigned>::iterator it = indices.begin(); it != indices.end(); ++it, ++i)
+    indices_bbas->data_array[i] = *it;
+
+  // generate output
+  pro.set_output_val<bbas_1d_array_double_sptr>(0, distance_bbas);
+  pro.set_output_val<bbas_1d_array_unsigned_sptr>(1, indices_bbas);
+  return true;
+}

--- a/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_overlap_process.cxx
+++ b/contrib/brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_overlap_process.cxx
@@ -1,0 +1,96 @@
+// This is brl/bpro/core/bvgl_pro/processes/bvgl_geo_index_region_overlap_process.cxx
+#include <iostream>
+#include <complex>
+#include <bprb/bprb_func_process.h>
+//:
+// \file
+// process to generate overlap of leaves to a given region
+#include <vul/vul_file.h>
+#include <vgl/vgl_intersection.h>
+#include <vgl/vgl_area.h>
+#include <bvgl/algo/bvgl_2d_geo_index.h>
+#include <bvgl/algo/bvgl_2d_geo_index_sptr.h>
+#include <vcl_compiler.h>
+#include <bpro/core/bbas_pro/bbas_1d_array_double.h>
+
+
+//: process to get leaf overlap with given 2-d bbox region
+namespace bvgl_geo_index_region_overlap_process_globals
+{
+  unsigned n_inputs_  = 5;
+  unsigned n_outputs_ = 1;
+}
+
+bool bvgl_geo_index_region_overlap_process_cons(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_region_overlap_process_globals;
+
+  std::vector<std::string> input_types_(n_inputs_);
+  input_types_[0] = "vcl_string";    // input geo index text file
+  input_types_[1] = "double";        // lower left lon
+  input_types_[2] = "double";        // lower left lat
+  input_types_[3] = "double";        // upper right lon
+  input_types_[4] = "double";        // upper right lat
+
+  std::vector<std::string> output_types_(n_outputs_);
+  output_types_[0] = "bbas_1d_array_double_sptr";   // per-leaf overlap with given region
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+bool bvgl_geo_index_region_overlap_process(bprb_func_process& pro)
+{
+  using namespace bvgl_geo_index_region_overlap_process_globals;
+
+  // sanity check
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": Wrong Inputs!!!\n";
+    return false;
+  }
+
+  // general iterator
+  unsigned i = 0;
+
+  // get inputs
+  i = 0;
+  std::string geo_index_txt = pro.get_input<std::string>(i++);
+  double ll_lon = pro.get_input<double>(i++);
+  double ll_lat = pro.get_input<double>(i++);
+  double ur_lon = pro.get_input<double>(i++);
+  double ur_lat = pro.get_input<double>(i++);
+
+  // read the tree
+  // since we are interested only for the structure, type of the tree doesn't matter here
+  if (!vul_file::exists(geo_index_txt)) {
+    std::cerr << pro.name() << ": can not find geo index file " << geo_index_txt << "!\n";
+    return false;
+  }
+  double min_size;
+  bvgl_2d_geo_index_node_sptr root = bvgl_2d_geo_index::read_and_construct<float>(geo_index_txt, min_size);
+  std::vector<bvgl_2d_geo_index_node_sptr> leaves;
+  bvgl_2d_geo_index::get_leaves(root, leaves);
+
+  // test region bounding box
+  vgl_box_2d<double> bbox(ll_lon, ur_lon, ll_lat, ur_lat);
+  std::cout << "bounding box: " << bbox << std::endl;
+
+  // % overlap of each leaf with bounding box
+  unsigned nleaves = leaves.size();
+  std::vector<double> overlap(nleaves,0.0);
+
+  for (i = 0; i < nleaves; i++) {
+    double leaf_area_total = vgl_area(leaves[i]->extent_);
+    double leaf_area_overlap = vgl_area(vgl_intersection(bbox, leaves[i]->extent_));
+    overlap[i] = leaf_area_overlap/leaf_area_total;
+  }
+
+  // fill out bbas_1d array
+  bbas_1d_array_double_sptr overlap_bbas = new bbas_1d_array_double(nleaves);
+  i = 0;
+  for(std::vector<double>::iterator it = overlap.begin(); it != overlap.end(); ++it, ++i)
+    overlap_bbas->data_array[i] = *it;
+
+  // generate output
+  pro.set_output_val<bbas_1d_array_double_sptr>(0, overlap_bbas);
+  return true;
+}

--- a/contrib/brl/bpro/core/pyscripts/brad_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/brad_adaptor.py
@@ -388,6 +388,39 @@ def get_image_coverage(mdata):
     else:
         return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
+def get_image_footprint(mdata):
+    batch.init_process("bradGetImageFootprintProcess")
+    batch.set_input_from_db(0, mdata)
+    status = batch.run_process()
+    if status:
+
+        # output size parameters
+        (id, type) = batch.commit_output(0)
+        nsheets = batch.get_output_unsigned(id)
+        batch.remove_data(id)
+        (id, type) = batch.commit_output(1)
+        nverts = batch.get_bbas_1d_array_unsigned(id)
+        batch.remove_data(id)
+
+        # output vertices
+        (id, type) = batch.commit_output(2);
+        verts = batch.get_output_double_array(id);
+        batch.remove_data(id)
+
+        # reshape output vertices
+        verts_out = []
+        idx = 0
+        for i in xrange(nsheets):
+            verts_out.append([])
+            for j in xrange(nverts[i]):
+                x = verts[idx]; idx += 1
+                y = verts[idx]; idx += 1
+                verts_out[i].append((x,y))
+
+        return verts_out
+    else:
+        return None
+
 def get_cloud_coverage(mdata):
     batch.init_process("bradGetCloudCoverageProcess")
     batch.set_input_from_db(0, mdata)

--- a/contrib/brl/bpro/core/pyscripts/brad_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/brad_adaptor.py
@@ -12,12 +12,12 @@ batch = brl_init.DummyBatch()
 
 # parse metadata of a sat image, reads sat image, nitf2 header and a
 # metadata file in the same folder as the image if found
-def read_nitf_metadata(nitf_filename, imd_folder="", verbose = False):
+def read_nitf_metadata(nitf_filename, img_folder="", verbose = False):
     batch.init_process("bradNITFReadMetadataProcess")
     # requires full path and name
     batch.set_input_string(0, nitf_filename)
     # pass empty if meta is in img folder
-    batch.set_input_string(1, imd_folder)
+    batch.set_input_string(1, img_folder)
     batch.set_input_bool(2, verbose)
     status = batch.run_process()
     meta = None

--- a/contrib/brl/bpro/core/pyscripts/bvgl_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bvgl_adaptor.py
@@ -17,12 +17,16 @@ def box_2d_intersection(in_kml, out_kml=""):
     if status:
         (id, type) = batch.commit_output(0)
         ll_lon = batch.get_output_double(id)
+        batch.remove_data(id)
         (id, type) = batch.commit_output(1)
         ll_lat = batch.get_output_double(id)
+        batch.remove_data(id)
         (id, type) = batch.commit_output(2)
         ur_lon = batch.get_output_double(id)
+        batch.remove_data(id)
         (id, type) = batch.commit_output(3)
         ur_lat = batch.get_output_double(id)
+        batch.remove_data(id)
         return True, ll_lon, ll_lat, ur_lon, ur_lat
     else:
         return False, 0.0, 0.0, 0.0, 0.0
@@ -41,6 +45,7 @@ def geo_index_region_resource(geo_index_txt, ll_lon, ll_lat, ur_lon, ur_lat, out
     if status:
         (id, type) = batch.commit_output(0)
         n_leaves = batch.get_output_unsigned(id)
+        batch.remove_data(id)
         return n_leaves
     else:
         return 0
@@ -57,6 +62,7 @@ def geo_index_region_poly_resource(geo_index_txt, poly_kml, out_file):
     if status:
         (id, type) = batch.commit_output(0)
         n_leaves = batch.get_output_unsigned(id)
+        batch.remove_data(id)
         return n_leaves
     else:
         return 0

--- a/contrib/brl/bpro/core/pyscripts/bvgl_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bvgl_adaptor.py
@@ -60,3 +60,69 @@ def geo_index_region_poly_resource(geo_index_txt, poly_kml, out_file):
         return n_leaves
     else:
         return 0
+
+
+# obtain 2d quad tree geological leaves % overlap with given region
+def geo_index_region_overlap(geo_index_txt, ll_lon, ll_lat, ur_lon, ur_lat):
+  batch.init_process("bvglGeoIndexRegionOverlapProcess")
+  batch.set_input_string(0, geo_index_txt)
+  batch.set_input_double(1, ll_lon)
+  batch.set_input_double(2, ll_lat)
+  batch.set_input_double(3, ur_lon)
+  batch.set_input_double(4, ur_lat)
+  status = batch.run_process()
+  if status:
+    (id, type) = batch.commit_output(0)
+    overlap = batch.get_output_double_array(id)
+    batch.remove_data(id)
+    return overlap
+  else:
+    return None
+
+
+# obtain 2d quad tree geological leaf distance to given location
+# users may provide an optional "max_nodes" parameter to limit the number of
+# distance measurements, relying on tree nodes higher in the hierachy.
+# returns a list of distance measurements and a list of indices denoting
+# the position of each tree leaf in the distance list
+# (e.g., distance[indices] provides a distance for every leaf, possibly
+# measured from a parent node centroid)
+def geo_index_region_distance(geo_index_txt, lon, lat, max_nodes=None):
+  if not max_nodes: max_nodes = 0
+
+  batch.init_process("bvglGeoIndexRegionDistanceProcess")
+  batch.set_input_string(0, geo_index_txt)
+  batch.set_input_double(1, lon)
+  batch.set_input_double(2, lat)
+  batch.set_input_unsigned(3, max_nodes)
+  status = batch.run_process()
+  if status:
+    (id, type) = batch.commit_output(0)
+    distance = batch.get_output_double_array(id)
+    batch.remove_data(id)
+
+    (id, type) = batch.commit_output(1)
+    indices = batch.get_bbas_1d_array_unsigned(id)
+    batch.remove_data(id)
+
+    return distance, indices
+  else:
+    return None
+
+
+# obtain geospatial extents from a geo_index file
+# returns list, where each element is [ll_lon,ll_lat,ur_lon,ur_lat]
+def geo_index_extents(geo_index_txt):
+  batch.init_process("bvglGeoIndexExtentProcess")
+  batch.set_input_string(0, geo_index_txt)
+  status = batch.run_process()
+  if status:
+    (id, type) = batch.commit_output(0)
+    extents_flat = batch.get_output_double_array(id)
+    batch.remove_data(id)
+
+    n_scene = len(extents_flat)/4
+    extents = [extents_flat[4*i : 4*i+4] for i in xrange(n_scene)]
+    return extents
+  else:
+    return None

--- a/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
@@ -286,7 +286,14 @@ def convert_to_local_rational_camera(rational_cam, lvcs):
 # ;
 # camera saving;
 # ;
-
+def print_rational_camera(camera):
+    batch.init_process("vpglPrintRationalCameraProcess")
+    batch.set_input_from_db(0, camera)
+    status = batch.run_process()
+    if status:
+        return
+    else:
+        raise VpglException("Failed to print rational camera")
 
 def save_rational_camera(camera, path):
     batch.init_process("vpglSaveRationalCameraProcess")

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_print_rational_camera_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_print_rational_camera_process.cxx
@@ -1,0 +1,48 @@
+// This is brl/bpro/core/vpgl_pro/processes/vpgl_print_rational_camera_process.cxx
+#include <iostream>
+#include <bprb/bprb_func_process.h>
+//:
+// \file
+
+#include <bprb/bprb_parameters.h>
+#include <vcl_compiler.h>
+#include <vpgl/vpgl_camera.h>
+#include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/vpgl_local_rational_camera.h>
+
+//: initialization
+bool vpgl_print_rational_camera_process_cons(bprb_func_process& pro)
+{
+  // this process takes one input: the filename
+  std::vector<std::string> input_types;
+  input_types.push_back("vpgl_camera_double_sptr");
+  // this process has no output
+  std::vector<std::string> output_types;
+  return pro.set_input_types(input_types) && pro.set_output_types(output_types);
+}
+
+bool vpgl_print_rational_camera_process(bprb_func_process& pro)
+{
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": Wrong Inputs!!\n";
+    return false;
+  }
+  // get input
+  vpgl_camera_double_sptr camera = pro.get_input<vpgl_camera_double_sptr>(0);
+
+  vpgl_local_rational_camera<double>* cam = dynamic_cast<vpgl_local_rational_camera<double>*>(camera.as_pointer());
+  if (!cam) {
+    // try rational camera
+    vpgl_rational_camera<double>* cam2 = dynamic_cast<vpgl_rational_camera<double>*>(camera.as_pointer());
+    if (!cam2) {
+      std::cerr << pro.name() << "error: could not convert camera input to a vpgl_rational_camera or local rational camera\n";
+      return false;
+    }
+    cam2->print(std::cout);
+  }
+  else {
+    cam->print(std::cout);
+  }
+
+  return true;
+}

--- a/contrib/brl/bpro/core/vpgl_pro/vpgl_processes.h
+++ b/contrib/brl/bpro/core/vpgl_pro/vpgl_processes.h
@@ -12,6 +12,7 @@ DECLARE_FUNC_CONS(vpgl_load_rational_camera_process);
 DECLARE_FUNC_CONS(vpgl_load_rational_camera_nitf_process);
 DECLARE_FUNC_CONS(vpgl_load_perspective_camera_process);
 DECLARE_FUNC_CONS(vpgl_save_rational_camera_process);
+DECLARE_FUNC_CONS(vpgl_print_rational_camera_process);
 DECLARE_FUNC_CONS(vpgl_save_perspective_camera_process);
 DECLARE_FUNC_CONS(vpgl_nitf_camera_coverage_process);
 DECLARE_FUNC_CONS(vpgl_create_local_rational_camera_process);

--- a/contrib/brl/bpro/core/vpgl_pro/vpgl_processes.h
+++ b/contrib/brl/bpro/core/vpgl_pro/vpgl_processes.h
@@ -85,6 +85,7 @@ DECLARE_FUNC_CONS(vpgl_convert_local_rational_to_perspective_process);
 #if HAS_GEOTIFF
 DECLARE_FUNC_CONS(vpgl_load_geo_camera_process3);
 DECLARE_FUNC_CONS(vpgl_save_geo_camera_tfw_process);
+DECLARE_FUNC_CONS(vpgl_get_geotransform_process);
 #endif
 DECLARE_FUNC_CONS(vpgl_interpolate_perspective_cameras_process);
 DECLARE_FUNC_CONS(vpgl_load_lvcs_process);

--- a/contrib/brl/bpro/core/vpgl_pro/vpgl_register.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/vpgl_register.cxx
@@ -26,6 +26,7 @@ void vpgl_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_nitf_camera_coverage_process, "vpglNITFCameraCoverageProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_save_perspective_camera_process, "vpglSavePerspectiveCameraProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_save_rational_camera_process, "vpglSaveRationalCameraProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_print_rational_camera_process, "vpglPrintRationalCameraProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_create_local_rational_camera_process, "vpglCreateLocalRationalCameraProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_convert_to_local_rational_camera_process, "vpglConvertToLocalRationalCameraProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_create_local_rational_camera_nitf_process, "vpglCreateLocalRationalCameraNITFProcess");

--- a/contrib/brl/bpro/core/vpgl_pro/vpgl_register.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/vpgl_register.cxx
@@ -98,6 +98,7 @@ void vpgl_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_create_geo_camera_process, "vpglCreateGeoCameraProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_load_geo_camera_process3, "vpglLoadGeotiffCamFromHeaderProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_save_geo_camera_tfw_process, "vpglSaveGeoCameraTFWProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_get_geotransform_process, "vpglGetGeoTransformProcess");
 #endif
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, vpgl_interpolate_perspective_cameras_process, "vpglInterpolatePerspectiveCamerasProcess");
 

--- a/contrib/brl/bseg/bvxm/pro/processes/bvxm_create_scene_xml_process.h
+++ b/contrib/brl/bseg/bvxm/pro/processes/bvxm_create_scene_xml_process.h
@@ -10,8 +10,11 @@
 // \verbatim
 // Modifications
 //    July, 2015, Yi Dong, add a process to generate quad-tree structured scenes for a large region
+//    Aug,  2018, Yi Dong, add extension on the input ROI to enlarge the region
+//                         also returns scenes that cover the bounding box of input ROI
 // \endverbatim
 #include <bprb/bprb_func_process.h>
+#include <vgl_box_2d.h>
 
 // generate a bvxm scene xml
 //: global variables
@@ -29,8 +32,10 @@ bool bvxm_create_scene_xml_process(bprb_func_process& pro);
 //: global variables
 namespace bvxm_create_scene_xml_large_scale_process_globals
 {
-  constexpr unsigned n_inputs_ = 9;
+  constexpr unsigned n_inputs_  = 10;
   constexpr unsigned n_outputs_ = 1;
+
+  vgl_box_2d<double> enlarge_region_by_meter(vgl_box_2d<double> const& box_ori, double const& extension);
 }
 //: set input and output types
 bool bvxm_create_scene_xml_large_scale_process_cons(bprb_func_process& pro);

--- a/contrib/brl/bseg/bvxm/pyscripts/bvxm_adaptor.py
+++ b/contrib/brl/bseg/bvxm/pyscripts/bvxm_adaptor.py
@@ -44,7 +44,7 @@ def create_scene_xml(scene_xml, world_dir, lvcs, lvcs_file, dim_x, dim_y, dim_z,
     return batch.run_process()
 
 
-def create_scene_large_scale(roi_kml, scene_root, world_dir, dem_folder, world_size=500.0, voxel_size=1.0, height_diff=120.0, height_sub=25.0, land_folder=""):
+def create_scene_large_scale(roi_kml, scene_root, world_dir, dem_folder, world_size=500.0, voxel_size=1.0, height_diff=120.0, height_sub=25.0, extension = 500.0, land_folder=""):
     batch.init_process("bvxmCreateSceneXmlLargeScaleProcess")
     batch.set_input_string(0, roi_kml)
     batch.set_input_string(1, scene_root)
@@ -55,6 +55,7 @@ def create_scene_large_scale(roi_kml, scene_root, world_dir, dem_folder, world_s
     batch.set_input_float(6, voxel_size)
     batch.set_input_float(7, height_diff)
     batch.set_input_float(8, height_sub)
+    batch.set_input_float(9, extension)
     status = batch.run_process()
     if status:
         (id, type) = batch.commit_output(0)

--- a/contrib/brl/bseg/bvxm/pyscripts/bvxm_adaptor.py
+++ b/contrib/brl/bseg/bvxm/pyscripts/bvxm_adaptor.py
@@ -60,6 +60,7 @@ def create_scene_large_scale(roi_kml, scene_root, world_dir, dem_folder, world_s
     if status:
         (id, type) = batch.commit_output(0)
         n_scenes = batch.get_output_unsigned(id)
+        batch.remove_data(id)
         return n_scenes
     else:
         return 0
@@ -71,16 +72,22 @@ def scene_box(scene):
     batch.run_process()
     (id, type) = batch.commit_output(0)
     lower_left_lon = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(1)
     lower_left_lat = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(2)
     lower_left_elev = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(3)
     upper_right_lon = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(4)
     upper_right_lat = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(5)
     upper_right_elev = batch.get_output_double(id)
+    batch.remove_data(id)
     return lower_left_lon, lower_left_lat, lower_left_elev, upper_right_lon, upper_right_lat, upper_right_elev
 
 # changed to always draw a filled polygon, default alpha value (a) is set to 0 so that the box is completely transparent though so it will look as an empty polygon
@@ -117,10 +124,13 @@ def scene_origin(scene):
     batch.run_process()
     (id, type) = batch.commit_output(0)
     lower_left_lon = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(1)
     lower_left_lat = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(2)
     lower_left_z = batch.get_output_double(id)
+    batch.remove_data(id)
     return lower_left_lon, lower_left_lat, lower_left_z
 
 # return the scene bbox and voxel size in local coordinates
@@ -132,18 +142,25 @@ def scene_local_box(scene):
     batch.run_process()
     (id, type) = batch.commit_output(0)
     lower_left_x = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(1)
     lower_left_y = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(2)
     upper_right_x = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(3)
     upper_right_y = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(4)
     voxel_size = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(5)
     lower_left_z = batch.get_output_double(id)  # min z
+    batch.remove_data(id)
     (id, type) = batch.commit_output(6)
     upper_right_z = batch.get_output_double(id)  # max z
+    batch.remove_data(id)
     return lower_left_x, lower_left_y, upper_right_x, upper_right_y, voxel_size, lower_left_z, upper_right_z
 
 # return the scene world directory
@@ -155,6 +172,7 @@ def model_dir(scene):
     batch.run_process()
     (id, type) = batch.commit_output(0)
     model_dir = batch.get_output_string(id)
+    batch.remove_data(id)
     return model_dir
 
 


### PR DESCRIPTION
Various updates to BRL contrib libraries and adaptors:

- brdb_query fix compile error on VS2017
- bwm update for new line options
- remove dependency on brdb by imesh lib
- vpgl_adaptor: add vpglGetGeoTransform, exception checks
- brl, vpgl_geo_camera_processes - appropriate half-pixel offset in TFW file
- brl vpgl_adaptor - print out rational camera
- brad_adaptor - add process to get image footprint from metadata
- bvxm_adaptor - create_scene_xml_large_scale_process, enlarge the scene region based on given expansion size in meter
- new bvgl python processes for geo_index manipulation
- brl adaptor bugfix - clean database outputs in bvgl_adaptor and bvxm_adaptor
- brad_image_metadata - lat/lon from TXT metadata file only when present in TXT file
- brad_image_metadata - fix bug when parsing SWIR tag from imd file
- brad_adaptor - fix argument spelling (imd->img)

