### PR TITLE
vpgl_rational_camera refactoring

### DIFF
--- a/core/vpgl/CMakeLists.txt
+++ b/core/vpgl/CMakeLists.txt
@@ -22,6 +22,7 @@ set( vpgl_sources
   vpgl_radial_distortion.h         vpgl_radial_distortion.hxx
   vpgl_poly_radial_distortion.h    vpgl_poly_radial_distortion.hxx
   vpgl_rational_camera.h           vpgl_rational_camera.hxx
+                                   vpgl_rational_camera.cxx
   vpgl_local_rational_camera.h     vpgl_local_rational_camera.hxx
   vpgl_generic_camera.h            vpgl_generic_camera.hxx
   vpgl_dll.h

--- a/core/vpgl/file_formats/vpgl_nitf_rational_camera.h
+++ b/core/vpgl/file_formats/vpgl_nitf_rational_camera.h
@@ -34,7 +34,7 @@ class vpgl_nitf_rational_camera : public vpgl_rational_camera<double>
  public:
 
   enum geopt_coord { LAT, LON };
-  vpgl_nitf_rational_camera();
+  vpgl_nitf_rational_camera() = default;
 
   //: Construct from a nitf image file
   vpgl_nitf_rational_camera(std::string const& nitf_image_path,
@@ -54,11 +54,16 @@ class vpgl_nitf_rational_camera : public vpgl_rational_camera<double>
   vnl_double_2 lower_left() const {return ll_;}
   vnl_double_2 lower_right() const {return lr_;}
 
+  //: print all camera information
+  void print(
+      std::ostream& ostr = std::cout,
+      vpgl_rational_order output_order = vpgl_rational_order::VXL
+      ) const;
+
  private:
-  //internal functions
-  // NITF_RATIONAL00B - commercial + airborne
-  void set_order_b(int*);
+  // internal functions
   bool init(vil_nitf2_image* nitf_image, bool verbose);
+
   // data members
   std::string nitf_rational_type_;
   std::string image_id_;

--- a/core/vpgl/vpgl_local_rational_camera.h
+++ b/core/vpgl/vpgl_local_rational_camera.h
@@ -39,7 +39,6 @@ class vpgl_local_rational_camera : public vpgl_rational_camera<T>
   vpgl_local_rational_camera(T longitude, T latitude, T elevation,
                              vpgl_rational_camera<T> const& rcam);
 
-
   ~vpgl_local_rational_camera() override = default;
 
   std::string type_name() const override { return "vpgl_local_rational_camera"; }
@@ -55,51 +54,33 @@ class vpgl_local_rational_camera : public vpgl_rational_camera<T>
              static_cast<vpgl_rational_camera<T> const&>(that)      &&
              this->lvcs() == that.lvcs() );
   }
-// Mutators/Accessors
 
-//: set the local vertical coordinate system
-void set_lvcs(vpgl_lvcs const& lvcs) {lvcs_ = lvcs;}
+  //: set the local vertical coordinate system
+  void set_lvcs(vpgl_lvcs const& lvcs) {lvcs_ = lvcs;}
+  void set_lvcs(double const& lon, double const& lat, double const& elev);
 
-vpgl_lvcs lvcs() const {return lvcs_;}
+  //: get the local vertical coordinate system
+  vpgl_lvcs lvcs() const {return lvcs_;}
 
-//: The generic camera interface. u represents image column, v image row.
-void project(const T x, const T y, const T z, T& u, T& v) const override;
+  //: project 3D->2D, x,y,z are relative to the lvcs
+  using vpgl_rational_camera<T>::project; // "project" overload from base class
+  void project(const T x, const T y, const T z, T& u, T& v) const override;
 
-// Interface for vnl
+  // write PVL (paramter value language) to output stream
+  void write_pvl(std::ostream& s, vpgl_rational_order output_order) const override;
 
-//: Project a world point onto the image
-vnl_vector_fixed<T, 2> project(vnl_vector_fixed<T, 3> const& world_point) const override;
+  //: read from PVL (parameter value language) file/stream
+  using vpgl_rational_camera<T>::read_pvl; // "read_pvl" overload from base class
+  bool read_pvl(std::istream& istr) override;
 
