### PR TITLE
More BRL contrib updates

### DIFF
--- a/contrib/brl/bbas/bil/algo/tests/test_bil_detect_ridges.cxx
+++ b/contrib/brl/bbas/bil/algo/tests/test_bil_detect_ridges.cxx
@@ -47,9 +47,22 @@ class vil_math_abs_functor
 
 static void test_bil_detect_ridges(int argc, char* argv[])
 {
-  assert(argc > 1);
-  vil_image_resource_sptr res = vil_load_image_resource((std::string(argv[1]) + "/c.20.tif").c_str());
-  TEST("File loading", !res, false);
+  // test data path passed as argument
+  if (argc < 2) {
+    TEST("Test directory", false, true);
+    std::cout << "no test directory specified" << std::endl;
+    return;
+  }
+
+  // load test file
+  std::string file = std::string(argv[1]) + "/c.20.tif";
+  vil_image_resource_sptr res = vil_load_image_resource(file.c_str());
+  if (!res) {
+    TEST("Test file", false, true);
+    std::cout << "failed file path: " << file << std::endl;
+    return;
+  }
+
   vil_image_view<vxl_uint_16> view_uint16 = res->get_view();
   vil_image_view<float> view_float;
 

--- a/contrib/brl/bbas/bpgl/bpgl_comp_rational_camera.hxx
+++ b/contrib/brl/bbas/bpgl/bpgl_comp_rational_camera.hxx
@@ -93,7 +93,7 @@ bpgl_comp_rational_camera<T>::bpgl_comp_rational_camera(std::string cam_path)
   }
   if  (!good)
   {
-    std::cout << "error: not a composite rational camera file\n";
+    //std::cout << "error: not a composite rational camera file\n";
     return;
   }
   *this = bpgl_comp_rational_camera<T>(M, *rcam);

--- a/contrib/brl/bbas/brad/brad_image_metadata.h
+++ b/contrib/brl/bbas/brad/brad_image_metadata.h
@@ -8,6 +8,7 @@
 // \verbatim
 //  Modifications
 //   Yi Dong Nov, 2017 -- Major update to adopt new image calibration mechanism
+//   Yi Dong Apr, 2018 -- Add gain/offset parsing from IMD file
 // \endverbatim
 //----------------------------------------------------------------------------
 #ifndef brad_image_metadata_h_

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rectify_images_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rectify_images_process.cxx
@@ -551,13 +551,15 @@ bool vpgl_construct_height_map_process(bprb_func_process& pro)
   auto img_size_y = (unsigned)std::ceil(depth/voxel_size);
   vil_image_view<float> out_map(img_size_x, img_size_y);
   out_map.fill((float)min_z);
-
+  double dz = voxel_size;
+  if (voxel_size >= 1.0)
+    dz = voxel_size / 2.0;
   for (double x = 0; x < width; x += voxel_size)
     for (double y = 0; y < depth; y += voxel_size) {
       // try each height
       double min_dif = 2.0;  // 2 pixels error in projection
       double best_z = min_z;
-      for (double z = min_z; z < height; z += (voxel_size/2.0)) {
+      for (double z = min_z; z < height; z += dz) {
         // project this x,y,z using the camera onto the images
         double u1,v1,u2,v2;
         cam1_rational->project(x+min_x, max_y-y, z, u1, v1);


### PR DESCRIPTION
- `vpgl_compute_affine_from_rational_process` - use `vpgl_affine_camera_convert::convert`
- `vpgl_construct_height_map_process`
  - z search space at half voxel_size only for voxel_size above 1 meter
  - OpemMP parallelized
- `test_bil_detect_ridges` - directly ensure test data presence
- `bpgl_comp_rational_camera` - clean up stdout (remove error statement)
- `brad_image_metadata` - add gain/offset/solar_irrad parsing directly from IMD file