### PR TITLE
VXL_USE_ECW option

### DIFF
--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -104,10 +104,18 @@ else()
 endif()
 
 ################################
-# JPEG 2000
+# JPEG2000 via ECW
 ################################
+option(VXL_USE_ECW "Use the ECW J2K library if available" OFF)
+mark_as_advanced(VXL_USE_ECW)
 include( ${VXL_CMAKE_DIR}/NewCMake/FindECW.cmake )
 if(ECW_FOUND)
+  if( VXL_USING_NATIVE_ECW )
+    message("-- Found ECW J2K (native library)")
+  else()
+    message("-- Found ECW J2K (v3p library)")
+  endif()
+
   set( vil_ff_sources ${vil_ff_sources}
     file_formats/vil_j2k_image.h           file_formats/vil_j2k_image.cxx
     file_formats/NCSJPCVilIOStream.h       file_formats/NCSJPCVilIOStream.cxx

--- a/v3p/j2k/CMakeLists.txt
+++ b/v3p/j2k/CMakeLists.txt
@@ -1,10 +1,13 @@
-PROJECT (J2K)
-INCLUDE(${MODULE_PATH}/NewCMake/FindECW.cmake)
-#MESSAGE(${MODULE_PATH})
-INCLUDE(${MODULE_PATH}/NewCMake/FindWin32SDK.cmake)
-INCLUDE(${CMAKE_ROOT}/Modules/FindMFC.cmake)
-IF(J2K_SOURCES_FOUND) 
+project(J2K)
 
-INCLUDE_DIRECTORIES(./Source/include)
-SUBDIRS(./Source/C/NCSEcw/NCSEcw)
-ENDIF(J2K_SOURCES_FOUND) 
+if ( VXL_USE_ECW )
+  include(${VXL_CMAKE_DIR}/NewCMake/FindECW.cmake)
+
+  if( ECW_FOUND )
+    if( NOT VXL_USING_NATIVE_ECW )
+      include_directories(${CMAKE_CURRENT_LIST_DIR}/Source/include)
+      add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Source/C/NCSEcw/NCSEcw)
+    endif()
+  endif()
+
+endif()


### PR DESCRIPTION
VXL_USE_ECW option to control check/inclusion of ECW J2K libraries (native or V3P if available)
- VXL_USE_ECW option in vil CMakeLists.txt
- VXL_USE_ECW is false by default, as the library is not typically available
- additional tab indent of FindECW.cmake