-// Interface for vgl
+  //: read from TXT file/stream
+  using vpgl_rational_camera<T>::read_txt; // "read_txt" overload from base class
+  bool read_txt(std::istream& istr) override;
 
-//: Project a world point onto the image
-vgl_point_2d<T> project(vgl_point_3d<T> world_point) const override;
-
-
-//: print the camera parameters
-void print(std::ostream& s = std::cout) const override;
-
-//: save to file (the lvcs is after the global rational camera parameters)
-bool save(std::string cam_path) override;
-
-
-protected:
-vpgl_lvcs lvcs_;
+ protected:
+  // members
+  vpgl_lvcs lvcs_;
 };
-
-//: Creates a local rational camera from a file
-// \relatesalso vpgl_local_rational_camera
-template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera(std::string cam_path);
-
-//: Creates a local rational camera from a stream (RPB format)
-// \relatesalso vpgl_local_rational_camera
-template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr);
-
-//: read camera from txt file (small sat format)
-template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::string cam_path);
 
 //: Write to stream
 // \relatesalso vpgl_local_rational_camera
@@ -110,6 +91,27 @@ std::ostream& operator<<(std::ostream& s, const vpgl_local_rational_camera<T>& p
 // \relatesalso vpgl_local_rational_camera
 template <class T>
 std::istream& operator>>(std::istream& is, vpgl_local_rational_camera<T>& p);
+
+//: Creates a local rational camera from a PVL file
+// \relatesalso vpgl_local_rational_camera
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera(std::string cam_path);
+
+//: Creates a local rational camera from a PVL input stream
+// \relatesalso vpgl_local_rational_camera
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr);
+
+//: Creates a local rational camera from a TXT file
+// \relatesalso vpgl_local_rational_camera
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::string cam_path);
+
+//: Creates a local rational camera from a TXT input stream
+// \relatesalso vpgl_local_rational_camera
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::istream& istr);
+
 
 #define VPGL_LOCAL_RATIONAL_CAMERA_INSTANTIATE(T) extern "please include vgl/vpgl_local_rational_camera.hxx first"
 

--- a/core/vpgl/vpgl_local_rational_camera.hxx
+++ b/core/vpgl/vpgl_local_rational_camera.hxx
@@ -5,12 +5,14 @@
 // \file
 #include <vector>
 #include <fstream>
+#include <iomanip>
 #include "vpgl_local_rational_camera.h"
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_point_3d.h>
+
 //--------------------------------------
 // Constructors
 //
@@ -26,8 +28,7 @@ vpgl_local_rational_camera<T>::vpgl_local_rational_camera():
 template <class T>
 vpgl_local_rational_camera<T>::
 vpgl_local_rational_camera(vpgl_lvcs const& lvcs,
-                           vpgl_rational_camera<T> const& rcam):
-
+                           vpgl_rational_camera<T> const& rcam) :
   vpgl_rational_camera<T>(rcam), lvcs_(lvcs)
 {
 }
