### PR TITLE
vpgl_equi_rectification

### DIFF
--- a/core/vpgl/algo/CMakeLists.txt
+++ b/core/vpgl/algo/CMakeLists.txt
@@ -29,6 +29,7 @@ set( vpgl_algo_sources
   vpgl_affine_rectification.h      vpgl_affine_rectification.cxx
   vpgl_camera_transform.h          vpgl_camera_transform.cxx
   vpgl_fit_rational_cubic.h        vpgl_fit_rational_cubic.cxx
+  vpgl_equi_rectification.h        vpgl_equi_rectification.cxx
 )
 include(${VXL_CMAKE_DIR}/FindTIFF.cmake)
 if(TIFF_FOUND)

--- a/core/vpgl/algo/tests/CMakeLists.txt
+++ b/core/vpgl/algo/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable( vpgl_algo_test_all
   test_affine_rectification.cxx
   test_affine_tensor_transfer.cxx
   test_fit_rational_cubic.cxx
+  test_equi_rectification.cxx
 )
 target_link_libraries( vpgl_algo_test_all ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}testlib )
 endif()
@@ -61,6 +62,7 @@ add_executable( vpgl_algo_test_all
   test_affine_tensor_transfer.cxx
   test_backproject_dem.cxx
   test_fit_rational_cubic.cxx
+  test_equi_rectification.cxx
 )
 target_link_libraries( vpgl_algo_test_all ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vpgl_file_formats ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}testlib )
 add_test( NAME vpgl_algo_test_backproject_dem COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_backproject_dem )
@@ -86,6 +88,7 @@ add_test( NAME vpgl_algo_test_ba_shared_k_lsqr COMMAND $<TARGET_FILE:vpgl_algo_t
 add_test( NAME vpgl_algo_test_affine_rect COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_affine_rect )
 add_test( NAME vpgl_algo_test_affine_tensor_transfer COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_affine_tensor_transfer )
 add_test( NAME vpgl_algo_test_fit_rational_cubic COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_fit_rational_cubic )
+add_test( NAME vpgl_algo_test_equi_rectification COMMAND $<TARGET_FILE:vpgl_algo_test_all> test_equi_rectification )
 
 add_executable( vpgl_algo_test_include test_include.cxx )
 target_link_libraries( vpgl_algo_test_include ${VXL_LIB_PREFIX}vpgl_algo )

--- a/core/vpgl/algo/tests/test_camera_compute.cxx
+++ b/core/vpgl/algo/tests/test_camera_compute.cxx
@@ -249,6 +249,52 @@ static void test_calibration_compute_natural()
   TEST_NEAR( "   K Discrepancy", ( trueK.get_matrix() - K.get_matrix() ).frobenius_norm(), 0, 1e-6 );
 }
 
+static void test_compute_affine()
+{
+  std::vector<vgl_point_3d<double> > pts_3d;
+  pts_3d.emplace_back(31.191099166870,121.919998168945,53.835998535156);
+  pts_3d.emplace_back(67.191101074219,66.720397949219,74.165496826172);
+  pts_3d.emplace_back(54.891101837158,97.920303344727,66.359802246094);
+  pts_3d.emplace_back(50.991100311279,80.220397949219,67.610298156738);
+  pts_3d.emplace_back(28.791099548340,67.320396423340,67.759902954102);
+  pts_3d.emplace_back(53.091098785400,40.920299530029,68.854202270508);
+  pts_3d.emplace_back(43.791099548340,49.620399475098,67.872703552246);
+  pts_3d.emplace_back(93.290100097656,30.420299530029,79.595397949219);
+  pts_3d.emplace_back(94.790100097656,52.020401000977,74.720100402832);
+  pts_3d.emplace_back(100.489997863770,86.520401000977,68.012802124023);
+  pts_3d.emplace_back(91.790100097656,102.419998168945,68.957199096680);
+  pts_3d.emplace_back(87.891098022461,127.620002746582,67.613098144531);
+  pts_3d.emplace_back(31.491100311279,107.220001220703,60.077598571777);
+  pts_3d.emplace_back(59.391101837158,115.319999694824,61.324699401855);
+  pts_3d.emplace_back(59.991100311279,133.320007324219,62.057498931885);
+  pts_3d.emplace_back(36.891101837158,144.119995117188,55.506599426270);
+  pts_3d.emplace_back(18.891099929810,111.419998168945,57.615100860596);
+  pts_3d.emplace_back(19.491100311279,78.720397949219,85.827499389648);
+  pts_3d.emplace_back(26.991100311279,35.220401763916,83.151901245117);
+  pts_3d.emplace_back(61.191101074219,16.320400238037,68.855102539063);
+  pts_3d.emplace_back(127.489997863770,32.220401763916,96.971298217773);
+  pts_3d.emplace_back(123.290000915527,16.920299530029,99.897903442383);
+  pts_3d.emplace_back(122.089996337891,92.220397949219,69.267196655273);
+  pts_3d.emplace_back(85.491096496582,92.820396423340,67.331802368164);
+  vnl_vector_fixed<double,4> row00, row01;
+  row00[0] = 2.13641;   row00[1] = 0.000728937; row00[2] = -0.103897; row00[3] = 253.827;
+  row01[0] = -0.0107484;   row01[1] = -2.13683; row01[2] = -0.229387; row01[3] = 648.49;
+  vpgl_affine_camera<double> acam(row00, row01), fitted_acam;
+  std::vector< vgl_point_2d<double> > pts_2d;
+  for (const auto & i : pts_3d) {
+    pts_2d.push_back( acam.project( i ) );
+  }
+  bool good = vpgl_affine_camera_compute::compute(pts_2d, pts_3d, fitted_acam);
+  double er0 = 0.0;
+  vnl_matrix_fixed<double, 3, 4> Mgt = acam.get_matrix(), Mfitted = fitted_acam.get_matrix();
+  for (size_t r = 0; r<2; ++r)
+	  for (size_t c = 0; c < 2; ++c) {
+		  er0 += fabs(Mgt[r][c] - Mfitted[r][c]);
+	  }
+  good = good && er0 < 1,0e-6;
+  TEST("compute affine camera from pts", good, true);
+}
+
 static void test_compute_rational()
 {
   double neu_u1[20] =
@@ -326,6 +372,7 @@ static void test_camera_compute()
   test_perspective_compute_direct_linear_transform();
   test_perspective_compute_ground();
   test_calibration_compute_natural();
+  test_compute_affine();
   test_compute_rational();
 }
 

