### PR TITLE
vpgl_affine_fundamental_matrix

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_fm_compute_affine_ransac.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_fm_compute_affine_ransac.h
@@ -8,6 +8,17 @@
 // A robust algorithm for computing the fundamental matrix from lists of
 // corresponding points between two rectified images.
 // This uses RREL to do the robust computation.
+//
+// Internally, the affine fundamental matrix has the form
+// (using Hartly and Zisserman convention for a-e):
+//       | 0  0  a |
+//   A = | 0  0  b |
+//       | c  d  e |
+//
+// which results in the following constraint matrix during "fit_from_minimal_set"
+//   PL^T * A * PR = 0
+//   a*pl.x + b*pl.y + c*pr.x + d*pl.y + e = 0
+//
 // \author Thomas Pollard
 // \date May 08, 2005
 //

--- a/core/vpgl/tests/CMakeLists.txt
+++ b/core/vpgl/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable( vpgl_test_all
   test_generic_camera.cxx
   test_lvcs.cxx
   test_tri_focal_tensor.cxx
+  test_affine_fundamental_matrix.cxx
   test_affine_tri_focal_tensor.cxx
 )
 
@@ -32,6 +33,7 @@ add_test( NAME vpgl_test_local_rational_camera COMMAND $<TARGET_FILE:vpgl_test_a
 add_test( NAME vpgl_test_generic_camera COMMAND $<TARGET_FILE:vpgl_test_all> test_generic_camera)
 add_test( NAME vpgl_test_lvcs COMMAND $<TARGET_FILE:vpgl_test_all> test_lvcs)
 add_test( NAME vpgl_test_tri_focal_tensor COMMAND $<TARGET_FILE:vpgl_test_all> test_tri_focal_tensor)
+add_test( NAME vpgl_test_affine_fundamental_matrix COMMAND $<TARGET_FILE:vpgl_test_all> test_affine_fundamental_matrix)
 add_test( NAME vpgl_test_affine_tri_focal_tensor COMMAND $<TARGET_FILE:vpgl_test_all> test_affine_tri_focal_tensor)
 set( HAS_GEOTIFF 0 )
 include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)

--- a/core/vpgl/tests/test_affine_fundamental_matrix.cxx
+++ b/core/vpgl/tests/test_affine_fundamental_matrix.cxx
@@ -1,0 +1,22 @@
+#include <testlib/testlib_test.h>
+
+#include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_affine_fundamental_matrix.h>
+#include <vnl/vnl_math.h>
+
+static void test_affine_fundamental_matrix()
+{
+  vnl_matrix_fixed<double, 3,4> M(0.0), Mp(0.0);
+  M[2][3] = 1.0;   Mp[2][3] = 1.0; // affine
+  M[0][0] = 1.0;   M[1][1] = 1.0; M[1][3] = 10.0;
+  double s2 = sqrt(2.0)/2.0;
+  Mp[0][0] = s2; Mp[0][2] = s2; Mp[0][3] = -3.12132; Mp[1][1] = 1.0;
+  vpgl_affine_camera<double> cr(M), cl(Mp);
+  vpgl_affine_fundamental_matrix<double> F(cr, cl);
+  vnl_matrix_fixed<double, 3, 3> Mf = F.get_matrix();
+  double er = fabs(Mf[1][2] + 1) + fabs(Mf[2][1] - 1) + fabs(Mf[2][2] + 10.0);
+  bool good =  er < 0.001;
+  TEST("compute F matrix", good, true);
+}
+
+TESTMAIN(test_affine_fundamental_matrix);

--- a/core/vpgl/tests/test_driver.cxx
+++ b/core/vpgl/tests/test_driver.cxx
@@ -14,6 +14,7 @@ DECLARE( test_generic_camera );
 DECLARE( test_lvcs );
 DECLARE( test_tri_focal_tensor );
 DECLARE( test_affine_tri_focal_tensor );
+DECLARE( test_affine_fundamental_matrix);
 
 void register_tests()
 {
@@ -31,6 +32,7 @@ void register_tests()
   REGISTER( test_lvcs );
   REGISTER( test_tri_focal_tensor );
   REGISTER( test_affine_tri_focal_tensor );
+  REGISTER( test_affine_fundamental_matrix);
 }
 
 DEFINE_MAIN;

--- a/core/vpgl/vpgl_affine_fundamental_matrix.h
+++ b/core/vpgl/vpgl_affine_fundamental_matrix.h
@@ -8,15 +8,16 @@
 // \date June 8, 2005
 // \author Joseph Mundy, Matt Leotta, Vishal Jain
 //
-// The fundamental matrix has the form:
+// The fundamental matrix has the form (using Hartly and Zisserman convention for a-e as of Nov. 2018):
 // \verbatim
-// | 0  0  e |
-// | 0  0  d |
-// | a  b  c |
+// | 0  0  a |
+// | 0  0  b |
+// | c  d  e |
 // \endverbatim
 
 #include <vnl/vnl_fwd.h>
 #include "vpgl_fundamental_matrix.h"
