### PR TITLE
vpgl_affine_camera

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/tests/test_camera_from_box.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_camera_from_box.cxx
@@ -8,11 +8,9 @@
 #include <vpgl/vpgl_affine_camera.h>
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_box_3d.h>
-#include <vgl/vgl_homg_point_3d.h>
-#include <vgl/algo/vgl_rotation_3d.h>
+#include <vgl/vgl_ray_3d.h>
 #include <bpgl/algo/bpgl_project.h>
 #include <bpgl/algo/bpgl_camera_from_box.h>
-#include <vgl/vgl_homg_line_3d_2_points.h>
 
 static void test_camera_from_box()
 {
@@ -31,8 +29,8 @@ static void test_camera_from_box()
   double len = (pmin-imin).length() + (pmax-imax).length();
   TEST_NEAR("affine_cam_from_box", len, 0.0, 1e-6);
   vgl_homg_point_2d<double> ph(ni/2.0+10, nj/2.0+10);
-  vgl_homg_line_3d_2_points<double> line = C.backproject(ph);
-  TEST_NEAR("Backproject", line.point_infinite().x(), -0.57735, 0.1);
+  vgl_ray_3d<double> bp_ray = C.backproject_ray(ph);
+  TEST_NEAR("Backproject", bp_ray.direction().x(), -0.57735, 0.1);
   vgl_point_3d<double> cam_center(10, 10, 10);
   vpgl_perspective_camera<double> Cp = bpgl_camera_from_box::persp_camera_from_box(box, cam_center, ni, nj);
   vgl_box_2d<double> b2dp = bpgl_project::project_bounding_box(Cp, box);
@@ -51,11 +49,9 @@ static void test_camera_from_box()
   vgl_box_2d<double> sun_b2d = bpgl_project::project_bounding_box(sun_cam, sun_box);
   TEST_NEAR("Project bounding box", sun_b2d.centroid().x(), 128, 10);
   vgl_homg_point_2d<double> sun_ph(ni/2.0, nj/2.0);
-  vgl_homg_line_3d_2_points<double> sun_line = sun_cam.backproject(sun_ph);
-  vgl_homg_point_3d<double> pi = sun_line.point_infinite();
-  vgl_vector_3d<double> vpi(pi.x(), pi.y(), pi.z());
-  len = (sun_ray-vpi).length();
-  TEST_NEAR("Affine camera from sun", len, 0.0, 1e-6);
+  vgl_ray_3d<double> sun_bp_ray = sun_cam.backproject_ray(sun_ph);
+  double dp = dot_product(sun_ray, sun_bp_ray.direction());
+  TEST_NEAR("Affine camera from sun", dp, 1.0, 1e-6);
 }
 
 TESTMAIN(test_camera_from_box);

--- a/core/vpgl/tests/test_affine_camera.cxx
+++ b/core/vpgl/tests/test_affine_camera.cxx
@@ -3,7 +3,10 @@
 #include <vpgl/vpgl_affine_camera.h>
 #include <vgl/vgl_vector_3d.h>
 #include <vgl/vgl_point_3d.h>
+#include <vgl/vgl_ray_3d.h>
+#include <vgl/vgl_distance.h>
 #include <vnl/vnl_math.h>
+
 
 static void test_affine_camera()
 {
@@ -41,6 +44,26 @@ static void test_affine_camera()
   vgl_homg_plane_3d<double> pp = C.principal_plane();
   double algd = (pp.a()+pp.b()+pp.c())*1000*sq3+pp.d();
   TEST_NEAR("principal plane", algd, 0.0, 1e-08);
+
+  // test realistic affine camera
+  vnl_vector_fixed<double, 4> row1, row2;
+  row1[0] = 1.3483235713495938;  row1[1] = 0.0038174980872772743;
+  row1[2] = 0.27647870881886161; row1[3] = 8.8599950663932052;
+
+  row2[0] = 0.21806927892797245; row2[1] = -0.92631091145800215;
+  row2[2] = -1.0010535330976205; row2[3] = 538.93376518200034;
+
+  vpgl_affine_camera<double> row_cam(row1, row2);
+  row_cam.set_viewing_distance( 9325.6025071654913);
+  vgl_vector_3d<double> row_ray_dir = row_cam.ray_dir();
+  vgl_vector_3d<double> test_dir(0.13271023792536230, 0.74172901339587183,-0.65743901879686173);
+  TEST_NEAR("row ray dir", (row_ray_dir-test_dir).length(), 0.0, 1e-5);
+
+  vgl_point_3d<double> wrld_pt(274.30804459155252,85.614875071463018,-35.273309156122778);
+  vgl_homg_point_2d<double> img_pt(369.28342202880049, 554.72813713086771);
+  vgl_ray_3d<double> row_ray = row_cam.backproject_ray(img_pt);
+  double ray_dist = vgl_distance(row_ray,wrld_pt);
+  TEST_NEAR("row_ray_dist", ray_dist, 0.0, 0.05);
 }
 
 TESTMAIN(test_affine_camera);

--- a/core/vpgl/tests/test_affine_camera.cxx
+++ b/core/vpgl/tests/test_affine_camera.cxx
@@ -64,6 +64,15 @@ static void test_affine_camera()
   vgl_ray_3d<double> row_ray = row_cam.backproject_ray(img_pt);
   double ray_dist = vgl_distance(row_ray,wrld_pt);
   TEST_NEAR("row_ray_dist", ray_dist, 0.0, 0.05);