--- a/core/vpgl/algo/tests/test_driver.cxx
+++ b/core/vpgl/algo/tests/test_driver.cxx
@@ -21,6 +21,7 @@ DECLARE( test_affine_rect );
 DECLARE( test_backproject_dem );
 DECLARE( test_affine_tensor_transfer );
 DECLARE( test_fit_rational_cubic );
+DECLARE( test_equi_rectification );
 
 void register_tests()
 {
@@ -44,6 +45,7 @@ REGISTER( test_ba_shared_k_lsqr );
 REGISTER( test_affine_rect );
 REGISTER( test_affine_tensor_transfer );
 REGISTER( test_fit_rational_cubic );
+REGISTER( test_equi_rectification );
 #if HAS_GEOTIFF
  REGISTER( test_backproject_dem );
 #endif

--- a/core/vpgl/algo/tests/test_equi_rectification.cxx
+++ b/core/vpgl/algo/tests/test_equi_rectification.cxx
@@ -1,0 +1,178 @@
+#include <limits>
+#include <iostream>
+#include <testlib/testlib_test.h>
+#include <vpgl/algo/vpgl_equi_rectification.h>
+#include <vpgl/algo/vpgl_fm_compute_8_point.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_proj_camera.h>
+#include <vpgl/vpgl_fundamental_matrix.h>
+#include <vpgl/vpgl_affine_fundamental_matrix.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_matrix_fixed.h>
+#include <vgl/vgl_homg_point_2d.h>
+#include <vgl/vgl_homg_point_3d.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+static void test_equi_rectification()
+{
+  //
+  // **************  the affine case **************
+  //
+  vnl_vector_fixed<double,4> row00, row01;
+  row00[0] = 2.13641;   row00[1] = 0.000728937; row00[2] = -0.103897; row00[3] = 253.827;
+  row01[0] = -0.0107484;   row01[1] = -2.13683; row01[2] = -0.229387; row01[3] = 648.49;
+  vpgl_affine_camera<double> acam0(row00, row01);
+  vnl_vector_fixed<double, 4> row10, row11;
+  row10[0] = 2.8301;   row10[1] = -0.00578537; row10[2] = 0.965491; row10[3] = 370.849;
+  row11[0] = 0.250657;   row11[1] = -2.88516; row11[2] = -0.754392; row11[3] = 1061.18;
+  vpgl_affine_camera<double> acam1(row10, row11);
+  std::vector<vnl_vector_fixed<double, 3> > pts0;
+  pts0.emplace_back(517.08519082044199, 405.49679591436848, 1.0);
+  pts0.emplace_back(368.62656130374893, 533.20968068909804, 1.0);
+  pts0.emplace_back(392.29848889951120, 423.99376519663429, 1.0);
+  pts0.emplace_back(415.10361646971978, 515.81585132594773, 1.0);
+  pts0.emplace_back(307.54159114243384, 576.47594817744562, 1.0);
+  pts0.emplace_back(354.56356426606294, 455.17288861683886, 1.0);
+  pts0.emplace_back(461.26439037279738, 470.63791935664727, 1.0);
+  pts0.emplace_back(468.61976984314731, 472.78601453482474, 1.0);
+  pts0.emplace_back(291.13628062306191, 534.29929831742788, 1.0);
+  pts0.emplace_back(472.90116979986323, 509.41945691988161, 1.0);
+  pts0.emplace_back(505.67433037185447, 412.38062091046197, 1.0);
+  pts0.emplace_back(418.21079400745646, 339.73123667808431, 1.0);
+  pts0.emplace_back(395.10755292805965, 541.36311485813326, 1.0);
+  pts0.emplace_back(431.57972126743914, 413.56864677893407, 1.0);
+  pts0.emplace_back(409.02926512641517, 523.17245556597663, 1.0);
+  pts0.emplace_back(499.77563737866802, 369.29886348233589, 1.0);
+  pts0.emplace_back(374.57684472738765, 462.98842569351308, 1.0);
+  pts0.emplace_back(394.33365039580144, 535.31987299994341, 1.0);
+  pts0.emplace_back(325.92706836270702, 290.57854159710979, 1.0);
+  pts0.emplace_back(294.89461576267445, 551.15374537669527, 1.0);
+
+  std::vector<vnl_vector_fixed<double , 3> > pts1;
+  pts1.emplace_back(804.37166610597023, 732.29242173264697, 1.0);
+  pts1.emplace_back(608.10981184076206, 886.30988997648990, 1.0);
+  pts1.emplace_back(639.12331300363223, 741.77946271747237, 1.0);
+  pts1.emplace_back(669.62370166924109, 868.59261223726821, 1.0);
+  pts1.emplace_back(527.32634094356399, 937.14824986983365, 1.0);
+  pts1.emplace_back(589.23380555663482, 779.19537477125436, 1.0);
+  pts1.emplace_back(730.63082919432691, 813.32064833166964, 1.0);
+  pts1.emplace_back(740.38139587443618, 817.13405514819260, 1.0);
+  pts1.emplace_back(505.46073221505446, 878.16309403135233, 1.0);
+  pts1.emplace_back(746.16876781993733, 867.12969312267182, 1.0);
+  pts1.emplace_back(789.27727876815152, 740.17098322795971, 1.0);
+  pts1.emplace_back(673.18351202450344, 631.22037119164338, 1.0);
+  pts1.emplace_back(643.21533310416612, 900.60585407866961, 1.0);
+  pts1.emplace_back(691.12680646128774, 732.57853165751123, 1.0);
+  pts1.emplace_back(661.60016063111368, 877.77190747452846, 1.0);
+  pts1.emplace_back(781.32708227848002, 681.26778313753960, 1.0);
+  pts1.emplace_back(615.77038654683304, 792.23232532727650, 1.0);
+  pts1.emplace_back(642.17104021771706, 892.34992238263681, 1.0);
+  pts1.emplace_back(550.77860354735083, 553.39783796559527, 1.0);
+  pts1.emplace_back(510.49270359363777, 901.38726023140657, 1.0);
+
+  vpgl_affine_fundamental_matrix<double>  aF(acam0, acam1);
+  vnl_matrix_fixed<double, 3, 3> H0,  H1, test_H0, test_H1;
+  bool good = vpgl_equi_rectification::rectify_pair(aF, pts0, pts1, H0, H1);
+  TEST("Run on a real example", good, true);
+
+  //check colinear epipolar lines
+  bool equal_v = true;
+
+  size_t n = pts0.size();
+  for (size_t k = 0; k < n; ++k) {
+    vnl_vector_fixed<double, 3> p0 = pts0[k], hp0, p1 = pts1[k], hp1;
+    hp0 = H0*p0;  hp1 = H1*p1;
+
+    double v0 = hp0[1]/hp0[2], v1 = hp1[1]/hp1[2];
+    double dv = fabs(v1-v0);
+    if(dv>0.001)
+      equal_v = false;
+  }
+
+  TEST("real_example:affine_rectification has collinear epipolar lines", equal_v, true);
+
+  //  check with synthetic data for u transform
+  double su = -0.5, sigma_u = 0.1, tu = 10;
+  double u0_avg = 0.0, u1_avg = 0.0, v1_avg = 0.0;
+  std::vector<vnl_vector_fixed<double, 3> > syn_pts0, syn_pts1=pts1;
+  for (size_t i = 0; i < n; ++i) {
+    const vnl_vector_fixed<double, 3>& sp1 = syn_pts1[i];
+    u1_avg += sp1[0];   v1_avg += sp1[1];
+    vnl_vector_fixed<double, 3> syn_p0;
+    syn_p0[0] = su * sp1[0] + sigma_u * sp1[1] + tu;
+    syn_p0[1] = sp1[1]; syn_p0[2] = 1.0;
+    u0_avg += syn_p0[0];
+    syn_pts0.push_back(syn_p0);
+  }
+  u0_avg/=n; u1_avg/=n; v1_avg/=n;
+  vnl_matrix_fixed<double, 3,3> fm(0.0);
+  fm[1][2] = fm[2][1] = -1.0;
+  vpgl_affine_fundamental_matrix<double>  syn_aF(fm);
+  vnl_matrix_fixed<double, 3, 3> syn_H0, syn_H1, syn_test_H0, syn_test_H1;
+  good = vpgl_equi_rectification::rectify_pair(syn_aF, syn_pts0, syn_pts1, syn_H0, syn_H1);
+
+  syn_test_H0.set_identity();
+  syn_test_H0[0][0] = -1.414213562; syn_test_H0[0][1] = 1.414213562*0.058578644;
+  syn_test_H0[0][2] =5.857864376*1.414213562; syn_test_H0[1][1] = -1;
+
+  syn_test_H1.set_identity();
+  syn_test_H1[0][0] = 0.707106781; syn_test_H1[0][1] = -0.058578644; syn_test_H1[0][2] = -5.857864376;
+  syn_test_H1[1][1] = -1;
+  double syn_er0 = 0.0, syn_er1 = 0.0;
+  for (size_t r = 0; r<2; ++r)
+    for (size_t c = 0; c < 2; ++c) {
+      syn_er0 += fabs(syn_H0[r][c] - syn_test_H0[r][c]);
+      syn_er1 += fabs(syn_H1[r][c] - syn_test_H1[r][c]);
+    }
+  syn_er0 /= 6; syn_er1 /= 6;
+  TEST_NEAR("affine_rectification collinear epipolar lines", syn_er0+syn_er1, 0.0, 1e-8);
+
+  //
+  // **************  the projective case **************
+  //
+  double random_list0[12] = { 1, 15, 9, -1, 2, -6, -9, 7, -5, 6, 10, 0 };
+  double random_list1[12] = { 10.6, 1.009, .676, .5, -13, -10, 8, 5, 88, -2, -100, 11 };
+  vpgl_proj_camera<double> C0( random_list0 );
+  vpgl_proj_camera<double> C1( random_list1 );
+  vpgl_fundamental_matrix<double> F( C0, C1 );
+  vnl_matrix_fixed<double, 3, 3> mF = F.get_matrix();
+
+  std::vector< vgl_homg_point_3d<double> > p3d;
+  p3d.emplace_back( 2, -1, 5 );
+  p3d.emplace_back( 1, 10, 0 );
+  p3d.emplace_back( -5, -7, 1 );
+  p3d.emplace_back( 0, 8, 10 );
+  p3d.emplace_back( 1, 2, 3 );
+  p3d.emplace_back( -4, -10, 0 );
+  p3d.emplace_back( 6, 8, -5 );
+  p3d.emplace_back( -2, 0, -1.5 );
+
+  std::vector< vgl_homg_point_2d<double> > pts2d0, pts2d1;
+  for (const auto & i : p3d) {
+    pts2d0.push_back( C0.project( i ) );
+    pts2d1.push_back( C1.project( i ) );
+  }
+  std::vector<vnl_vector_fixed<double, 3> > ppts0, ppts1;
+  for(size_t i = 0; i< pts2d0.size(); ++i){
+    ppts0.emplace_back(pts2d0[i].x(), pts2d0[i].y(), pts2d0[i].w());
+    ppts1.emplace_back(pts2d1[i].x(), pts2d1[i].y(), pts2d1[i].w());
+  }
+  vnl_matrix_fixed<double, 3, 3> pH0,  pH1;
+  good = vpgl_equi_rectification::rectify_pair(F, ppts0, ppts1, pH0, pH1);
+  TEST("equi rectification projective", good, true);
+  equal_v = true;
+  for (size_t k = 0; k < pts2d0.size() && equal_v; ++k) {
+    vnl_vector_fixed<double, 3> p0 = pts0[k], hp0, p1 = pts1[k], hp1;
+    hp0 = pH0 * p0;  hp1 = pH1 * p1;
+    double v0 = hp0[1] / hp0[2], v1 = hp1[1] / hp1[2];
+    double dv = fabs(v1 - v0);
+    if (dv > 1.1)
+      equal_v = false;
+  }
+  TEST("collinear epipolar lines projective", equal_v, true);
+
+}
+
+TESTMAIN(test_equi_rectification);

--- a/core/vpgl/algo/vpgl_affine_rectification.cxx
+++ b/core/vpgl/algo/vpgl_affine_rectification.cxx
@@ -78,8 +78,8 @@ bool vpgl_affine_rectification::compute_rectification(const vpgl_affine_fundamen
                                                       vnl_matrix_fixed<double, 3, 3>& H2)
 {
   vnl_matrix_fixed<double, 3, 3> FAM = FA.get_matrix();
-  vnl_vector_fixed<double, 2> e1; e1[0] = -FAM[2][1]; e1[1] = FAM[2][0]; e1[2] = 0;
-  vnl_vector_fixed<double, 2> e2; e2[0] = -FAM[1][2]; e2[1] = FAM[0][2]; e2[2] = 0;
+  vnl_vector_fixed<double, 3> e1; e1[0] = -FAM[2][1]; e1[1] = FAM[2][0]; e1[2] = 0;
+  vnl_vector_fixed<double, 3> e2; e2[0] = -FAM[1][2]; e2[1] = FAM[0][2]; e2[2] = 0;
 
   double e1l = e1.magnitude();
   double e2l = e2.magnitude();

--- a/core/vpgl/algo/vpgl_affine_rectification.h
+++ b/core/vpgl/algo/vpgl_affine_rectification.h
@@ -14,10 +14,12 @@
 class vpgl_affine_rectification
 {
  public:
+
   static vpgl_affine_camera<double>* compute_affine_cam(const std::vector< vgl_point_2d<double> >& image_pts,
                                                         const std::vector< vgl_point_3d<double> >& world_pts);
 
   //:extract the fundamental matrix from a pair of affine cameras
+  // DEPRECATED - see constructor for vpgl_affine_fundamental_matrix
   static bool compute_affine_f(const vpgl_affine_camera<double>* cam1,
                                const vpgl_affine_camera<double>* cam2,
                                vpgl_affine_fundamental_matrix<double>& FA);
@@ -25,6 +27,7 @@ class vpgl_affine_rectification
   //: compute the rectification homographies using the affine fundamental matrix
   //  an image correspondence needs to be passed to find homographies
   //  (if cameras are known, one can use a known point in 3d in the scene, project it using the cameras and pass the output image points to this routine)
+  // DEPRECATED - see vpgl/algo/vpgl_equi_rectification
   static bool compute_rectification(const vpgl_affine_fundamental_matrix<double>& FA,
                                     const std::vector<vnl_vector_fixed<double, 3> >& img_p1,
                                     const std::vector<vnl_vector_fixed<double, 3> >& img_p2,

--- a/core/vpgl/algo/vpgl_camera_compute.cxx
+++ b/core/vpgl/algo/vpgl_camera_compute.cxx
@@ -107,10 +107,12 @@ vpgl_affine_camera_compute::compute(
 {
   assert( image_pts.size() == world_pts.size() );
   assert( image_pts.size() > 3 );
+  vgl_box_3d<double> bb;
 
   // Form the solution matrix.
   vnl_matrix<double> A(static_cast<unsigned int>(world_pts.size()), 4, 1 );
   for (unsigned int i = 0; i < world_pts.size(); ++i) {
+    bb.add(world_pts[i]);
     A(i,0) = world_pts[i].x(); A(i,1) = world_pts[i].y(); A(i,2) = world_pts[i].z();
   }
   vnl_vector<double> b1( image_pts.size() );
@@ -132,6 +134,7 @@ vpgl_affine_camera_compute::compute(
 
   // Fill in the camera.
   camera.set_rows( x1, x2 );
+  camera.set_viewing_distance(10.0*bb.max_z());
   return true;
 }
 

--- a/core/vpgl/algo/vpgl_equi_rectification.cxx
+++ b/core/vpgl/algo/vpgl_equi_rectification.cxx
@@ -1,0 +1,313 @@
+#include "vpgl_equi_rectification.h"
+#include <vnl/algo/vnl_lsqr.h>
+#include <vnl/vnl_sparse_matrix_linear_system.h>
+#include <vpgl/algo/vpgl_camera_compute.h>
+#include <vgl/vgl_homg_point_2d.h>
+#include <vgl/vgl_tolerance.h>
+#include <math.h>
+#include <vnl_det.h>
+#include <vnl_inverse.h>
+
+bool vpgl_equi_rectification::rectify_pair(const vpgl_affine_fundamental_matrix<double>& aF,
+                                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts0,
+                                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts1,
+                                           vnl_matrix_fixed<double, 3, 3>& H0, vnl_matrix_fixed<double, 3, 3>& H1,
+                                           double min_scale){
+  double tol = 100.0*vgl_tolerance<double>::position;
+  vnl_matrix_fixed<double, 3, 3> Mf = aF.get_matrix();
+
+  //  vnl_vector_fixed<double, 3> e0; e0[0] = -Mf[2][1]; e0[1] = Mf[2][0]; e0[2] = 0;
+  //  vnl_vector_fixed<double, 3> e1; e1[0] = -Mf[1][2]; e1[1] = Mf[0][2]; e1[2] = 0;
+  // retains original image orientation compared to other solution above
+  vnl_vector_fixed<double, 3> e0; e0[0] = Mf[2][1]; e0[1] = -Mf[2][0]; e0[2] = 0;
+  vnl_vector_fixed<double, 3> e1; e1[0] = Mf[1][2]; e1[1] = -Mf[0][2]; e1[2] = 0;
+  double e0m = e0.magnitude();
+  double e1m = e1.magnitude();
+  if(e0m<tol || e1m < tol){
+    std::cout << "in vpgl_equi_rectification::compute_rectification(affine), null epipoles" << std::endl;
+    return false;
+  }
+  e0/= e0m; e1/=e1m;
+  H0.set_identity();
+  H1.set_identity();
+
+  // rotation of the left image so that epipolar lines become parallel
+  H0[0][0] = H0[1][1] = e0[0];
+  H0[0][1] = e0[1]; H0[1][0] = -e0[1];
+
+  // rotation of the right image so that epipolar lines become parallel
+  H1[0][0] = H1[1][1] = e1[0];
+  H1[0][1] = e1[1]; H1[1][0] = -e1[1];
+
+  auto n = static_cast<unsigned int>(img_pts0.size());
+  if (n != img_pts1.size()) {
+    std::cout << "in vpgl_equi_rectification::compute_rectification()--img_pts0 and img_pts1 do not have equal size"
+              << std::endl;
+    return false;
+  }
+
+  // find a scaling and offset for the row coordinates
+  double v0_avg = 0, rv1_avg = 0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0*img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1*img_pts1[i];
+    v0_avg += p0rot[1]; rv1_avg += p1rot[1];
+  }
+  v0_avg/=n; rv1_avg/=n;
+  double rSv0v1 = 0.0, rSv1v1 = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0*img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1*img_pts1[i];
+    double v0 = p0rot[1]-v0_avg, v1 = p1rot[1]-rv1_avg;
+    rSv0v1 += v0*v1; rSv1v1 += v1*v1;
+  }
+  if(fabs(rSv1v1)< 100.0*vgl_tolerance<double>::position){
+    std::cout << "row scaling problem is singular" << std::endl;
+    return false;
+  }
+  double sr = rSv0v1/rSv1v1;
+  double tv = v0_avg - sr*rv1_avg;
+  std::cout << "affine row trans: " << sr << ' ' << tv << std::endl;
+
+  // Assign the transformation equally between the left and right images
+  bool neg_scale = sr<0.0;// determine if scale factor is negative
+  double sv = fabs(sr), sqts = sqrt(sv), tfact = 1.0/(1.0 + sqts);
+  if(sv < min_scale){
+      std::cout << "in vpgl_equi_rectification::compute_rectification(), row scale " << sv << " too small "<< std::endl;
+      return false;
+  }
+  vnl_matrix_fixed<double, 3,3> Vsqt, Vsqt_inv;
+  Vsqt.set_identity();
+  Vsqt[1][1] = sqts;
+  if(neg_scale)
+    Vsqt[1][1] = -sqts;
+  Vsqt[1][2] = tfact*tv;
+  H1 = Vsqt*H1;
+
+  Vsqt_inv.set_identity();
+  Vsqt_inv[1][1] = 1.0/sqts;
+  Vsqt_inv[1][2] = -tfact*tv/sqts;
+  H0 = Vsqt_inv*H0;
+
+  double u0_avg = 0.0,  u1_avg = 0.0, v1_avg = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0 * img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1 * img_pts1[i];
+    u0_avg += p0rot[0]; u1_avg += p1rot[0]; v1_avg += p1rot[1];
+  }
+  u0_avg /= n; u1_avg /= n; v1_avg /= n;
+
+  double Su0u1 = 0.0, Su1u1 = 0.0;
+  double Su0v1 = 0.0, Su1v1 = 0.0, Sv1v1 = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0 * img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1 * img_pts1[i];
+    double u0 = p0rot[0]-u0_avg, u1 = p1rot[0]-u1_avg, v1 = p1rot[1]-v1_avg;
+    Su0u1 += u0*u1; Su1u1 += u1*u1;
+    Su0v1 += u0*v1; Su1v1 += u1*v1; Sv1v1 += v1*v1;
+  }
+  Su0u1/=n; Su1u1/=n;
+  Su0v1/=n; Su1v1/=n; Sv1v1/=n;
+  vnl_matrix_fixed<double, 2, 2> AA, AAinv;
+  vnl_vector_fixed<double, 2> bb, x;
+  AA[0][0]=Su1u1; AA[0][1]=AA[1][0]=Su1v1;
+  AA[1][1] = Sv1v1; AA[2][2] = 1.0;
+  bb[0] = Su0u1;
+  bb[1] = Su0v1;
+  double d = fabs(vnl_det(AA));
+  if(d < 100.0*vgl_tolerance<double>::position){
+    std::cout << "Singular solution for u affine transform" << std::endl;
+    return false;
+  }
+  AAinv = vnl_inverse(AA);
+  x = AAinv*bb;
+  neg_scale = x[0]<0.0;// determine if column scale factor is negative
+  double su = fabs(x[0]), sigma_u = x[1], sqtsu = sqrt(su), ufact = 1.0 / (1.0 + sqtsu);
+  // un-normalize to get the translation term
+  double tu = u0_avg - x[0]*u1_avg -sigma_u*v1_avg;
+  std::cout << "affine column trans: " << x[0] << ' ' << sigma_u << ' ' << tu << std::endl;
+  if(su < min_scale){
+    std::cout << "in vpgl_equi_rectification::compute_rectification(), row scale " << x[0] << " too small "<< std::endl;
+    return false;
+  }
+  //compute sqrt of transform
+  vnl_matrix_fixed<double, 3, 3> Usqt, Usqt_inv;
+  Usqt.set_identity();
+  Usqt[0][0] = sqtsu;
+  if (neg_scale)
+    Usqt[0][0] = -sqtsu;
+  Usqt[0][1] = ufact * sigma_u;
+  Usqt[0][2] = ufact * tu;
+  H1 =Usqt * H1;
+
+  Usqt_inv.set_identity();
+  Usqt_inv[0][0] = 1.0 / sqtsu;
+  Usqt_inv[0][1] = -ufact * sigma_u / sqtsu;
+  Usqt_inv[0][2] = -ufact * tu/sqtsu;
+  H0 = Usqt_inv * H0;
+  return true;
+}
+
+bool vpgl_equi_rectification::rectify_pair(const vpgl_fundamental_matrix<double>& F,
+                                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts0,
+                                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts1,
+                                           vnl_matrix_fixed<double, 3, 3>& H0, vnl_matrix_fixed<double, 3, 3>& H1,
+                                           double min_scale){
+  size_t n = img_pts0.size();
+  if(n == 0||img_pts1.size()!= n){
+    std::cout << "null image pointset or pointsets of unequal size" << std::endl;
+    return false;
+  }
+  double tol = 100.0*vgl_tolerance<double>::position;
+  vgl_homg_point_2d<double> he0, he1;
+  F.get_epipoles(he0, he1);
+  vnl_vector_fixed<double, 3> e0(he0.x(), he0.y(), he0.w());
+  vnl_vector_fixed<double, 3> e1(he1.x(), he1.y(), he1.w());
+  double e0m = e0.magnitude(), e1m = e1.magnitude();
+  if(e0m<tol || e1m < tol){
+    std::cout << "in vpgl_equi_rectification::compute_rectification(projective), null epipoles" << std::endl;
+    return false;
+  }
+  e0/=e0m; e1/=e1m;
+  // transform the right epipole (right side of F)
+  vnl_matrix_fixed<double, 3, 3> T0, R0, G0;
+  T0.set_identity(); R0.set_identity(); G0.set_identity();
+  if(fabs(e0[2]) < tol){//epipole already an ideal point
+    R0[0][0] =  R0[1][1] = e0[0];
+    R0[0][1] = e0[1]; R0[1][0] = -e0[1];
+  }else{
+    // follow the prescription in H&Z
+    // translate the first image point to the origin
+    e0 /= e0[2];
+    vnl_vector_fixed<double, 3> p00 = img_pts0[0], e0tr;
+    T0[0][2] = -p00[0]/p00[2];  T0[1][2] = -p00[1]/p00[2];
+    double theta = atan2(e0[1], e0[0]);
+    double c = cos(-theta), s = sin(-theta);
+    R0[0][0] = c;     R0[0][1] = -s;
+    R0[1][0] = s;     R0[1][1] = c;
+    e0tr = R0*e0;
+    double f = e0tr[0]/e0tr[2];
+    G0[2][0]= -1.0/f;
+  }
+  H0 = G0*R0*T0;
+  // transform the left epipole (left side of F)
+  vnl_matrix_fixed<double, 3, 3> T1, R1, G1;
+  T1.set_identity(); R1.set_identity(); G1.set_identity();
+  if(fabs(e1[2]) < tol){//epipole already an ideal point
+    R1[0][0] =  R1[1][1] = e1[0];
+    R1[0][1] = e1[1]; R1[1][0] = -e1[1];
+  }else{
+    // follow the prescription in H&Z
+    // translate the first image point to the origin
+    vnl_vector_fixed<double, 3> p10 = img_pts1[0], e1tr;
+    T0[0][2] = -p10[0]/p10[2];  T0[1][2] = -p10[1]/p10[2];
+    double theta = atan2(e1[1], e1[0]);
+    double c = cos(-theta), s = sin(-theta);
+    R1[0][0] = c;     R1[0][1] = -s;
+    R1[1][0] = s;     R1[1][1] = c;
+    e1tr = R1*e1;
+    double f = e1tr[0]/e1tr[2];
+    G1[2][0]= -1.0/f;
+  }
+  H1 = G1*R1*T1;
+  // the following is the same as for the affine case
+  // find a scaling and offset for the row coordinates
+  double v0_avg = 0, rv1_avg = 0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0*img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1*img_pts1[i];
+    v0_avg += p0rot[1]; rv1_avg += p1rot[1];
+  }
+  v0_avg/=n; rv1_avg/=n;
+  double rSv0v1 = 0.0, rSv1v1 = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0*img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1*img_pts1[i];
+    double v0 = p0rot[1]-v0_avg, v1 = p1rot[1]-rv1_avg;
+    rSv0v1 += v0*v1; rSv1v1 += v1*v1;
+  }
+  if(fabs(rSv1v1)< 100.0*vgl_tolerance<double>::position){
+    std::cout << "row scaling problem is singular" << std::endl;
+    return false;
+  }
+  double sr = rSv0v1/rSv1v1;
+  double tv = v0_avg - sr*rv1_avg;
+  std::cout << "affine row trans: " << sr << ' ' << tv << std::endl;
+  // Assign the transformation equally between the left and right images
+  bool neg_scale = sr<0.0;// determine if scale factor is negative
+  double sv = fabs(sr), sqts = sqrt(sv), tfact = 1.0/(1.0 + sqts);
+  if(sv < min_scale){
+      std::cout << "in vpgl_equi_rectification::compute_rectification(), row scale " << sv << " too small "<< std::endl;
+      return false;
+  }
+  vnl_matrix_fixed<double, 3,3> Vsqt, Vsqt_inv;
+  Vsqt.set_identity();
+  Vsqt[1][1] = sqts;
+  if(neg_scale)
+    Vsqt[1][1] = -sqts;
+  Vsqt[1][2] = tfact*tv;
+  H1 = Vsqt*H1;
+
+  Vsqt_inv.set_identity();
+  Vsqt_inv[1][1] = 1.0/sqts;
+  Vsqt_inv[1][2] = -tfact*tv/sqts;
+  H0 = Vsqt_inv*H0;
+
+  double u0_avg = 0.0,  u1_avg = 0.0, v1_avg = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0 * img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1 * img_pts1[i];
+    u0_avg += p0rot[0]; u1_avg += p1rot[0]; v1_avg += p1rot[1];
+  }
+  u0_avg /= n; u1_avg /= n; v1_avg /= n;
+
+  double Su0u1 = 0.0, Su1u1 = 0.0;
+  double Su0v1 = 0.0, Su1v1 = 0.0, Sv1v1 = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    vnl_vector_fixed<double, 3> p0rot = H0 * img_pts0[i];
+    vnl_vector_fixed<double, 3> p1rot = H1 * img_pts1[i];
+    double u0 = p0rot[0]-u0_avg, u1 = p1rot[0]-u1_avg, v1 = p1rot[1]-v1_avg;
+    Su0u1 += u0*u1; Su1u1 += u1*u1;
+    Su0v1 += u0*v1; Su1v1 += u1*v1; Sv1v1 += v1*v1;
+  }
+  Su0u1/=n; Su1u1/=n;
+  Su0v1/=n; Su1v1/=n; Sv1v1/=n;
+  vnl_matrix_fixed<double, 2, 2> AA, AAinv;
+  vnl_vector_fixed<double, 2> bb, x;
+  AA[0][0]=Su1u1; AA[0][1]=AA[1][0]=Su1v1;
+  AA[1][1] = Sv1v1; AA[2][2] = 1.0;
+  bb[0] = Su0u1;
+  bb[1] = Su0v1;
+  double d = fabs(vnl_det(AA));
+  if(d < 100.0*vgl_tolerance<double>::position){
+    std::cout << "Singular solution for u affine transform" << std::endl;
+    return false;
+  }
+  AAinv = vnl_inverse(AA);
+  x = AAinv*bb;
+  neg_scale = x[0]<0.0;// determine if column scale factor is negative
+  double su = fabs(x[0]), sigma_u = x[1], sqtsu = sqrt(su), ufact = 1.0 / (1.0 + sqtsu);
+  // un-normalize to get the translation term
+  double tu = u0_avg - x[0]*u1_avg -sigma_u*v1_avg;
+  std::cout << "affine column trans: " << x[0] << ' ' << sigma_u << ' ' << tu << std::endl;
+  if(su < min_scale){
+    std::cout << "in vpgl_equi_rectification::compute_rectification(), row scale " << x[0] << " too small "<< std::endl;
+    return false;
+  }
+  //compute sqrt of transform
+  vnl_matrix_fixed<double, 3, 3> Usqt, Usqt_inv;
+  Usqt.set_identity();
+  Usqt[0][0] = sqtsu;
+  if (neg_scale)
+    Usqt[0][0] = -sqtsu;
+  Usqt[0][1] = ufact * sigma_u;
+  Usqt[0][2] = ufact * tu;
+  H1 =Usqt * H1;
+
+  Usqt_inv.set_identity();
+  Usqt_inv[0][0] = 1.0 / sqtsu;
+  Usqt_inv[0][1] = -ufact * sigma_u / sqtsu;
+  Usqt_inv[0][2] = -ufact * tu/sqtsu;
+  H0 = Usqt_inv * H0;
+  return true;
+}

