### PR TITLE
remove redundant find_path from FindGEOTIFF

### DIFF
--- a/config/cmake/Modules/FindGEOTIFF.cmake
+++ b/config/cmake/Modules/FindGEOTIFF.cmake
@@ -12,7 +12,7 @@
 # Additionally
 # VXL_USING_NATIVE_GEOTIFF  - True if we are using a GEOTIFF library provided outside vxl (or v3p)
 
-if (${VXL_USE_GEOTIFF})
+if ( VXL_USE_GEOTIFF )
 
   if( NOT GEOTIFF_FOUND )
 
@@ -31,18 +31,13 @@ if (${VXL_USE_GEOTIFF})
     #
     if( NOT GEOTIFF_FOUND )
       if(EXISTS ${VXL_ROOT_SOURCE_DIR}/v3p/geotiff/geotiff.h)
-        # Use FIND_PATH here to allow the user to set the path to IGNORE
-        # to disable geotiff support.
-        find_path(GEOTIFF_INCLUDE_DIR geotiff.h
-          ${VXL_ROOT_SOURCE_DIR}/v3p/geotiff
-        )
-        if( GEOTIFF_INCLUDE_DIR )
-          set( GEOTIFF_FOUND "YES" )
-          set( GEOTIFF_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_DIR}/include/vxl/v3p/geotiff)
-          set( GEOTIFF_LIBRARIES geotiff )
-        endif()
-
+        set( GEOTIFF_FOUND "YES" )
+        set( GEOTIFF_INCLUDE_DIR ${VXL_ROOT_SOURCE_DIR}/v3p/geotiff )
+        set( GEOTIFF_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_DIR}/include/vxl/v3p/geotiff )
+        set( GEOTIFF_LIBRARIES geotiff )
       endif()
     endif()
+
   endif()
+
 endif()

--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -155,6 +155,12 @@ if(TIFF_FOUND)
   mark_as_advanced(VXL_USE_GEOTIFF)
   include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)
   if(GEOTIFF_FOUND)
+    if( VXL_USING_NATIVE_GEOTIFF )
+      message("-- Found GeoTiff (native library)")
+    else()
+      message("-- Found GeoTiff (v3p library)")
+    endif()
+
     set(HAS_GEOTIFF 1 )
     include_directories(${GEOTIFF_INCLUDE_DIR})
     set( vil_ff_sources ${vil_ff_sources}


### PR DESCRIPTION
Remove redundant find_path statement from FindGEOTIFF (path was already checked for existence, find_path is unnecessary).  Also correct "VXL_USE_GEOTFIF" test and add message to vil cmake that geotiff was discovered.