+
+  // test postmultiply with a translation
+  vgl_vector_3d<double> trans(3.0, -10.0, 5.0);
+  vpgl_affine_camera<double> trans_row_cam = postmultiply_a(row_cam, trans);
+  vgl_homg_point_2d<double> hpt = trans_row_cam.project(vgl_point_3d<double>(0, 0, 0));
+  vgl_point_2d<double> pt(hpt);
+  vgl_point_2d<double> test_pt(14.24918434, 543.8458145);
+  double pdist = (pt-test_pt).length();
+  TEST_NEAR("postmultiply translation", pdist, 0.0, 0.0001);
 }
 
 TESTMAIN(test_affine_camera);

--- a/core/vpgl/vpgl_affine_camera.h
+++ b/core/vpgl/vpgl_affine_camera.h
@@ -80,7 +80,7 @@ class vpgl_affine_camera : public vpgl_proj_camera<T>
             this->viewing_distance() == that.viewing_distance() );
   }
 
-//: Find the 3d coordinates of the center of the camera. Will be an ideal point with the sense of the ray direction.
+  //: Find the 3d coordinates of the center of the camera. Will be an ideal point with the sense of the ray direction.
   vgl_homg_point_3d<T> camera_center() const override;
 
   //: Find the 3d ray that goes through the camera center.
@@ -95,6 +95,9 @@ class vpgl_affine_camera : public vpgl_proj_camera<T>
 
   //: Clone `this': creation of a new object and initialization
   vpgl_affine_camera<T>* clone(void) const override;
+
+  //: the direction of all affine camera rays
+  vgl_vector_3d<T> ray_dir() const {return ray_dir_;}
 
  private:
   T view_distance_; // distance from origin along rays

--- a/core/vpgl/vpgl_affine_camera.h
+++ b/core/vpgl/vpgl_affine_camera.h
@@ -133,6 +133,19 @@ vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>& in_camera,
   return postmultiply_a(in_camera, transform.get_matrix());
 }
 
+//: compute At = A*H, where H is just 3-d translation
+template <class T>
+vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>& in_camera,
+                                      const vnl_vector_fixed<T,3>& translation );
+
+//: compute At = A*H, where H is just 3-d translation
+template <class T>
+vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>& in_camera,
+                                      const vgl_vector_3d<T>& translation ){
+  vnl_vector_fixed<T, 3> tr(translation.x(), translation.y(), translation.z());
+  return postmultiply_a(in_camera, tr);
+}
+
 //: Read vpgl_affine_camera  from stream
 template <class Type>
 std::istream&  operator>>(std::istream& s, vpgl_affine_camera<Type>& c);

--- a/core/vpgl/vpgl_affine_camera.hxx
+++ b/core/vpgl/vpgl_affine_camera.hxx
@@ -324,6 +324,19 @@ vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>& in_camera,
   return vpgl_affine_camera<T>(in_camera.get_matrix()*transform);
 }
 
+template <class T>
+vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>& in_camera,
+                                      const vnl_vector_fixed<T,3>& translation ){
+  const vnl_matrix_fixed<T, 3, 4> m = in_camera.get_matrix();
+  vnl_matrix_fixed<T, 3, 4> tm = m;
+  vnl_vector_fixed<T, 4> r0 = m.get_row(0), r1 = m.get_row(1);
+  vnl_vector_fixed<T, 4> t;
+  for(size_t c = 0; c<3; ++c) t[c] = translation[c]; t[3] = T(1);
+  T dp0 = dot_product(r0, t); tm[0][3] = dp0;
+  T dp1 = dot_product(r1, t); tm[1][3] = dp1;
+  return vpgl_affine_camera<T>(tm);
+}
+
 // Code for easy instantiation.
 #undef vpgl_AFFINE_CAMERA_INSTANTIATE
 #define vpgl_AFFINE_CAMERA_INSTANTIATE(T) \
@@ -334,7 +347,9 @@ template vgl_h_matrix_3d<T> get_canonical_h(const vpgl_affine_camera<T>&); \
 template vpgl_affine_camera<T> premultiply_a( const vpgl_affine_camera<T>&, const vnl_matrix_fixed<T,3,3>&); \
 template vpgl_affine_camera<T> premultiply_a( const vpgl_affine_camera<T>&, const vgl_h_matrix_2d<T>&); \
 template vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>&, const vnl_matrix_fixed<T,4,4>&); \
-template vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>&, const vgl_h_matrix_3d<T>&)
+template vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>&, const vgl_h_matrix_3d<T>&); \
+template vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>&, const vnl_vector_fixed<T,3>&); \
+template vpgl_affine_camera<T> postmultiply_a( const vpgl_affine_camera<T>&, const vgl_vector_3d<T>&)
 
 
 #endif // vpgl_affine_camera_hxx_


### PR DESCRIPTION
Improvements to vpgl_affine_camera
- improve backprojection via direct ray construction
- ray_dir accessor
- postmultiply by translation
- new related tests
- related change to BRL bpgl test_camera_from_box - backproject via ray instead of line_3d_2p