--- a/core/vpgl/algo/vpgl_equi_rectification.h
+++ b/core/vpgl/algo/vpgl_equi_rectification.h
@@ -1,0 +1,73 @@
+// This is core/vpgl/algo/vpgl_equi_rectification.h
+#ifndef vpgl_equi_rectification_h_
+#define vpgl_equi_rectification_h_
+//:
+// \file
+// \brief Rectify a pair of images by applying equal and opposite warp transforms to each image
+// \author J.L. Mundy
+// \date February 10, 2019
+//
+// \verbatim
+//  Modifications
+//   <none>
+// \endverbatim
+//
+// Equi-affine rectification applies the required warp equally to each image, rather than applying
+// the required row and column scaling solely to image1.  As a first step, rotations are applied
+// to each image, R0 and R1 so that the epipolar lines of aF are horizontal, i.e.,parallel to image rows.
+// The image row coordinates are then scaled so that rows are in correspondence. The transform is as follows.
+//       _           _
+//      |  1   0   0  |
+//  V = |  0   sv  tv |
+//      |  0   0   1  |
+//       -           -
+// The values of sv and tv are found by minimizing the square distance between the transformed image1 points
+// and the corrsponding points in image0. That is ||V*R1[X1]- R0[X0]||^2 is minimized.
+// To determine the equal and opposite transformations it is necessary to define the square root of the
+// transformation matrix.
+//
+//                                    _                      _
+//                                   |  1    0         0      |
+//                                   |                tv      |
+//   V = V^1/2 * V^1/2, where V^1/2 =|  0  sv^1/2  ---------- |
+//                                   |            (1 + sv^1/2)|
+//                                   |  0   0          1      |
+//                                    -                      -
+// The transformation is then equalized for each image, i.e. V^1/2 * R1  and (V^1/2)^-1 * R0.
+// A similar proceedure is applied to scale the column coordinates, so that overall disparity
+// is minimized.
+
+#include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_affine_fundamental_matrix.h>
+#include <vpgl/vpgl_fundamental_matrix.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vnl/vnl_matrix_fixed.h>
+
+class vpgl_equi_rectification
+{
+ public:
+  //: given the affine fundamental matrix and a set of correspondences between
+  // the two images, image0 and image1, pts0, pts1, determine the corresponding
+  // affine homographies, H0 and H1, that warp each image into a rectified pair.
+  // A rectified pair has rows in correspondence,i.e., a point in one image has
+  // its corresponding point on the same row in the other image. Equivalently,
+  // an epipolar line in image 1 is the same row as for a given point in image 0.
+  // min_scale limits the amount of warping to avoid aliasing
+  static bool rectify_pair(const vpgl_affine_fundamental_matrix<double>& aF,
+                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts0,
+                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts1,
+                           vnl_matrix_fixed<double, 3, 3>& H0, vnl_matrix_fixed<double, 3, 3>& H1,
+                           double min_scale = 0.1);
+
+  //: the rectification of images with projective cameras
+  static bool rectify_pair(const vpgl_fundamental_matrix<double>& F,
+                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts0,
+                           const std::vector<vnl_vector_fixed<double, 3> >& img_pts1,
+                           vnl_matrix_fixed<double, 3, 3>& H0, vnl_matrix_fixed<double, 3, 3>& H1,
+                           double min_scale = 0.1);
+ private:
+  //: no public constructor - static methods only
+  vpgl_equi_rectification() = delete;
+};
+
+#endif // vpgl_equi_rectification_h_


### PR DESCRIPTION
`vpgl_equi_rectification` - Rectify a pair of images by applying equal and opposite warp transforms to each image, thus reducing scale distortion during rectification.  Includes bugfix for `vpgl_affine_rectification` (vector should be of length 3).

`vpgl_affine_camera_compute` compute viewing distance, additional test

