### PR TITLE
vpgl_rational_camera_compute

### DIFF
--- a/core/vpgl/algo/CMakeLists.txt
+++ b/core/vpgl/algo/CMakeLists.txt
@@ -28,6 +28,7 @@ set( vpgl_algo_sources
   vpgl_ba_shared_k_lsqr.h          vpgl_ba_shared_k_lsqr.cxx
   vpgl_affine_rectification.h      vpgl_affine_rectification.cxx
   vpgl_camera_transform.h          vpgl_camera_transform.cxx
+  vpgl_fit_rational_cubic.h        vpgl_fit_rational_cubic.cxx
 )
 include(${VXL_CMAKE_DIR}/FindTIFF.cmake)
 if(TIFF_FOUND)

--- a/core/vpgl/algo/tests/CMakeLists.txt
+++ b/core/vpgl/algo/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable( vpgl_algo_test_all
   test_bundle_adjust.cxx
   test_affine_rectification.cxx
   test_affine_tensor_transfer.cxx
+  test_fit_rational_cubic.cxx
 )
 target_link_libraries( vpgl_algo_test_all ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}testlib )
 endif()
@@ -59,6 +60,7 @@ add_executable( vpgl_algo_test_all
   test_affine_rectification.cxx
   test_affine_tensor_transfer.cxx
   test_backproject_dem.cxx
+  test_fit_rational_cubic.cxx
 )
 target_link_libraries( vpgl_algo_test_all ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vpgl_file_formats ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}testlib )
 add_test( NAME vpgl_algo_test_backproject_dem COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_backproject_dem )