+#include "vpgl_affine_camera.h"
 
 template <class T>
 class vpgl_affine_fundamental_matrix : public vpgl_fundamental_matrix<T>
@@ -28,12 +29,21 @@ class vpgl_affine_fundamental_matrix : public vpgl_fundamental_matrix<T>
   //: Default constructor creates dummy matrix.
   vpgl_affine_fundamental_matrix();
 
+  //: Construct from a fundamental matrix in vnl form.
+  vpgl_affine_fundamental_matrix( const vnl_matrix_fixed<T,3,3>& F );
+
   //: Cast up from a regular vpgl_fundamental_matrix.
   vpgl_affine_fundamental_matrix( const vpgl_fundamental_matrix<T>& fm );
 
+  //: construct from two affine cameras (Ar, the camera with image points on the right of F, and Al on the left of F)
+  vpgl_affine_fundamental_matrix( const vpgl_affine_camera<T>& Ar, const vpgl_affine_camera<T>& Al);
+
   // Getters and Setters:----------------
 
-  //: Form the matrix from its free parameters.
+  //: Form the matrix from 3x3 vnl_fixed_matrix
+  void set_matrix( const vnl_matrix_fixed<T,3,3>& F );
+
+  //: Form the matrix from its free parameters. (JLM changed to H&Z convention 11/12/2018)
   void set_from_params( T a, T b, T c, T d, T e );
 };
 

--- a/core/vpgl/vpgl_affine_fundamental_matrix.hxx
+++ b/core/vpgl/vpgl_affine_fundamental_matrix.hxx
@@ -7,26 +7,118 @@
 #include "vpgl_affine_fundamental_matrix.h"
 //
 #include <vnl/vnl_matrix_fixed.h>
-
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_cross.h>
+#include <vnl/vnl_det.h>
+#include <vnl/vnl_inverse.h>
+#include <vgl/vgl_tolerance.h> // for degenerate determinate
 //---------------------------------
 template <class T>
 vpgl_affine_fundamental_matrix<T>::vpgl_affine_fundamental_matrix() :
   vpgl_fundamental_matrix<T>()
 {
-  vnl_matrix_fixed<T,3,3> default_matrix( (T)0 );
-  default_matrix(0,1) = default_matrix(0,2) = (T)1;
-  default_matrix(1,0) = default_matrix(2,0) = -(T)1;
-  vpgl_fundamental_matrix<T>::set_matrix( default_matrix );
+  T m[] = { 0,0,0,
+            0,0,1,
+            0,1,0 };
+  vnl_matrix_fixed<T,3,3> M(m);
+  set_matrix(M);
 }
 
+//---------------------------------
+template <class T>
+vpgl_affine_fundamental_matrix<T>::vpgl_affine_fundamental_matrix(
+  const vnl_matrix_fixed<T,3,3>& F )
+{
+  set_matrix(F);
+}
 
 //---------------------------------
 template <class T>
 vpgl_affine_fundamental_matrix<T>::vpgl_affine_fundamental_matrix(
   const vpgl_fundamental_matrix<T>& fm )
 {
-  set_from_params( fm.get_matrix()(2,0), fm.get_matrix()(2,1), fm.get_matrix()(2,2),
-                   fm.get_matrix()(1,2), fm.get_matrix()(0,2) );
+  set_matrix(fm.get_matrix());
+}
+
+//---------------------------------
+template <class T>
+vpgl_affine_fundamental_matrix<T>::vpgl_affine_fundamental_matrix( const vpgl_affine_camera<T>& Ar, const vpgl_affine_camera<T>& Al)
+{
+
+  // note H&Z use prime ' to indicate quantities in the Al cam.
+  // that is x'. ( F x)  = 0 .  So here p == '
+  vnl_matrix_fixed<double, 3, 4> M = Ar.get_matrix(), Mp = Al.get_matrix();
+
+  //
+  // M = |a00 a01 a02 a03| = |A0 a03|
+  //     |a10 a11 a12 a13|   |A1 a13|
+  //     | 0   0   0   1 |   |3x0 1 |
+
+  // 1) camera ray  r = A0 X A1
+  vnl_vector_fixed<double, 3> A0, A1, r;
+  A0[0]=M[0][0];   A0[1]=M[0][1];   A0[2]=M[0][2];
+  A1[0]=M[1][0];   A1[1]=M[1][1];   A1[2]=M[1][2];
+  r = vnl_cross_3d(A0, A1);
+
+  //
+  // 2) D = |A0.A0  A0.A1|
+  //        |A0.A1  A1.A1|
+  //
+  vnl_matrix_fixed<double, 2, 2> D, Dinv;
+  D[0][0] = dot_product(A0, A0);
+  D[0][1] = dot_product(A0, A1); D[1][0] = D[0][1];
+  D[1][1] = dot_product(A1, A1);
+  double det = vnl_det(D);
+  // det is 2nd order
+  if (fabs(det) < T(2)*vgl_tolerance<T>::position) {
+	  std::cout << "Affine fundamental matrix - singular determinant" << std::endl;
+	  return;
+  }
+  Dinv = vnl_inverse(D);
+
+  // 3) A'0, A'1 terms p == '
+  vnl_vector_fixed<double, 3> Ap0, Ap1;
+  Ap0[0]=Mp[0][0];   Ap0[1]=Mp[0][1];   Ap0[2]=Mp[0][2];
+  Ap1[0]=Mp[1][0];   Ap1[1]=Mp[1][1];   Ap1[2]=Mp[1][2];
+  vnl_matrix_fixed<double, 2, 2> Dp, DpD;
+  Dp[0][0] = dot_product(Ap0, A0);
+  Dp[0][1] = dot_product(Ap0, A1);
+  Dp[1][0] = dot_product(Ap1, A0);
+  Dp[1][1] = dot_product(Ap1, A1);
+  DpD = Dp*Dinv;
+
+  //4)
+  //      |0  0  a|
+  // F =  |0  0  b|
+  //      |c  d  e|
+  //
+  double a = dot_product(r, Ap1), b = -dot_product(r, Ap0), c, d, e;
+
+  // 5) k and k'
+  vnl_vector_fixed<double, 2> kp, k, t, tp;
+  kp[0] = -a; kp[1] = -b;
+  k = kp*DpD;
+
+  // 6) c, d, e
+  c = k[0];
+  d = k[1];
+  t[0] = M[0][3];   t[1] = M[1][3];
+  tp[0] = Mp[0][3];   tp[1] = Mp[1][3];
+  e = dot_product(kp, tp) - dot_product(k, t);
+
+  // normalization factor
+  double norm = 1.0/std::sqrt(a*a + b*b);
+
+  // set matrix from normalized parameters
+  set_from_params(a*norm,b*norm,c*norm,d*norm,e*norm);
+}
+
+
+//---------------------------------
+template <class T>
+void vpgl_affine_fundamental_matrix<T>::set_matrix( const vnl_matrix_fixed<T,3,3>& F )
+{
+  set_from_params( F[0][2], F[1][2], F[2][0], F[2][1], F[2][2] );
 }
 
 