@@ -40,226 +41,194 @@ vpgl_local_rational_camera(T longitude, T latitude, T elevation,
   vpgl_rational_camera<T>(rcam),
   lvcs_(vpgl_lvcs(latitude, longitude, elevation,
                   vpgl_lvcs::wgs84, vpgl_lvcs::DEG, vpgl_lvcs::METERS))
-  {
-  }
+{
+}
 
-
+// clone local rational camera
 template <class T>
 vpgl_local_rational_camera<T>* vpgl_local_rational_camera<T>::clone(void) const
 {
   return new vpgl_local_rational_camera<T>(*this);
 }
 
-// Base projection method, x, y, z are in local Cartesian coordinates
+
+//--------------------------------------
+// Accessor/Mutator
+
+// set lvcs from lon/lat/elev
 template <class T>
-void vpgl_local_rational_camera<T>::project(const T x, const T y, const T z,
-                                            T& u, T& v) const
+void vpgl_local_rational_camera<T>::
+set_lvcs(double const& longitude, double const& latitude, double const& elevation)
 {
-  //first convert to global geographic  coordinates
+  lvcs_ = vpgl_lvcs(latitude, longitude, elevation,
+                    vpgl_lvcs::wgs84, vpgl_lvcs::DEG,
+                    vpgl_lvcs::METERS);
+}
+
+
+//--------------------------------------
+// Point projections
+
+// generic interface, x, y, z are in local Cartesian coordinates
+template <class T>
+void vpgl_local_rational_camera<T>::project(
+    const T x, const T y, const T z,
+    T& u, T& v) const
+{
+  // first, convert to global geographic coordinates
   double lon, lat, gz;
   vpgl_lvcs& non_const_lvcs = const_cast<vpgl_lvcs&>(lvcs_);
   non_const_lvcs.local_to_global(x, y, z, vpgl_lvcs::wgs84, lon, lat, gz);
+
+  // then, project global to 2D
   vpgl_rational_camera<T>::project((T)lon, (T)lat, (T)gz, u, v);
 }
 
-//vnl interface methods
+
+//--------------------------------------
+// Output
+
+// write camera parameters to output stream as PVL (paramter value language)
 template <class T>
-vnl_vector_fixed<T, 2>
-vpgl_local_rational_camera<T>::project(vnl_vector_fixed<T, 3> const& world_point)const
+void vpgl_local_rational_camera<T>::write_pvl(
+    std::ostream& ostr,
+    vpgl_rational_order output_order
+    ) const
 {
-  vnl_vector_fixed<T, 2> image_point;
-  this->project(world_point[0], world_point[1], world_point[2],
-                image_point[0], image_point[1]);
-  return image_point;
-}
+  // parent print
+  vpgl_rational_camera<T>::write_pvl(ostr,output_order);
 
-//vgl interface methods
-template <class T>
-vgl_point_2d<T> vpgl_local_rational_camera<T>::project(vgl_point_3d<T> world_point)const
-{
-  T u = 0, v = 0;
-  this->project(world_point.x(), world_point.y(), world_point.z(), u, v);
-  return vgl_point_2d<T>(u, v);
-}
-
-//: print the camera parameters
-template <class T>
-void vpgl_local_rational_camera<T>::print(std::ostream& s) const
-{
-  vpgl_rational_camera<T>::print(s);
-  s << lvcs_ <<'\n'
-    <<"------------------------------------------------\n\n";
-}
-
-template <class T>
-bool vpgl_local_rational_camera<T>::save(std::string cam_path)
-{
-  std::ofstream file_out;
-  file_out.open(cam_path.c_str());
-  if (!file_out.good()) {
-    std::cerr << "error: bad filename: " << cam_path << std::endl;
-    return false;
-  }
-  file_out.precision(12);
-
-  int map[20];
-  map[0]=19;
-  map[1]=9;
-  map[2]=15;
-  map[3]=18;
-  map[4]=6;
-  map[5]=8;
-  map[6]=14;
-  map[7]=3;
-  map[8]=12;
-  map[9]=17;
-  map[10]=5;
-  map[11]=0;
-  map[12]=4;
-  map[13]=7;
-  map[14]=1;
-  map[15]=10;
-  map[16]=13;
-  map[17]=2;
-  map[18]=11;
-  map[19]=16;
-
-  file_out << "satId = \"????\";\n"
-           << "bandId = \"RGB\";\n"
-           << "SpecId = \"RPC00B\";\n"
-           << "BEGIN_GROUP = IMAGE\n"
-           << "\n\n"  // skip errBias and errRand fields
-           << "  lineOffset = " << vpgl_rational_camera<T>::offset(vpgl_rational_camera<T>::V_INDX) << '\n'
-           << "  sampOffset = " << vpgl_rational_camera<T>::offset(vpgl_rational_camera<T>::U_INDX) << '\n'
-           << "  latOffset = " << vpgl_rational_camera<T>::offset(vpgl_rational_camera<T>::Y_INDX) << '\n'
-           << "  longOffset = " << vpgl_rational_camera<T>::offset(vpgl_rational_camera<T>::X_INDX) << '\n'
-           << "  heightOffset = " << vpgl_rational_camera<T>::offset(vpgl_rational_camera<T>::Z_INDX) << '\n'
-           << "  lineScale = " << vpgl_rational_camera<T>::scale(vpgl_rational_camera<T>::V_INDX) << '\n'
-           << "  sampScale = " << vpgl_rational_camera<T>::scale(vpgl_rational_camera<T>::U_INDX) << '\n'
-           << "  latScale = " << vpgl_rational_camera<T>::scale(vpgl_rational_camera<T>::Y_INDX) << '\n'
-           << "  longScale = " << vpgl_rational_camera<T>::scale(vpgl_rational_camera<T>::X_INDX) << '\n'
-           << "  heightScale = " << vpgl_rational_camera<T>::scale(vpgl_rational_camera<T>::Z_INDX) << '\n';
-  vnl_matrix_fixed<T,4,20> coeffs = this->coefficient_matrix();
-  file_out << "  lineNumCoef = (";
-  for (int i=0; i<20; i++) {
-    file_out << "\n    " << coeffs[vpgl_rational_camera<T>::NEU_V][map[i]];
-    if (i < 19)
-      file_out << ',';
-  }
-  file_out << ");\n  lineDenCoef = (";
-  for (int i=0; i<20; i++) {
-    file_out << "\n    " << coeffs[vpgl_rational_camera<T>::DEN_V][map[i]];
-    if (i < 19)
-      file_out << ',';
-  }
-  file_out << ");\n  sampNumCoef = (";
-  for (int i=0; i<20; i++) {
-    file_out << "\n    " << coeffs[vpgl_rational_camera<T>::NEU_U][map[i]];
-    if (i < 19)
-      file_out << ',';
-  }
-  file_out << ");\n  sampDenCoef = (";
-  for (int i=0; i<20; i++) {
-    file_out << "\n    " << coeffs[vpgl_rational_camera<T>::DEN_U][map[i]];
-    if (i < 19)
-      file_out << ',';
-  }
-  file_out << ");\n"
-           << "END_GROUP = IMAGE\n"
-           << "END;\n"
-
-           << "lvcs\n";
+  // append lvcs
   double longitude, latitude, elevation;
   lvcs_.get_origin(latitude, longitude, elevation);
-  file_out << longitude << '\n'
-           << latitude << '\n'
-           << elevation << '\n';
+  ostr << "lvcs" << std::endl
+       << std::setprecision(12) << longitude << std::endl
+       << std::setprecision(12) << latitude << std::endl
+       << std::setprecision(12) << elevation << std::endl;
+}
+
+
+//--------------------------------------
+// Input
+
+// read from a PVL file stream
+template <class T>
+bool vpgl_local_rational_camera<T>::read_pvl(std::istream& istr)
+{
+  // read rational camera
+  if (!vpgl_rational_camera<T>::read_pvl(istr))
+    return false;
+
+  // read lvcs
+  double longitude, latitude, elevation;
+  bool has_lvcs = false;
+  std::string input;
+
+  while (!istr.eof() && !has_lvcs) {
+    istr >> input;
+    if (input=="lvcs") {
+      istr >> longitude >> latitude >> elevation;
+      has_lvcs = true;
+    }
+  }
+
+  if (!has_lvcs) {
+    //std::cerr << "error: not a composite rational camera file\n";
+    return false;
+  }
+
+  // store lvcs & return
+  this->set_lvcs(longitude, latitude, elevation);
   return true;
 }
 
-// read from a file
+// read from a TXT file stream
 template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera(std::string cam_path)
+bool vpgl_local_rational_camera<T>::read_txt(std::istream& istr)
 {
-  std::ifstream file_inp;
-  file_inp.open(cam_path.c_str());
-  if (!file_inp.good()) {
-    std::cout << "error: bad filename: " << cam_path << std::endl;
-    return nullptr;
-  }
-  return read_local_rational_camera<T>(file_inp);
-}
-//: read from an open istream
-template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr)
-{
-  vpgl_rational_camera<T>* rcam = read_rational_camera<T>(istr);
-  if (!rcam)
-    return nullptr;
+  // read rational camera
+  if (!vpgl_rational_camera<T>::read_txt(istr))
+    return false;
+
+  // read lvcs
+  double longitude, latitude, elevation;
+  bool has_lvcs = false;
   std::string input;
-  bool good = false;
-  vpgl_lvcs lvcs;
-  while (!istr.eof()&&!good) {
+
+  while (!istr.eof() && !has_lvcs) {
     istr >> input;
-    if (input=="lvcs")
-    {
-      double longitude, latitude, elevation;
+    if (input=="lvcs") {
       istr >> longitude >> latitude >> elevation;
-      lvcs = vpgl_lvcs(latitude, longitude, elevation,
-                       vpgl_lvcs::wgs84, vpgl_lvcs::DEG, vpgl_lvcs::METERS);
-      good = true;
+      has_lvcs = true;
     }
   }
-  if  (!good)
-  {
-    //std::cout << "error: not a composite rational camera file\n";
-    return nullptr;
-  }
-  return new vpgl_local_rational_camera<T>(lvcs, *rcam);
-}
-template <class T>
-vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::string cam_path){
 
-  vpgl_rational_camera<T>* rcam = read_rational_camera_from_txt<T>(cam_path);
-
-  if(! rcam){
-    std::cout << "Failed to read rational camera part of " << cam_path << '\n';
-    return nullptr;
+  if (!has_lvcs) {
+    //std::cerr << "error: not a composite rational camera file\n";
+    return false;
   }
-  std::ifstream file_inp;
-  file_inp.open(cam_path.c_str());
-  if (!file_inp.good()) {
-    std::cout << "error: bad filename: " << cam_path << std::endl;
-    return nullptr;
-  }
-  bool good = false;
-  vpgl_lvcs lvcs;
-  std::string input;
-  while (!file_inp.eof()&&!good) {
-   file_inp >> input;
-    if (input=="lvcs")
-    {
-      double longitude, latitude, elevation;
-      file_inp >> longitude >> latitude >> elevation;
-      lvcs = vpgl_lvcs(latitude, longitude, elevation,
-                       vpgl_lvcs::wgs84, vpgl_lvcs::DEG, vpgl_lvcs::METERS);
-      good = true;
-    }
-  }
-  if  (!good)
-  {
-    //std::cout << "error: not a composite rational camera file\n";
-    return nullptr;
-  }
-  return new vpgl_local_rational_camera<T>(lvcs, *rcam);
 }
 
-//: Write to stream
+
+//--------------------------------------
+// Convenience functions
+
+// write to stream
 template <class T>
-std::ostream&  operator<<(std::ostream& s, const vpgl_local_rational_camera<T>& c )
+std::ostream& operator<<(std::ostream& s, const vpgl_local_rational_camera<T >& c )
 {
   c.print(s);
   return s;
+}
+
+// read from stream
+template <class T>
+std::istream& operator >>(std::istream& s, vpgl_local_rational_camera<T >& c )
+{
+  c.read_pvl(s);
+  return s;
+}
+
+// read from a PVL file/stream
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera(std::string cam_path)
+{
+  vpgl_local_rational_camera<T> cam;
+  if (!cam.read_pvl(cam_path))
+    return nullptr;
+  else
+    return cam.clone();
+}
+
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera(std::istream& istr)
+{
+  vpgl_local_rational_camera<T> cam;
+  if (!cam.read_pvl(istr))
+    return nullptr;
+  else
+    return cam.clone();
+}
+
+// read from a TXT file/stream
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::string cam_path)
+{
+  vpgl_local_rational_camera<T> cam;
+  if (!cam.read_txt(cam_path))
+    return nullptr;
+  else
+    return cam.clone();
+}
+
+template <class T>
+vpgl_local_rational_camera<T>* read_local_rational_camera_from_txt(std::istream& istr)
+{
+  vpgl_local_rational_camera<T> cam;
+  if (!cam.read_txt(istr))
+    return nullptr;
+  else
+    return cam.clone();
 }
 
 
@@ -268,8 +237,10 @@ std::ostream&  operator<<(std::ostream& s, const vpgl_local_rational_camera<T>& 
 #define vpgl_LOCAL_RATIONAL_CAMERA_INSTANTIATE(T) \
 template class vpgl_local_rational_camera<T >; \
 template std::ostream& operator<<(std::ostream&, const vpgl_local_rational_camera<T >&); \
+template std::istream& operator>>(std::istream&, vpgl_local_rational_camera<T >&); \
 template vpgl_local_rational_camera<T >* read_local_rational_camera(std::string); \
- template vpgl_local_rational_camera<T >* read_local_rational_camera_from_txt(std::string); \
-template vpgl_local_rational_camera<T >* read_local_rational_camera(std::istream&)
+template vpgl_local_rational_camera<T >* read_local_rational_camera(std::istream&); \
+template vpgl_local_rational_camera<T >* read_local_rational_camera_from_txt(std::string); \
+template vpgl_local_rational_camera<T >* read_local_rational_camera_from_txt(std::istream&)
 
 #endif // vpgl_local_rational_camera_hxx_

--- a/core/vpgl/vpgl_rational_camera.cxx
+++ b/core/vpgl/vpgl_rational_camera.cxx
@@ -1,0 +1,92 @@
+// This is core/vpgl/vpgl_rational_camera.cxx
+#include "vpgl_rational_camera.h"
+
+
+// std::vector from vpgl_rational_order
+std::vector<unsigned>
+vpgl_rational_order_func::to_vector(vpgl_rational_order choice) {
+  std::vector<unsigned> order(20,0);
+  switch(choice) {
+
+    // order[VXL_INDEX] = VXL_INDEX
+    case vpgl_rational_order::VXL : {
+      order[0]  =  0; // xxx
+      order[1]  =  1; // xxy
+      order[2]  =  2; // xxz
+      order[3]  =  3; // xx
+      order[4]  =  4; // xyy
+      order[5]  =  5; // xyz
+      order[6]  =  6; // xy
+      order[7]  =  7; // xzz
+      order[8]  =  8; // xz
+      order[9]  =  9; // x
+      order[10] = 10; // yyy
+      order[11] = 11; // yyz
+      order[12] = 12; // yy
+      order[13] = 13; // yzz
+      order[14] = 14; // yz
+      order[15] = 15; // y
+      order[16] = 16; // zzz
+      order[17] = 17; // zz
+      order[18] = 18; // z
+      order[19] = 19; // 1
+      break;
+    }
+
+    // order[VXL_INDEX] = RPC00B_INDEX
+    case vpgl_rational_order::RPC00B : {
+      order[0]  = 11; // xxx
+      order[1]  = 14; // xxy
+      order[2]  = 17; // xxz
+      order[3]  =  7; // xx
+      order[4]  = 12; // xyy
+      order[5]  = 10; // xyz
+      order[6]  =  4; // xy
+      order[7]  = 13; // xzz
+      order[8]  =  5; // xz
+      order[9]  =  1; // x
+      order[10] = 15; // yyy
+      order[11] = 18; // yyz
+      order[12] =  8; // yy
+      order[13] = 16; // yzz
+      order[14] =  6; // yz
+      order[15] =  2; // y
+      order[16] = 19; // zzz
+      order[17] =  9; // zz
+      order[18] =  3; // z
+      order[19] =  0; // 1
+      break;
+    }
+
+    default: {
+      throw std::invalid_argument("vpgl_rational_order not recognized");
+    }
+  }
+  return order;
+}
+
+// string from vpgl_rational_order
+std::string
+vpgl_rational_order_func::to_string(vpgl_rational_order choice)
+{
+  switch(choice) {
+    case vpgl_rational_order::VXL :
+      return "VXL";
+    case vpgl_rational_order::RPC00B :
+      return "RPC00B";
+    default:
+      throw std::invalid_argument("vpgl_rational_order not recognized");
+  }
+}
+
+// vpgl_rational_order from string
+vpgl_rational_order
+vpgl_rational_order_func::from_string(std::string const& buf)
+{
+  if (buf.find("VXL") != std::string::npos)
+    return vpgl_rational_order::VXL;
+  else if (buf.find("RPC00B") != std::string::npos)
+    return vpgl_rational_order::RPC00B;
+  else
+    throw std::invalid_argument("string not recognized as vpgl_rational_order");
+}


### PR DESCRIPTION
`vpgl_rational_camera` refactoring
- input/output coefficient order schema that differs from VXL internal order now encapsulated in one place - see new `vpgl_rational_order` scoped enumeration
- new `read*` methods for easier overloading with additional file validation
- general refactoring (review, cleanup, & update)
- refactor derived classes (`vpgl_local_rational_camera` and `vpgl_nitf_rational_camera`) for compatibility with base class
- additional `project` tests