@@ -83,6 +85,7 @@ add_test( NAME vpgl_algo_test_ba_fixed_k_lsqr COMMAND $<TARGET_FILE:vpgl_algo_te
 add_test( NAME vpgl_algo_test_ba_shared_k_lsqr COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_ba_shared_k_lsqr )
 add_test( NAME vpgl_algo_test_affine_rect COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_affine_rect )
 add_test( NAME vpgl_algo_test_affine_tensor_transfer COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_affine_tensor_transfer )
+add_test( NAME vpgl_algo_test_fit_rational_cubic COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_fit_rational_cubic )
 
 add_executable( vpgl_algo_test_include test_include.cxx )
 target_link_libraries( vpgl_algo_test_include ${VXL_LIB_PREFIX}vpgl_algo )

--- a/core/vpgl/algo/tests/test_driver.cxx
+++ b/core/vpgl/algo/tests/test_driver.cxx
@@ -20,6 +20,7 @@ DECLARE( test_ba_shared_k_lsqr );
 DECLARE( test_affine_rect );
 DECLARE( test_backproject_dem );
 DECLARE( test_affine_tensor_transfer );
+DECLARE( test_fit_rational_cubic );
 
 void register_tests()
 {
@@ -42,6 +43,7 @@ REGISTER( test_ba_fixed_k_lsqr );
 REGISTER( test_ba_shared_k_lsqr );
 REGISTER( test_affine_rect );
 REGISTER( test_affine_tensor_transfer );
+REGISTER( test_fit_rational_cubic );
 #if HAS_GEOTIFF
  REGISTER( test_backproject_dem );
 #endif

--- a/core/vpgl/algo/tests/test_fit_rational_cubic.cxx
+++ b/core/vpgl/algo/tests/test_fit_rational_cubic.cxx
@@ -1,0 +1,182 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <testlib/testlib_test.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <vpl/vpl.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vnl/vnl_random.h>
+#include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/algo/vpgl_fit_rational_cubic.h>
+
+static vnl_vector_fixed<double, 20> power_vector(double x, double y, double z){
+  // Form the monomials in homogeneous form
+  double w  = 1;
+  double xx = x*x;
+  double xy = x*y;
+  double xz = x*z;
+  double yy = y*y;
+  double yz = y*z;
+  double zz = z*z;
+  double xxx = x*xx;
+  double xxy = x*xy;
+  double xxz = x*xz;
+  double xyy = x*yy;
+  double xyz = x*yz;
+  double xzz = x*zz;
+  double yyy = y*yy;
+  double yyz = y*yz;
+  double yzz = y*zz;
+  double zzz = z*zz;
+  double xww = x*w*w;
+  double yww = y*w*w;
+  double zww = z*w*w;
+  double www = w*w*w;
+  double xxw = xx*w;
+  double xyw = xy*w;
+  double xzw = xz*w;
+  double yyw = yy*w;
+  double yzw = yz*w;
+  double zzw = zz*w;
+
+  //fill the vector
+  vnl_vector_fixed<double, 20> pv;
+  pv.put( 0, double(xxx));
+  pv.put( 1, double(xxy));
+  pv.put( 2, double(xxz));
+  pv.put( 3, double(xxw));
+  pv.put( 4, double(xyy));
+  pv.put( 5, double(xyz));
+  pv.put( 6, double(xyw));
+  pv.put( 7, double(xzz));
+  pv.put( 8, double(xzw));
+  pv.put( 9, double(xww));
+  pv.put(10, double(yyy));
+  pv.put(11, double(yyz));
+  pv.put(12, double(yyw));
+  pv.put(13, double(yzz));
+  pv.put(14, double(yzw));
+  pv.put(15, double(yww));
+  pv.put(16, double(zzz));
+  pv.put(17, double(zzw));
+  pv.put(18, double(zww));
+  pv.put(19, double(www));
+  return pv;
+}
+
+static void project(const double x, const double y, const double z, double& u, double& v,
+                    vnl_vector_fixed<double,20> const& neu_u, vnl_vector_fixed<double,20> const& den_u,
+                    vnl_vector_fixed<double,20> const& neu_v, vnl_vector_fixed<double,20> const& den_v){
+  vnl_matrix_fixed<double, 4, 20> rational_coeffs;
+  for(size_t i =0; i<20; ++i){
+    rational_coeffs[0][i] = neu_u[i];
+    rational_coeffs[1][i] = den_u[i];
+    rational_coeffs[2][i] = neu_v[i];
+    rational_coeffs[3][i] = den_v[i];
+  }
+  vnl_vector_fixed<double, 4> polys = rational_coeffs*power_vector(x, y, z);
+  u = polys[0]/polys[1];
+  v = polys[2]/polys[3];
+}
+
+static void test_fit_rational_cubic()
+{
+  vnl_random rng;
+  //Rational polynomial coefficients
+  vnl_vector_fixed<double,20> neu_u, den_u, neu_v, den_v;
+  neu_u.fill(0.0);  den_u.fill(0.0);   neu_v.fill(0.0); den_v.fill(0.0);
+  neu_u[0]=0.1; neu_u[10]=0.071; neu_u[7]=0.01;  neu_u[9]=0.3;
+  neu_u[15]=1.0; neu_u[18]=1.0, neu_u[19]=1.0;
+
+  den_u[0]=0.1; den_u[10]=0.05; den_u[17]=0.01; den_u[9]=1.0;
+  den_u[15]=1.0; den_u[18]=1.0; den_u[19]=1.0;
+
+  neu_v[0]=0.02; neu_v[10]=0.014; neu_v[7]=0.1; neu_v[9]=0.4;
+  neu_v[15]=0.5; neu_v[18]=0.01; neu_v[19]=0.33;
+
+  den_v[0]=0.1; den_v[10]=0.05; den_v[17]=0.03; den_v[9]=1.0;
+  den_v[15]=1.0; den_v[18]=0.3; den_v[19]=1.0;
+
+  std::vector<vgl_point_2d<double> > image_pts;
+  std::vector<vgl_point_3d<double> > ground_pts;
+  size_t n_points = 1000;
+  for (unsigned i = 0; i < n_points; i++) {
+    double x = 2.0*rng.drand64() - 1.0;
+    double y = 2.0*rng.drand64() - 1.0;
+    double z = 2.0*rng.drand64() - 1.0;
+    vgl_point_3d<double> p3d(x,y,z);
+    ground_pts.push_back(p3d);
+    double u, v;
+    project(x, y, z, u, v, neu_u, den_u, neu_v, den_v);
+    image_pts.push_back(vgl_point_2d<double>(u, v));
+  }
+  vnl_vector<double> coeffs;
+  coeffs.set_size(80);
+  coeffs.fill(0.0);
+  for (size_t i = 0; i < 20; ++i) {
+	  coeffs[i] = neu_u[i];
+	  coeffs[20 + i] = den_u[i];
+	  coeffs[40 + i] = neu_v[i];
+	  coeffs[60 + i] = den_v[i];
+  }
+  vpgl_fit_rational_cubic frc(image_pts, ground_pts);
+  //frc.set_initial_guess(coeffs);
+  frc.compute_initial_guess();
+  std::cout << "initial rms error " << frc.initial_rms_error() << std::endl;
+  frc.fit();
+  std::cout << "final rms error " << frc.final_rms_error() << std::endl;
+  bool good = frc.final_rms_error() < 1.0e-7;
+  std::vector<std::vector<double> > result = frc.rational_coeffs();
+  TEST("fit test rpc", good, true);
+
+  // actual rpc
+  neu_u.fill(0.0);  den_u.fill(0.0);   neu_v.fill(0.0); den_v.fill(0.0);
+  neu_u[0]=0.01666376; neu_u[1]=1.025488; neu_u[2]=-0.0001935893; neu_u[3]=0.02406288; neu_u[4]=0.002217166;  neu_u[5]=-7.561634e-05;
+  neu_u[6]=4.181984e-05; neu_u[7]=-0.01500574; neu_u[8]=-0.0005594865; neu_u[9]=6.275384e-06; neu_u[10]=4.613564e-06; neu_u[11]=0.0002020006;
+  neu_u[12]=-7.284628e-05; neu_u[13]=-9.125171e-06; neu_u[14]=-0.0001030499; neu_u[15]=-7.775356e-05; neu_u[16]=-2.434858e-07; neu_u[17]=-1.238075e-06;
+  neu_u[18]=7.033904e-06; neu_u[19]=-2.06226e-07;
+
+  den_u[0]=1.0; den_u[1]=-0.001694469; den_u[2]=-0.002273012; den_u[3]=-0.0003236357; den_u[4]=7.259351e-05;  den_u[5]=3.494455e-06;
+  den_u[6]=-7.274219e-06; den_u[7]=3.526226e-05; den_u[8]=7.985993e-05; den_u[9]=-8.700142e-06; den_u[10]=2.69718e-07; den_u[11]=2.318892e-06;
+  den_u[12]=-4.58529e-06; den_u[13]=-1.084096e-07; den_u[14]=-3.374917e-06; den_u[15]=-3.194725e-06; den_u[16]=3.890611e-08; den_u[17]=-1.892156e-07;
+  den_u[18]=1.864785e-07; den_u[19]=0.0;
+
+  neu_v[0]=0.02715755; neu_v[1]=-1.736789; neu_v[2]=-2.811587; neu_v[3]=0.07540262; neu_v[4]=-0.009770075;  neu_v[5]=3.424154e-05;
+  neu_v[6]=0.0005777122; neu_v[7]=-0.007835224; neu_v[8]=-0.02033735; neu_v[9]=-7.760178e-06; neu_v[10]=2.818243e-06; neu_v[11]=9.863188e-05;
+  neu_v[12]=4.299843e-05; neu_v[13]=8.353142e-05; neu_v[14]=8.882562e-05; neu_v[15]=9.245976e-05; neu_v[16]=0.0001351957; neu_v[17]=-3.178406e-06;
+  neu_v[18]=-1.656909e-06; neu_v[19]=-3.632718e-06;
+
+  den_v[0]=1.0; den_v[1]=0.006090274; den_v[2]=0.002161391; den_v[3]=-0.0003634971; den_v[4]=0.0008519521;  den_v[5]=-2.178864e-05;
+  den_v[6]=-3.838019e-05; den_v[7]=0.0001847707; den_v[8]=0.0006151288; den_v[9]=-4.760751e-05; den_v[10]=8.566625e-06; den_v[11]=-1.928669e-05;
+  den_v[12]=-0.0001572831; den_v[13]=-4.532898e-07; den_v[14]=-9.574717e-05; den_v[15]=-8.064254e-05; den_v[16]=6.411648e-08; den_v[17]=2.63149e-06;
+  den_v[18]=6.70456e-06; den_v[19]=1.77085e-08;
+  image_pts.clear();
+  ground_pts.clear();
+  for (unsigned i = 0; i < n_points; i++) {
+    double x = 2.0*rng.drand64() - 1.0;
+    double y = 2.0*rng.drand64() - 1.0;
+    double z = 2.0*rng.drand64() - 1.0;
+    vgl_point_3d<double> p3d(x,y,z);
+    ground_pts.push_back(p3d);
+    double u, v;
+    project(x, y, z, u, v, neu_u, den_u, neu_v, den_v);
+    image_pts.push_back(vgl_point_2d<double>(u, v));
+  }
+  vpgl_fit_rational_cubic act_frc(image_pts, ground_pts);
+  act_frc.compute_initial_guess();
+  std::cout << "\n\ninitial rms error " << act_frc.initial_rms_error() << std::endl;
+  act_frc.fit();
+  std::cout << "final rms error " << act_frc.final_rms_error() << std::endl;
+  good = act_frc.final_rms_error() < 1.0e-7;
+  std::vector<std::vector<double> > act_result = act_frc.rational_coeffs();
+  TEST("test fit rational coefficients", good, true);
+
+}
+
+TESTMAIN(test_fit_rational_cubic);
+
+

--- a/core/vpgl/algo/vpgl_camera_compute.h
+++ b/core/vpgl/algo/vpgl_camera_compute.h
@@ -13,6 +13,7 @@
 #include <vpgl/vpgl_perspective_camera.h>
 #include <vpgl/vpgl_proj_camera.h>
 #include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_rational_camera.h>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
@@ -95,6 +96,16 @@ class vpgl_perspective_camera_compute
 
  private:
   vpgl_perspective_camera_compute() = delete;
+};
+
+// ground points are in wgs84: x = longitude (deg), y = latitude (deg), z = elevation(meters)
+class vpgl_rational_camera_compute{
+ public:
+  static bool compute( const std::vector< vgl_point_2d<double> >& image_pts,
+                       const std::vector< vgl_point_3d<double> >& ground_pts,
+                       vpgl_rational_camera<double>& camera );
+ private:
+  vpgl_rational_camera_compute() = delete;
 };
 
 #endif // vpgl_camera_compute_h_

--- a/core/vpgl/algo/vpgl_fit_rational_cubic.cxx
+++ b/core/vpgl/algo/vpgl_fit_rational_cubic.cxx
@@ -1,0 +1,204 @@
+#include <limits>
+#include <math.h>
+#include <sstream>
+#include <vnl/algo/vnl_svd.h>
+#include <vnl/algo/vnl_levenberg_marquardt.h>
+#include "vpgl_fit_rational_cubic.h"
+
+vpgl_cubic_lsqr::vpgl_cubic_lsqr(std::vector<vgl_point_2d<double> > const& image_pts,
+                                 std::vector<vgl_point_3d<double> > const& ground_pts):
+  vnl_least_squares_function(80, 2.0*image_pts.size(), vnl_least_squares_function::no_gradient),
+  image_pts_(image_pts), ground_pts_(ground_pts){
+  rational_coeffs_.fill(0.0);
+}
+
+vnl_vector_fixed<double, 20> vpgl_cubic_lsqr::power_vector(double x, double y, double z){
+  // Form the monomials in homogeneous form
+  double w  = 1;
+  double xx = x*x;
+  double xy = x*y;
+  double xz = x*z;
+  double yy = y*y;
+  double yz = y*z;
+  double zz = z*z;
+  double xxx = x*xx;
+  double xxy = x*xy;
+  double xxz = x*xz;
+  double xyy = x*yy;
+  double xyz = x*yz;
+  double xzz = x*zz;
+  double yyy = y*yy;
+  double yyz = y*yz;
+  double yzz = y*zz;
+  double zzz = z*zz;
+  double xww = x*w*w;
+  double yww = y*w*w;
+  double zww = z*w*w;
+  double www = w*w*w;
+  double xxw = xx*w;
+  double xyw = xy*w;
+  double xzw = xz*w;
+  double yyw = yy*w;
+  double yzw = yz*w;
+  double zzw = zz*w;
+
+  //fill the vector
+  vnl_vector_fixed<double, 20> pv;
+  pv.put( 0, double(xxx));
+  pv.put( 1, double(xxy));
+  pv.put( 2, double(xxz));
+  pv.put( 3, double(xxw));
+  pv.put( 4, double(xyy));
+  pv.put( 5, double(xyz));
+  pv.put( 6, double(xyw));
+  pv.put( 7, double(xzz));
+  pv.put( 8, double(xzw));
+  pv.put( 9, double(xww));
+  pv.put(10, double(yyy));
+  pv.put(11, double(yyz));
+  pv.put(12, double(yyw));
+  pv.put(13, double(yzz));
+  pv.put(14, double(yzw));
+  pv.put(15, double(yww));
+  pv.put(16, double(zzz));
+  pv.put(17, double(zzw));
+  pv.put(18, double(zww));
+  pv.put(19, double(www));
+  return pv;
+}
+
+void vpgl_cubic_lsqr::project(const double x, const double y, const double z, double& u, double& v){
+  vnl_vector_fixed<double, 4> polys = rational_coeffs_*power_vector(x, y, z);
+  u = polys[0]/polys[1];
+  v = polys[2]/polys[3];
+}
+
+void vpgl_cubic_lsqr::f(vnl_vector<double> const& coeffs,
+                        vnl_vector<double>& residuals){
+  // unpack the cubic coefficients
+  for(size_t j =0; j<4; ++j)
+	  for (size_t i = 0; i < 20; ++i) {
+      size_t index = j*20 + i;
+      rational_coeffs_[j][i] = coeffs[index];
+    }
+  size_t n = image_pts_.size();
+  for(size_t k = 0; k<n; ++k){
+    double u = 0.0, v = 0.0;
+    const vgl_point_3d<double>& p = ground_pts_[k];
+    const vgl_point_2d<double>& uv = image_pts_[k];
+    project(p.x(), p.y(), p.z(), u, v);
+    residuals[2*k]   = u-uv.x();
+    residuals[2*k+1] = v-uv.y();
+  }
+}
+
+bool vpgl_fit_rational_cubic::compute_initial_guess(){
+  size_t n = image_pts_.size();
+  vnl_matrix<double> A(2*n, 80);
+  A.fill(0.0);
+  for(size_t k = 0; k<n; ++k){
+    const vgl_point_3d<double>& p = ground_pts_[k];
+    const vgl_point_2d<double>& uv = image_pts_[k];
+    vnl_vector_fixed<double, 20> pv = vpgl_cubic_lsqr::power_vector(p.x(), p.y(), p.z());
+    double u = uv.x(), v = uv.y();
+    for(size_t i = 0; i<20; ++i){
+      A[2*k][i]      = pv[i];
+      A[2*k][i+20]   = -u*pv[i];
+      A[2*k+1][i+40] = pv[i];
+      A[2*k+1][i+60] = -v*pv[i];
+    }
+  }
+  vnl_svd<double> svd(A);
+  size_t r = svd.rank();
+  if(r<80){
+    std::cout << "insufficent rank " << r << " for linear solution of cubic coefficients" << std::endl;
+    return false;
+  }
+  initial_guess_ = svd.nullvector();
+  return true;
+}
+
+double vpgl_fit_rational_cubic::initial_rms_error(){
+  // unpack the initial cubic coefficients
+	vnl_matrix_fixed<double, 4, 20> rational_coeffs;
+  for(size_t j =0; j<4; ++j)
+    for (size_t i = 0; i < 20; ++i) {
+      size_t index = j*20 + i;
+      rational_coeffs[j][i] = initial_guess_[index];
+    }
+  size_t n = image_pts_.size();
+  double err_sq = 0.0;
+  for(size_t k = 0; k<n; ++k){
+    const vgl_point_3d<double>& p = ground_pts_[k];
+    const vgl_point_2d<double>& uv = image_pts_[k];
+    vnl_vector_fixed<double, 20> pv = vpgl_cubic_lsqr::power_vector(p.x(), p.y(), p.z());
+    vnl_vector_fixed<double, 4> polys = rational_coeffs*pv;
+    double u = polys[0]/polys[1];
+    double v = polys[2]/polys[3];
+    double er = (u-uv.x())*(u-uv.x()) + (v-uv.y())*(v-uv.y());
+    err_sq += er;
+  }
+  err_sq/=n;
+  return sqrt(err_sq);
+}
+
+bool vpgl_fit_rational_cubic::fit(){
+  if(verbose_) std::cout << "\n=====> Solve rational cubic polynomials <=====" << std::endl;
+
+  vpgl_cubic_lsqr lsq(image_pts_, ground_pts_);
+  vnl_levenberg_marquardt levmarq(lsq);
+  // same as internal default settings
+  double xtol = 1e-10;
+  double maxfev = 400 * 80; // Termination maximum number of iterations.
+  double ftol = xtol * 0.01;    // Termination tolerance on F (sum of squared residuals)
+  double gtol = 1e-5;           // Termination tolerance on Grad(F)' * F = 0
+  double epsfcn = xtol * 0.001; // Step length for FD Jacobian
+  levmarq.set_verbose(true);
+  // Set the x-tolerance.  Minimization terminates when the length of the steps taken in X (variables) are less than input x-tolerance
+  levmarq.set_x_tolerance(xtol);
+  // Set the epsilon-function.  This is the step length for FD Jacobian
+  levmarq.set_epsilon_function(epsfcn);
+  // Set the f-tolerance.  Minimization terminates when the successive RSM errors are less then this
+  levmarq.set_f_tolerance(ftol);
+  // Set the maximum number of iterations
+  levmarq.set_max_function_evals(maxfev);
+  // Minimize the error and get the best intersection point
+  // for output
+  vnl_vector<double> coeffs = initial_guess_;
+  levmarq.minimize(coeffs);
+  std::stringstream ss;
+  levmarq.diagnose_outcome(ss);
+  std::string outcome = ss.str();
+  size_t pos = outcome.find_last_of("/");
+  if(pos == std::string::npos){
+    std::cout << "unexpected Levenberg-Marquardt error message "<< outcome << std::endl;
+    return false;
+  }
+  std::stringstream ss2;
+  size_t nout = outcome.size();
+  for (size_t p = pos + 1; p < nout; ++p)
+    ss2 << outcome[p];
+  ss2 >> levmq_err_;
+  if(levmq_err_ > max_err_){
+    std::cout << "maximum error exceeded in Levenberg-Marquardt " << levmq_err_ << " > " << max_err_ << std::endl;
+    return false;
+  }
+  if(verbose_) std::cout << outcome << std::endl;
+
+  vnl_vector<double> residuals(2*image_pts_.size());
+  lsq.f(coeffs, residuals);// final set of residuals and coeffs
+  // output result
+  double max_coeff = 0.0;
+  for(size_t k = 0; k<80; ++k){
+    double mag = fabs(coeffs[k]);
+    if(mag>max_coeff)
+      max_coeff = mag;
+  }
+  for(size_t j = 0; j<4; ++j){
+    std::vector<double> temp(20, 0.0);
+    for(size_t i = 0; i<20; ++i)
+      temp[i] = coeffs[20*j + i]/max_coeff;
+    rational_coefs_.push_back(temp);
+  }
+  return true;
+}

--- a/core/vpgl/algo/vpgl_fit_rational_cubic.h
+++ b/core/vpgl/algo/vpgl_fit_rational_cubic.h
@@ -1,0 +1,82 @@
+// This is core/vpgl/algo/vpgl_fit_rational_cubic.h
+#ifndef vpgl_fit_rational_cubic_h_
+#define vpgl_fit_rational_cubic_h_
+//:
+// \file
+// \brief fit rational cubic polynomial to the projection from ground to image
+// \author J. L. Mundy
+// \date January 26, 2019
+//
+// \verbatim
+// modifications - none
+// \endverbatim
+
+#include <vector>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <vnl/vnl_least_squares_function.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vgl/vgl_point_2d.h>
+#include <vgl/vgl_point_3d.h>
+#include <vpgl/vpgl_rational_camera.h>
+
+class vpgl_cubic_lsqr : public vnl_least_squares_function
+{
+ public:
+  //: Constructor
+  vpgl_cubic_lsqr(std::vector<vgl_point_2d<double> > const& image_pts,
+                  std::vector<vgl_point_3d<double> > const& ground_pts);
+
+  //: The main function.
+  //  Given the parameter vector x, compute the vector of residuals fx.
+  //  fx has been sized appropriately before the call.
+  virtual void f(vnl_vector<double> const& coefs,
+                 vnl_vector<double>& residuals);
+  static vnl_vector_fixed<double, 20> power_vector(double x, double y, double z);
+
+ private:
+  vpgl_cubic_lsqr();//not valid
+  void project(const double x, const double y, const double z, double& u, double& v);
+  std::vector<vgl_point_2d<double> > image_pts_; //image points
+  std::vector<vgl_point_3d<double> > ground_pts_; //image points
+  vnl_matrix_fixed<double, 4, 20> rational_coeffs_;
+};
+
+
+class vpgl_fit_rational_cubic
+{
+ public:
+  vpgl_fit_rational_cubic(std::vector<vgl_point_2d<double> > image_pts,
+                          std::vector<vgl_point_3d<double> > ground_pts):
+  image_pts_(image_pts), ground_pts_(ground_pts), max_err_(1.0e-5), verbose_(false){
+	 initial_guess_.set_size(80);
+    initial_guess_.fill(0.0); initial_guess_[19] = 1.0;
+    initial_guess_[39] = 1.0;initial_guess_[59] = 1.0; initial_guess_[79] = 1.0;
+  }
+  void set_max_error(double max_error) { max_err_ = max_error; }
+  //: the user defines the initial coefficient values
+  void set_initial_guess(vnl_vector<double> initial_guess){initial_guess_ = initial_guess;}
+  //: the initial coefficients are computed using linear least squares
+  void set_verbose(bool verbose){verbose_ = verbose;}
+  bool compute_initial_guess();
+  double initial_rms_error();
+  double final_rms_error(){return levmq_err_;}
+  bool fit();
+  std::vector<std::vector<double> > rational_coeffs(){return rational_coefs_;}
+
+ private:
+  vpgl_fit_rational_cubic();
+  bool verbose_;
+  double max_err_;
+  double levmq_err_;
+  std::vector<vgl_point_2d<double> > image_pts_;
+  std::vector<vgl_point_3d<double> > ground_pts_;
+  std::vector<std::vector<double> > rational_coefs_;
+  vnl_vector<double> initial_guess_;
+};
+
+
+#endif // vpgl_fit_rational_cubic_h_


### PR DESCRIPTION
`vpgl_rational_camera_compute::compute` - new vpgl/algo capability to compute a rational camera model from world-to-image correspondences.  Supporting code and unit tests also included.