### PR TITLE
COMP: Improve header search robustness

### DIFF
--- a/core/vnl/tests/test_drand48.cpp
+++ b/core/vnl/tests/test_drand48.cpp
@@ -4,7 +4,7 @@
 
 #include <iostream>
 #include <stdlib.h>
-#include "vnl_drand48.h"
+#include <vnl/vnl_drand48.h>
 
 int main(int, char*[])
 {

--- a/core/vnl/tests/test_matrix_exp.cxx
+++ b/core/vnl/tests/test_matrix_exp.cxx
@@ -5,8 +5,8 @@
 #include <vnl/vnl_double_3.h>
 #include <vnl/vnl_matlab_print.h>
 #include <vnl/vnl_cross_product_matrix.h>
-#include "vnl_matrix_exp.h"
-#include "vnl_rotation_matrix.h"
+#include <vnl/vnl_matrix_exp.h>
+#include <vnl/vnl_rotation_matrix.h>
 #include <testlib/testlib_test.h>
 
 void test_matrix_exp()


### PR DESCRIPTION
The path to headers for the tests should be
consistently relative to the core directory.