### PR TITLE
COMP: Remove test for MIPSPro support by cmake

### DIFF
--- a/vcl/tests/test_preprocessor.cxx
+++ b/vcl/tests/test_preprocessor.cxx
@@ -33,8 +33,7 @@ int test_preprocessor_main(int /*argc*/,char* /*argv*/[])
         + VXL_COMPILER_IS_MSVC
         + VXL_COMPILER_IS_ADSP
         + VXL_COMPILER_IS_IAR
-        + VXL_COMPILER_IS_ARMCC
-        + VXL_COMPILER_IS_MIPSpro;
+        + VXL_COMPILER_IS_ARMCC;
 
   int result = 0;
 


### PR DESCRIPTION
vcl/tests/test_preprocessor.cxx:37:11: error:
'VXL_COMPILER_IS_MIPSpro' was not declared in this scope

cmake commit beb991110d84e9c0a6b1339e22fa98284b08bac9
  Author: Brad King <brad.king@kitware.com>
  Date:   Fri Jan 11 13:50:46 2019 -0500

  Remove now-unused code once used on IRIX

  We dropped support for IRIX as a host platform long ago.
  Remove some leftover code.