@@ -34,13 +126,14 @@ vpgl_affine_fundamental_matrix<T>::vpgl_affine_fundamental_matrix(
 template <class T>
 void vpgl_affine_fundamental_matrix<T>::set_from_params( T a, T b, T c, T d, T e )
 {
-  vnl_matrix_fixed<T,3,3> fm( (T)0 );
-  fm.put( 2, 0, a );
-  fm.put( 2, 1, b );
-  fm.put( 2, 2, c );
-  fm.put( 1, 2, d );
-  fm.put( 0, 2, e );
-  vpgl_fundamental_matrix<T>::set_matrix( fm );
+  // note JLM changed to H&Z convention 11/12/2018
+  vnl_matrix_fixed<T,3,3> F( (T)0 );
+  F.put( 0, 2, a );
+  F.put( 1, 2, b );
+  F.put( 2, 0, c );
+  F.put( 2, 1, d );
+  F.put( 2, 2, e );
+  vpgl_fundamental_matrix<T>::set_matrix(F);
 };
 
 

--- a/core/vpgl/vpgl_affine_tri_focal_tensor.h
+++ b/core/vpgl/vpgl_affine_tri_focal_tensor.h
@@ -338,9 +338,8 @@ bool fmatrix_12(vpgl_affine_fundamental_matrix<Type>& f_12){
   // INTERNALS---------------------------------------------------------------
   private:
   static vpgl_affine_fundamental_matrix<Type> null_F(){
-    vpgl_affine_fundamental_matrix<Type> ret;
-    ret.set_from_params(Type(0),Type(0),Type(0),Type(0),Type(0));
-    return ret;
+    vnl_matrix_fixed<Type, 3, 3> M(Type(0));
+    return vpgl_affine_fundamental_matrix<Type>(M);
   }
   vpgl_affine_camera<Type> null_acam(){
     vnl_matrix_fixed<Type, 2, 4> M(Type(0));

--- a/core/vpgl/vpgl_affine_tri_focal_tensor.hxx
+++ b/core/vpgl/vpgl_affine_tri_focal_tensor.hxx
@@ -69,7 +69,7 @@ bool affine(vpgl_fundamental_matrix<Type> const& F, vpgl_affine_fundamental_matr
     for(size_t c = 0; c<2; ++c)
       if(fabs(M[r][c]) > tol)
         return false;
-  aF.set_from_params(M[2][0], M[2][1], M[2][2], M[1][2], M[0][2]);
+  aF.set_matrix(M);
   return true;
 }
 


### PR DESCRIPTION
vpgl_affine_fundamental_matrix update:
- add constructor from 2 affine cameras
- adopt Hartly and Zisserman convention for internal a-e representation
- additional function overloads
- new tests

Additional updates to ignore internal vpgl_affine_fundamental_matrix representation 
- vpgl_affine_tri_focal_tensor 
- BRL bpgl_fm_compute_affine_ransac (and related test update)