### PR TITLE
Contrib BRL - align, rectify, surfaces

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/algo/CMakeLists.txt
@@ -17,6 +17,7 @@ set( bpgl_algo_sources
   bpgl_gridding.h
   bpgl_3d_from_disparity.h  bpgl_3d_from_disparity.hxx
   bpgl_heightmap_from_disparity.h  bpgl_heightmap_from_disparity.hxx
+  bpgl_rectify_affine_image_pair.h   bpgl_rectify_affine_image_pair.cxx
 )
 
 # the ransac implementations use rpl/rrel

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
@@ -1,0 +1,279 @@
+#include <fstream>
+
+#include <vgl/vgl_box_3d.h>
+#include <vil/vil_load.h>
+#include <vil/vil_convert.h>
+#include <vil/vil_bilin_interp.h>
+#include <vil/vil_bicub_interp.h>
+#include <vnl/vnl_random.h>
+#include <vnl/vnl_det.h>
+#include <vnl/vnl_inverse.h>
+
+#include <vpgl/algo/vpgl_camera_convert.h>
+#include <vpgl/algo/vpgl_equi_rectification.h>
+
+#include "bpgl_rectify_affine_image_pair.h"
+
+
+bool bpgl_rectify_affine_image_pair::
+set_images_and_cams(vil_image_view_base_sptr const& view0, vpgl_affine_camera<double> const& acam0,
+                    vil_image_view_base_sptr const& view1, vpgl_affine_camera<double> const& acam1)
+{
+  // convert images to float
+  vil_image_view_base_sptr fview0 = vil_convert_cast(float(), view0);
+  if(!fview0){
+    std::cerr << "can't convert view 0 to float" << std::endl;
+    return false;
+  }
+
+  vil_image_view_base_sptr fview1 = vil_convert_cast(float(), view1);
+  if(!fview1){
+    std::cerr << "can't convert view 1 to float" << std::endl;
+    return false;
+  }
+
+  // save to instance
+  fview0_ = *fview0;
+  acam0_  = acam0;
+  fview1_ = *fview1;
+  acam1_  = acam1;
+  aF_ = vpgl_affine_fundamental_matrix<double> (acam0_, acam1_);
+  return true;
+}
+
+
+bool bpgl_rectify_affine_image_pair::
+set_images_and_cams(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+                    vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1)
+{
+  // get image views
+  auto view0 = resc0->get_view();
+  if(!view0){
+    std::cerr << "null view from resource 0" << std::endl;
+    return false;
+  }
+
+  auto view1 = resc1->get_view();
+  if(!view1){
+    std::cerr << "null view from resource 1" << std::endl;
+    return false;
+  }
+
+  // save to instance
+  return this->set_images_and_cams(view0, acam0, view1, acam1);
+}
+
+
+bool bpgl_rectify_affine_image_pair::
+load_affine_camera(std::string const& cam_path, vpgl_affine_camera<double>& acam)
+{
+  std::ifstream istr(cam_path);
+  if(!istr){
+    std::cout << "Can't open camera path " << cam_path << std::endl;
+    return false;
+  }
+  vnl_matrix_fixed<double, 3, 4> M;
+  istr >> M;
+  bool aff = M[2][0] == 0.0 && M[2][1] == 0.0 && M[2][2] == 0.0;
+  if(aff && fabs(M[2][3]) > 0.0){
+    acam.set_matrix(M);
+    return true;
+  }
+  std::cout << "camera not affine" << M << std::endl;
+  return false;
+}
+
+
+bool bpgl_rectify_affine_image_pair::
+load_images_and_cams(std::string const& image0_path, std::string const& acam0_path,
+                     std::string const& image1_path, std::string const& acam1_path)
+{
+  // read cameras
+  vpgl_affine_camera<double> acam0, acam1;
+  if(!load_affine_camera(acam0_path, acam0))
+    return false;
+  if(!load_affine_camera(acam1_path, acam1))
+    return false;
+
+  // read images
+  auto resc0 = vil_load_image_resource(image0_path.c_str());
+  if(!resc0)
+    return false;
+  auto resc1 = vil_load_image_resource(image1_path.c_str());
+  if(!resc1)
+    return false;
+
+  // save to instance
+  return this->set_images_and_cams(resc0, acam0, resc1, acam1);
+}
+
+
+void bpgl_rectify_affine_image_pair::
+compute_warp_dimensions_offsets()
+{
+  double dni0 = fview0_.ni()-1, dnj0 = fview0_.nj()-1;
+  double dni1 = fview1_.ni()-1, dnj1 = fview1_.nj()-1;
+  std::vector<vnl_vector_fixed<double, 3> > corners_0(4), corners_1(4);
+  std::vector<vnl_vector_fixed<double, 3> > Hcorners_0(4), Hcorners_1(4);
+  corners_0[0] = vnl_vector_fixed<double, 3>(0,0,1);
+  corners_0[1] = vnl_vector_fixed<double, 3>(dni0,0,1);
+  corners_0[2] = vnl_vector_fixed<double, 3>(dni0,dnj0,1);
+  corners_0[3] = vnl_vector_fixed<double, 3>(0,dnj0,1);
+
+  corners_1[0] = vnl_vector_fixed<double, 3>(0,0,1);
+  corners_1[1] = vnl_vector_fixed<double, 3>(dni1,0,1);
+  corners_1[2] = vnl_vector_fixed<double, 3>(dni1,dnj1,1);
+  corners_1[3] = vnl_vector_fixed<double, 3>(0,dnj1,1);
+  for(size_t c = 0; c<4; ++c){
+    Hcorners_0[c] =  H0_*corners_0[c];
+    Hcorners_0[c] /= Hcorners_0[c][2];
+    Hcorners_1[c] =  H1_*corners_1[c];
+    Hcorners_1[c] /= Hcorners_1[c][2];
+  }
+  double mini0 = std::numeric_limits<double>::max(), maxi0 = -mini0;
+  double minj0 = std::numeric_limits<double>::max(), maxj0 = -minj0;
+  double mini1 = std::numeric_limits<double>::max(), maxi1 = -mini1;
+  double minj1 = std::numeric_limits<double>::max(), maxj1 = -minj1;
+  for(size_t c = 0; c<4; ++c){
+    if(Hcorners_0[c][0] < mini0)
+      mini0 = Hcorners_0[c][0];
+    if(Hcorners_1[c][0] < mini1)
+      mini1 = Hcorners_1[c][0];
+    if(Hcorners_0[c][0] > maxi0)
+      maxi0 = Hcorners_0[c][0];
+    if(Hcorners_1[c][0] > maxi1)
+      maxi1 = Hcorners_1[c][0];
+    if(Hcorners_0[c][1] < minj0)
+      minj0 = Hcorners_0[c][1];
+    if(Hcorners_1[c][1] < minj1)
+      minj1 = Hcorners_1[c][1];
+    if(Hcorners_0[c][1] > maxj0)
+      maxj0 = Hcorners_0[c][1];
+    if(Hcorners_1[c][1] > maxj1)
+      maxj1 = Hcorners_1[c][1];
+  }
+  double w0 = (maxi0-mini0), h0 = (maxj0-minj0);
+  double w1 = (maxi1-mini1), h1 = (maxj1-minj1);
+  double w = w0, h = h0;
+  du_off_ = mini0; dv_off_ = minj0;
+  if(w1<w){
+    w = w1;
+    du_off_ = mini1;
+  }
+  if(h1<h){
+    h = h1;
+    dv_off_ = minj1;
+  }
+  out_ni_ = static_cast<size_t>(w+0.5) +1;
+  out_nj_ = static_cast<size_t>(h+0.5) +1;
+}
+
+
+bool bpgl_rectify_affine_image_pair::
+compute_rectification(vgl_box_3d<double>const& scene_box, size_t n_points)
+{
+  double min_x = scene_box.min_x();
+  double min_y = scene_box.min_y();
+  double width = scene_box.width(), height = scene_box.height();
+  double ni0 = fview0_.ni(), nj0 = fview0_.nj();
+  double ni1=  fview1_.ni(), nj1 = fview1_.nj();
+  vnl_random rng;
+  double z0 = 0.5*(scene_box.min_z() + scene_box.max_z());
+  std::vector< vnl_vector_fixed<double, 3> > img_pts0, img_pts1;
+  for (unsigned i = 0; i < n_points; i++) {
+    double x = rng.drand64()*width + min_x;  // sample in local coords
+    double y = rng.drand64()*height + min_y;
+    double u, v;
+    acam0_.project(x,y,z0,u,v);
+  if(u>=0 || u<ni0||v>=0||v<nj0)
+     img_pts0.emplace_back(u,v,1);
+  acam1_.project(x, y, z0, u, v);
+  if (u >= 0 || u<ni1 || v >= 0 || v<nj1)
+     img_pts1.emplace_back(u,v,1);
+  }
+  // santity check
+  bool epi_constraint = true;
+  for (size_t k = 0; k < img_pts0.size(); ++k) {
+    vnl_vector_fixed<double, 3> pr = img_pts0[0], line_l, pl = img_pts1[0];
+    line_l = aF_.get_matrix() * pr;
+    double dp = dot_product(line_l, pl);
+    epi_constraint = epi_constraint && fabs(dp) < 1.0e-6;
+  }
+  if (!epi_constraint) {
+    std::cout << "epipolar constraint doesn't hold for F matrix and sampled points" << std::endl;
+    return false;
+  }
+
+  if(!vpgl_equi_rectification::rectify_pair(aF_, img_pts0, img_pts1, H0_, H1_)){
+    std::cout << "vpgl equi rectification failed" << std::endl;
+    return false;
+  }
+  double singular_tol = 1.0e-6;
+  if((fabs(vnl_det(H0_))<singular_tol)||
+     (fabs(vnl_det(H1_))<singular_tol)){
+    std::cout << "vpgl rectification produced singular homography(s)" << std::endl;
+    return false;
+  }
+  // second sanity check
+  bool equal_y = true;
+  for (size_t k = 0; k < img_pts0.size()&&equal_y; ++k) {
+    vnl_vector_fixed<double, 3> p0 = img_pts0[k], hp0, p1 = img_pts1[k], hp1;
+    hp0 = H0_*p0;  hp1 = H1_*p1;
+    double y0 = hp0[1]/hp0[2], y1 = hp1[1]/hp1[2];
+    double dy = fabs(y1-y0);
+    if(dy>0.001)
+      equal_y = false;
+  }
+  if(!equal_y){
+    std::cout << "homographies do not map to equal row positions" << std::endl;
+    return false;
+  }
+  this->compute_warp_dimensions_offsets();
+
+  vnl_matrix_fixed<double, 3, 3> tr;
+  tr.set_identity();
+  tr[0][2] = -du_off_; tr[1][2] = -dv_off_;
+  H0_ = tr*H0_;
+  H1_ = tr*H1_;
+  vnl_matrix_fixed<double, 3, 4> M0 = acam0_.get_matrix(), M1 = acam1_.get_matrix();
+  M0 = H0_*M0;  M1 = H1_*M1;
+  rect_acam0_.set_matrix(M0);
+  rect_acam1_.set_matrix(M1);
+  return true;
+}
+
+
+void bpgl_rectify_affine_image_pair::
+warp_image(vil_image_view<float> fview,
+           vnl_matrix_fixed<double, 3, 3> const& H,
+           vil_image_view<float>& fwarp,
+           size_t out_ni, size_t out_nj)
+{
+  size_t ni = fview.ni(), nj = fview.nj();
+  double dni = static_cast<double>(ni);
+  double dnj = static_cast<double>(nj);
+  fwarp.set_size(out_ni, out_nj);
+  fwarp.fill(0.0f);
+  vnl_matrix_fixed<double, 3, 3> Hinv = vnl_inverse(H);
+  for(size_t j =0; j<out_nj; ++j)
+    for(size_t i =0; i<out_ni; ++i){
+      double du = static_cast<double>(i);
+      double dv = static_cast<double>(j);
+      vnl_vector_fixed<double, 3> pix(du, dv, 1), hpix;
+      hpix = Hinv*pix;
+      double du_h = hpix[0]/hpix[2], dv_h = hpix[1]/hpix[2];
+      if(du_h <0.0 || du_h >= dni || dv_h<0.0 ||dv_h >= dnj)
+        continue;
+      //float fval = vil_bilin_interp_safe_extend(fview, du_h, dv_h);
+      float fval = vil_bicub_interp_safe_extend(fview, du_h, dv_h);
+      fwarp(i, j) = fval;
+    }
+}
+
+
+void bpgl_rectify_affine_image_pair::
+warp_pair()
+{
+  this->warp_image(fview0_, H0_, rect_fview0_, out_ni_, out_nj_);
+  this->warp_image(fview1_, H1_, rect_fview1_, out_ni_, out_nj_);
+}

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
@@ -1,0 +1,106 @@
+// This is brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
+#ifndef bpgl_rectify_affine_image_pair_h_
+#define bpgl_rectify_affine_image_pair_h_
+//:
+// \file/
+// \brief rectify two images into a stero pair given affine cameras for each
+// \author J. L. Mundy
+// \date February 6, 2019
+#include <iostream>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_affine_fundamental_matrix.h>
+#include <vil/vil_image_resource.h>
+#include <vil/vil_image_view.h>
+#include <vnl/vnl_matrix_fixed.h>
+
+//
+// requires two images and associated affine cameras. Class can load the data from files if needed.
+// the output is a pair of images that have common epiplolar lines along image rows. The difference in
+// column coordinates of corresponding points is minimized.
+//
+class bpgl_rectify_affine_image_pair
+{
+ public:
+  bpgl_rectify_affine_image_pair(){}
+
+  bpgl_rectify_affine_image_pair(vil_image_view_base_sptr const& view0, vpgl_affine_camera<double> const& acam0,
+                                 vil_image_view_base_sptr const& view1, vpgl_affine_camera<double> const& acam1)
+  {
+    bool good = this->set_images_and_cams(view0,acam0,view1,acam1);
+  }
+
+  bpgl_rectify_affine_image_pair(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+                                 vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1)
+  {
+    bool good = this->set_images_and_cams(resc0,acam0,resc1,acam1);
+  }
+
+  //: set images & cameras
+  bool set_images_and_cams(vil_image_view_base_sptr const& view0, vpgl_affine_camera<double> const& acam0,
+                           vil_image_view_base_sptr const& view1, vpgl_affine_camera<double> const& acam1);
+
+  bool set_images_and_cams(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+                           vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1);
+
+  //: accessors
+  const vpgl_affine_camera<double>& acam0()const{return acam0_;}
+  const vpgl_affine_camera<double>& acam1()const{return acam1_;}
+  const vpgl_affine_camera<double>& rect_acam0()const{return rect_acam0_;}
+  const vpgl_affine_camera<double>& rect_acam1()const{return rect_acam1_;}
+  const vil_image_view<float>& input_float_view0()const{return fview0_;}
+  const vil_image_view<float>& input_float_view1()const{return fview1_;}
+  const vil_image_view<float>& rectified_fview0() const{return rect_fview0_;}
+  const vil_image_view<float>& rectified_fview1() const{return rect_fview1_;}
+  vnl_matrix_fixed<double, 3, 3> H0() const {return H0_;}
+  vnl_matrix_fixed<double, 3, 3> H1() const {return H1_;}
+
+  //: utility methods
+  static bool load_affine_camera(std::string const& cam_path, vpgl_affine_camera<double>& acam);
+
+  bool process(vgl_box_3d<double>const& scene_box, size_t n_points = 1000)
+  {
+    if(!compute_rectification(scene_box,n_points))
+      return false;
+    warp_pair();
+    return true;
+  }
+
+  // for debug purposes
+  bool load_images_and_cams(std::string const& image0_path, std::string const& cam0_path,
+                            std::string const& image1_path, std::string const& cam1_path);
+
+ protected:
+
+  // protected utility methods
+  bool compute_rectification(vgl_box_3d<double> const& scene_box, size_t n_points = 1000);
+  void compute_warp_dimensions_offsets();
+  static void warp_image(vil_image_view<float> fview,
+                         vnl_matrix_fixed<double, 3, 3> const& H,
+                         vil_image_view<float>& fwarp,
+                         size_t out_ni, size_t out_nj);
+  void warp_pair();
+
+ private:
+  vil_image_view<float> fview0_;
+  vil_image_view<float> fview1_;
+  vil_image_view<float> rect_fview0_;
+  vil_image_view<float> rect_fview1_;
+
+  vpgl_affine_camera<double> acam0_;
+  vpgl_affine_camera<double> acam1_;
+  vpgl_affine_camera<double> rect_acam0_;
+  vpgl_affine_camera<double> rect_acam1_;
+
+  vpgl_affine_fundamental_matrix<double> aF_;
+  // H0, H1 include a translation to keep
+  // image coordinates positive definite
+  vnl_matrix_fixed<double, 3, 3> H0_;
+  vnl_matrix_fixed<double, 3, 3> H1_;
+
+  double du_off_;
+  double dv_off_;
+  size_t out_ni_;
+  size_t out_nj_;
+};
+
+#endif // bpgl_rectify_affine_image_pair_h_

--- a/contrib/brl/bbas/bpgl/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/algo/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable( bpgl_algo_test_all
   test_gridding.cxx
   test_3d_from_disparity.cxx
   test_heightmap_from_disparity.cxx
+  test_rectify_affine_image_pair.cxx
 )
 
 target_link_libraries( bpgl_algo_test_all bpgl_algo ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}testlib )
@@ -33,8 +34,9 @@ add_test( NAME bpgl_algo_test_project COMMAND $<TARGET_FILE:bpgl_algo_test_all> 
 add_test( NAME bpgl_algo_test_gridding COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_gridding )
 add_test( NAME bpgl_algo_test_3d_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_3d_from_disparity )
 add_test( NAME bpgl_algo_test_heightmap_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_heightmap_from_disparity )
+add_test( NAME bpgl_algo_test_rectify_affine_image_pair COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_rectify_affine_image_pair )
 
 add_executable( bpgl_algo_test_include test_include.cxx )
-target_link_libraries( bpgl_algo_test_include bpgl_algo )
+target_link_libraries( bpgl_algo_test_include bpgl_algo vpl)
 add_executable( bpgl_algo_test_template_include test_template_include.cxx )
 target_link_libraries( bpgl_algo_test_template_include bpgl_algo )

--- a/contrib/brl/bbas/bpgl/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/algo/tests/CMakeLists.txt
@@ -30,9 +30,9 @@ add_test( NAME bpgl_algo_test_interpolate COMMAND $<TARGET_FILE:bpgl_algo_test_a
 add_test( NAME bpgl_algo_test_camera_homographies COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_camera_homographies )
 add_test( NAME bpgl_algo_test_camera_from_box COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_camera_from_box )
 add_test( NAME bpgl_algo_test_project COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_project )
-add_test( NAME bpgl_algo_test_gridding COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_project )
-add_test( NAME bpgl_algo_test_3d_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_project )
-add_test( NAME bpgl_algo_test_heightmap_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_project )
+add_test( NAME bpgl_algo_test_gridding COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_gridding )
+add_test( NAME bpgl_algo_test_3d_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_3d_from_disparity )
+add_test( NAME bpgl_algo_test_heightmap_from_disparity COMMAND $<TARGET_FILE:bpgl_algo_test_all> test_heightmap_from_disparity )
 
 add_executable( bpgl_algo_test_include test_include.cxx )
 target_link_libraries( bpgl_algo_test_include bpgl_algo )

--- a/contrib/brl/bbas/bpgl/algo/tests/test_driver.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_driver.cxx
@@ -11,6 +11,7 @@ DECLARE( test_project );
 DECLARE( test_gridding );
 DECLARE( test_3d_from_disparity );
 DECLARE( test_heightmap_from_disparity );
+DECLARE( test_rectify_affine_image_pair );
 
 void register_tests()
 {
@@ -24,6 +25,7 @@ void register_tests()
   REGISTER( test_gridding );
   REGISTER( test_3d_from_disparity );
   REGISTER( test_heightmap_from_disparity );
+  REGISTER( test_rectify_affine_image_pair );
 }
 
 DEFINE_MAIN;

--- a/contrib/brl/bbas/bpgl/algo/tests/test_rectify_affine_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_rectify_affine_image_pair.cxx
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <fstream>
+#include <testlib/testlib_test.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+#include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/vpgl_local_rational_camera.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vpgl/vpgl_lvcs.h>
+#include <bpgl/algo/bpgl_project.h>
+#include <bpgl/algo/bpgl_rectify_affine_image_pair.h>
+#include <vnl/vnl_vector_fixed.h>
+#include <vpl/vpl.h>
+#include <vil/vil_save.h>
+#include <vil/vil_new.h>
+
+static void test_rectify_affine_image_pair() {
+
+  vnl_vector_fixed<double, 4> row1, row2;
+  row1[0] = 1.34832; row1[1] = 0.00382; row1[2] = 0.2765; row1[3] = 8.859995;
+  row2[0] = 0.2181; row2[1] = -0.92631; row2[2] = -1.00105; row2[3] = 538.9338;
+  vpgl_affine_camera<double> acam(row1, row2);
+  std::string acam_path = "./acam.txt";
+  std::ofstream ostr(acam_path.c_str());
+  if (ostr) {
+    ostr << acam;
+    ostr.close();
+  }
+  else {
+    TEST("load affine camera", false, true);
+    return;
+  }
+  vpgl_affine_camera<double> loaded_acam;
+  bool good = bpgl_rectify_affine_image_pair::load_affine_camera(acam_path, loaded_acam);
+  good = good && (loaded_acam.get_matrix())[0][0] == 1.34832;
+  TEST("load affine camera", good, true);
+  vpl_unlink(acam_path.c_str());
+
+  row1[0] = 3.24576; row1[1] = -0.000118349; row1[2] = -0.00137547; row1[3] = 317.948;
+  row2[0] = -0.000249604; row2[1] = -3.24236; row2[2] = -0.0741213; row2[3] = 877.16;
+  vpgl_affine_camera<double> acam0(row1, row2);
+
+  row1[0] = 1.89339; row1[1] = -0.00154537; row1[2] = 0.68649;  row1[3] = 257.216;
+  row2[0] = 0.111276; row2[1] = -1.99657; row2[2] = -0.309028; row2[3] = 650.835;
+  vpgl_affine_camera<double> acam1(row1, row2);
+
+  size_t ni0 = 1095, nj0 = 1209;
+  size_t ni1 = 963, nj1 = 906;
+  vil_image_view<vxl_byte> img0(ni0, nj0);
+  vil_image_view<vxl_byte> img1(ni1, nj1);
+  img0.fill(vxl_byte(127));
+  img1.fill(vxl_byte(127));
+
+  vil_image_resource_sptr res0 = vil_new_image_resource_of_view(img0);
+  vil_image_resource_sptr res1 = vil_new_image_resource_of_view(img1);
+
+  vgl_point_3d<double> pmin(0, 0, 60.0), pmax(135.0, 160.0, 95.0);
+  vgl_box_3d<double> scene_box;
+  scene_box.add(pmin);   scene_box.add(pmax);
+
+  bpgl_rectify_affine_image_pair rip;
+  bool success = rip.set_images_and_cams(res0, acam0, res1, acam1);
+  if (!success) {
+    std::cout << "bpgl_rectify_affine_image_pair could not set images & cameras" << std::endl;
+  } else {
+    std::cout << "acam0: " << rip.acam0() << std::endl
+              << "acam1: " << rip.acam1() << std::endl;
+  }
+
+  success = success && rip.process(scene_box);
+  TEST("rectify affine image pair", success, true);
+}
+
+TESTMAIN(test_rectify_affine_image_pair);

--- a/contrib/brl/bpro/core/bbas_pro/bbas_processes.h
+++ b/contrib/brl/bpro/core/bbas_pro/bbas_processes.h
@@ -22,5 +22,6 @@ DECLARE_FUNC_CONS(bsl_fusion_process);
 DECLARE_FUNC_CONS(imesh_ply_bbox_process);
 DECLARE_FUNC_CONS(bpgl_generate_depth_maps_process);
 DECLARE_FUNC_CONS(bpgl_heightmap_from_disparity_process);
+DECLARE_FUNC_CONS(bpgl_rectify_affine_image_pair_process);
 
 #endif // bbas_processes_h_

--- a/contrib/brl/bpro/core/bbas_pro/bbas_register.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/bbas_register.cxx
@@ -29,4 +29,5 @@ void bbas_register::register_process()
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, imesh_ply_bbox_process, "imeshPlyBboxProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bpgl_generate_depth_maps_process, "bpglGenerateDepthMapsProcess");
   REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bpgl_heightmap_from_disparity_process, "bpglHeightmapFromDisparityProcess");
+  REG_PROCESS_FUNC_CONS(bprb_func_process, bprb_batch_process_manager, bpgl_rectify_affine_image_pair_process, "bpglRectifyAffineImagePairProcess");
 }

--- a/contrib/brl/bpro/core/bbas_pro/processes/bpgl_rectify_affine_image_pair_process.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/processes/bpgl_rectify_affine_image_pair_process.cxx
@@ -1,0 +1,154 @@
+//This is brl/bpro/core/bbas_pro/processes/bpgl_rectify_affine_image_pair_process.cxx
+#include <string>
+#include <iostream>
+#include <bprb/bprb_func_process.h>
+#include <bprb/bprb_parameters.h>
+
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <vpgl/vpgl_camera_double_sptr.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vil/vil_image_view_base.h>
+#include <vil/vil_image_view.h>
+#include <vgl/vgl_box_3d.h>
+
+#include <bpgl/algo/bpgl_rectify_affine_image_pair.h>
+
+
+//: process to rectify affine image pair
+//
+// bpgl_rectify_affine_image_pair(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+//                                vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1);
+//
+// bool process(vgl_box_3d<double>const& scene_box )
+//
+// const vpgl_affine_camera<double>& rect_acam0()const{return rect_acam0_;}
+// const vpgl_affine_camera<double>& rect_acam1()const{return rect_acam1_;}
+// const vil_image_view<float>& rectified_fview0() const{return rect_fview0_;}
+// const vil_image_view<float>& rectified_fview1() const{return rect_fview1_;}
+
+namespace bpgl_rectify_affine_image_pair_process_globals
+{
+  unsigned n_inputs_  = 13;
+  unsigned n_outputs_ = 4;
+}
+
+
+bool bpgl_rectify_affine_image_pair_process_cons(bprb_func_process& pro)
+{
+  using namespace bpgl_rectify_affine_image_pair_process_globals;
+
+  std::vector<std::string> input_types_;
+  input_types_.emplace_back("vil_image_view_base_sptr");  // image0
+  input_types_.emplace_back("vpgl_camera_double_sptr");   // camera0
+  input_types_.emplace_back("vil_image_view_base_sptr");  // image0
+  input_types_.emplace_back("vpgl_camera_double_sptr");   // camera0
+  input_types_.emplace_back("double");     // min point x (e.g. lower left corner of a scene bbox)
+  input_types_.emplace_back("double");     // min point y
+  input_types_.emplace_back("double");     // min point z
+  input_types_.emplace_back("double");     // max point x (e.g. upper right corner of a scene bbox)
+  input_types_.emplace_back("double");     // max point y
+  input_types_.emplace_back("double");     // max point z
+  input_types_.emplace_back("unsigned");   // n_points -- randomly sample this many points form the voxel volume, e.g. 100
+  input_types_.emplace_back("vcl_string"); // output file for H0 rectification
+  input_types_.emplace_back("vcl_string"); // output file for H1 rectification
+
+  std::vector<std::string> output_types_;
+  output_types_.emplace_back("vil_image_view_base_sptr"); // rectified image0
+  output_types_.emplace_back("vpgl_camera_double_sptr");  // rectified camera0
+  output_types_.emplace_back("vil_image_view_base_sptr"); // rectified image1
+  output_types_.emplace_back("vpgl_camera_double_sptr");  // rectified camera1
+
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
+}
+
+
+bool bpgl_rectify_affine_image_pair_process(bprb_func_process& pro)
+{
+  using namespace bpgl_rectify_affine_image_pair_process_globals;
+
+  // sanity check
+  if (!pro.verify_inputs()) {
+    std::cerr << pro.name() << ": wrong inputs!!!\n";
+    return false;
+  }
+
+  // reusable variables
+  unsigned i = 0;
+  bool success = false;
+
+  // get inputs
+  i = 0;
+  auto image0_sptr  = pro.get_input<vil_image_view_base_sptr>(i++);
+  auto camera0_sptr = pro.get_input<vpgl_camera_double_sptr>(i++);
+  auto image1_sptr  = pro.get_input<vil_image_view_base_sptr>(i++);
+  auto camera1_sptr = pro.get_input<vpgl_camera_double_sptr>(i++);
+  auto min_x        = pro.get_input<double>(i++);
+  auto min_y        = pro.get_input<double>(i++);
+  auto min_z        = pro.get_input<double>(i++);
+  auto max_x        = pro.get_input<double>(i++);
+  auto max_y        = pro.get_input<double>(i++);
+  auto max_z        = pro.get_input<double>(i++);
+  auto n_points     = pro.get_input<unsigned>(i++);
+  auto file_H0      = pro.get_input<std::string>(i++);
+  auto file_H1      = pro.get_input<std::string>(i++);
+
+
+  // convert cameras
+  auto* camera0_ptr = dynamic_cast<vpgl_affine_camera<double>*> (camera0_sptr.as_pointer());
+  if (!camera0_ptr) {
+    std::cerr << pro.name() << " :-- camera 0 is not affine" << std::endl;
+    return false;
+  }
+
+  auto* camera1_ptr = dynamic_cast<vpgl_affine_camera<double>*> (camera1_sptr.as_pointer());
+  if (!camera1_ptr) {
+    std::cerr << pro.name() << " :-- camera 1 is not affine" << std::endl;
+    return false;
+  }
+
+  // bounding box
+  vgl_box_3d<double> scene_box(min_x,min_y,min_z, max_x,max_y,max_z);
+
+  // process
+  bpgl_rectify_affine_image_pair rectify_object;
+
+  success = rectify_object.set_images_and_cams(image0_sptr, *camera0_ptr, image1_sptr, *camera1_ptr);
+  if (!success) {
+    std::cerr << pro.name() << " :-- set_images_and_cams failed" << std::endl;
+    return false;
+  }
+
+  success = rectify_object.process(scene_box, n_points);
+  if (!success) {
+    std::cerr << pro.name() << " :-- process failed" << std::endl;
+    return false;
+  }
+
+  // write rectification homographies to file (optional)
+  if (!file_H0.empty()) {
+    std::ofstream ofs0(file_H0.c_str());
+    ofs0 << rectify_object.H0();
+    ofs0.close();
+  }
+
+  if (!file_H1.empty()) {
+    std::ofstream ofs1(file_H1.c_str());
+    ofs1 << rectify_object.H1();
+    ofs1.close();
+  }
+
+  // return
+  i = 0;
+  pro.set_output_val<vil_image_view_base_sptr>(i++,
+      new vil_image_view<float>(rectify_object.rectified_fview0()));
+  pro.set_output_val<vpgl_camera_double_sptr>(i++,
+      new vpgl_affine_camera<double>(rectify_object.rect_acam0()));
+  pro.set_output_val<vil_image_view_base_sptr>(i++,
+      new vil_image_view<float>(rectify_object.rectified_fview1()));
+  pro.set_output_val<vpgl_camera_double_sptr>(i++,
+      new vpgl_affine_camera<double>(rectify_object.rect_acam1()));
+  return true;
+}

--- a/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
@@ -397,3 +397,42 @@ def heightmap_from_disparity(camera1, camera2, disparity,
         return heightmap
     else:
         raise Exception("bpgl heightmap from disparity failed")
+
+
+def rectify_affine_image_pair(image0, affine_camera0, image1, affine_camera1,
+                              min_x, min_y, min_z, max_x, max_y, max_z,
+                              n_points = 1000,
+                              file_H0=None, file_H1=None):
+
+    batch.init_process("bpglRectifyAffineImagePairProcess")
+    batch.set_input_from_db(0, image0)
+    batch.set_input_from_db(1, affine_camera0)
+    batch.set_input_from_db(2, image1)
+    batch.set_input_from_db(3, affine_camera1)
+
+    batch.set_input_double(4, min_x)
+    batch.set_input_double(5, min_y)
+    batch.set_input_double(6, min_z)
+    batch.set_input_double(7, max_x)
+    batch.set_input_double(8, max_y)
+    batch.set_input_double(9, max_z)
+
+    batch.set_input_unsigned(10, n_points)
+
+    if not file_H0: file_H0 = ""
+    if not file_H1: file_H1 = ""
+    batch.set_input_string(11, file_H0)
+    batch.set_input_string(12, file_H1)
+
+    if batch.run_process():
+        (id, type) = batch.commit_output(0)
+        rect_image0 = dbvalue(id, type)
+        (id, type) = batch.commit_output(1)
+        rect_affine_camera0 = dbvalue(id, type)
+        (id, type) = batch.commit_output(2)
+        rect_image1 = dbvalue(id, type)
+        (id, type) = batch.commit_output(3)
+        rect_affine_camera1 = dbvalue(id, type)
+        return rect_image0, rect_affine_camera0, rect_image1, rect_affine_camera1
+    else:
+        raise Exception("bpgl_rectify_affine_image_pair failed")

--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -4,7 +4,11 @@ set(bsgm_sources
     bsgm_census.h                          bsgm_census.cxx
     bsgm_disparity_estimator.h             bsgm_disparity_estimator.cxx
     bsgm_multiscale_disparity_estimator.h  bsgm_multiscale_disparity_estimator.cxx
+    bsgm_align_pointsets_3d.h              bsgm_align_pointsets_3d.hxx
+    bsgm_prob_align_pointsets_3d.h         bsgm_prob_align_pointsets_3d.hxx
    )
+
+aux_source_directory(Templates bsgm_sources)
 
 vxl_add_library(LIBRARY_NAME bsgm LIBRARY_SOURCES ${bsgm_sources})
 

--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -6,6 +6,8 @@ set(bsgm_sources
     bsgm_multiscale_disparity_estimator.h  bsgm_multiscale_disparity_estimator.cxx
     bsgm_align_pointsets_3d.h              bsgm_align_pointsets_3d.hxx
     bsgm_prob_align_pointsets_3d.h         bsgm_prob_align_pointsets_3d.hxx
+    bsgm_pairwise_dsm.h                    bsgm_pairwise_dsm.cxx
+    bsgm_prob_pairwise_dsm.h               bsgm_prob_pairwise_dsm.cxx
    )
 
 aux_source_directory(Templates bsgm_sources)

--- a/contrib/brl/bseg/bsgm/Templates/bsgm_align_pointsets_3d+double-.cxx
+++ b/contrib/brl/bseg/bsgm/Templates/bsgm_align_pointsets_3d+double-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of bsgm_align_poinsets_3d<double>
+#include <bsgm/bsgm_align_pointsets_3d.hxx>
+BSGM_ALIGN_POINTSETS_3D_INSTANIATE(double);

--- a/contrib/brl/bseg/bsgm/Templates/bsgm_align_pointsets_3d+float-.cxx
+++ b/contrib/brl/bseg/bsgm/Templates/bsgm_align_pointsets_3d+float-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of bsgm_align_pointsets_3d<float>
+#include <bsgm/bsgm_align_pointsets_3d.hxx>
+BSGM_ALIGN_POINTSETS_3D_INSTANIATE(float);

--- a/contrib/brl/bseg/bsgm/Templates/bsgm_prob_align_pointsets_3d+double-.cxx
+++ b/contrib/brl/bseg/bsgm/Templates/bsgm_prob_align_pointsets_3d+double-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of bsgm_prob_align_poinsets_3d<double>
+#include <bsgm/bsgm_prob_align_pointsets_3d.hxx>
+BSGM_PROB_ALIGN_POINTSETS_3D_INSTANIATE(double);

--- a/contrib/brl/bseg/bsgm/Templates/bsgm_prob_align_pointsets_3d+float-.cxx
+++ b/contrib/brl/bseg/bsgm/Templates/bsgm_prob_align_pointsets_3d+float-.cxx
@@ -1,0 +1,3 @@
+// Instantiation of bsgm_prob_align_poinsets_3d<float>
+#include <bsgm/bsgm_prob_align_pointsets_3d.hxx>
+BSGM_PROB_ALIGN_POINTSETS_3D_INSTANIATE(float);

--- a/contrib/brl/bseg/bsgm/bsgm_align_pointsets_3d.h
+++ b/contrib/brl/bseg/bsgm/bsgm_align_pointsets_3d.h
@@ -1,0 +1,67 @@
+// This is brl/bseg/bsgm/bsgm_align_pointsets_3d.h
+#ifndef bsgm_align_pointsets_3d_h_
+#define bsgm_align_pointsets_3d_h_
+
+#include <iostream>
+#include <vector>
+#include <vgl/vgl_pointset_3d.h>
+#include <vgl/vgl_vector_3d.h>
+#include <bvgl/bvgl_k_nearest_neighbors_3d.h>
+
+template <typename T>
+struct alignment_params
+{
+  alignment_params():point_sample_dist_(T(1)/T(2)), coarse_inc_mul_(T(10)), fine_inc_mul_(T(5)/T(2)),
+    coarse_radius_mul_(T(40)), fine_radius_mul_(coarse_inc_mul_*T(5)/T(4)), consen_dist_mul_(T(2)),
+    min_n_pts_(2500) {}
+
+  T point_sample_dist_; //sets the spatial resolution for the search space
+  T coarse_inc_mul_;    //the translation vector increment for coarse search
+  T fine_inc_mul_;      //the translation vector increment for fine search
+  T coarse_radius_mul_; //the coarse search radius
+  T fine_radius_mul_;   //the fine search radius
+
+  T consen_dist_mul_;   //the max distance a transformed point from pointset 0
+                        //can be from the nearest point in the pointset 1 (2)
+  size_t min_n_pts_;    // the minium number of points in pointset 0 to be tested for consensus
+                        // with respect to pointset 1
+};
+
+template <typename T>
+class bsgm_align_pointsets_3d
+{
+ public:
+  bsgm_align_pointsets_3d(vgl_pointset_3d<T> const& ptset_0, vgl_pointset_3d<T> const& ptset_1):
+    ptset_0_(ptset_0), ptset_1_(ptset_1)
+  {
+    knn_ = bvgl_k_nearest_neighbors_3d<T>(ptset_1);
+  }
+
+  //: the function for computing the consensus for a transformation of pointset 1
+  // the value is the number of nearest points in pointset 1 within c_tol of each
+  // transformed point from pointset 0.
+  size_t consensus(T tx, T ty, T tz, T c_tol);
+
+  //: a loop that scans the search space looking for the maximum consensus
+  // rad, inc the radius and increment for the search
+  // tx0, ty0, tz0 - the center of the search space
+  // con_tol the distance tolerance for consensus
+  // max_tx, max_ty, max_tz the result of the search for maximum consensus, max_con
+  bool search(T rad, T inc, T tx0, T ty0, T tz0, T con_tol,
+              T& max_tx, T& max_ty, T& max_tz, size_t& max_con, bool verbose = false);
+
+  //: the main process method. If verbose is true a series of array showing the search are printed
+  bool find_translation(bool verbose = false);
+
+  vgl_vector_3d<T> translation() const {return translation_;}
+
+ private:
+  alignment_params<T> params_;
+  vgl_pointset_3d<T> ptset_0_;
+  vgl_pointset_3d<T> ptset_1_;
+  bvgl_k_nearest_neighbors_3d<T> knn_;
+  vgl_vector_3d<T> translation_;
+};
+
+
+#endif // bsgm_align_pointsets_3d_h_

--- a/contrib/brl/bseg/bsgm/bsgm_align_pointsets_3d.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_align_pointsets_3d.hxx
@@ -1,0 +1,107 @@
+// This is brl/bseg/bsgm/bsgm_align_pointsets_3d.hxx
+#include "bsgm_align_pointsets_3d.h"
+#include <vgl/vgl_distance.h>
+#include <vul/vul_timer.h>
+
+template <typename T>
+size_t bsgm_align_pointsets_3d<T>::consensus(T tx, T ty, T tz, T c_tol)
+{
+  size_t ncon = 0;
+  size_t n = ptset_0_.size();
+  size_t n_skip = n/params_.min_n_pts_;
+  if(n_skip == 0)
+	  n_skip = 1;
+  for(size_t i = 0; i<n; i+=n_skip){
+    const vgl_point_3d<T>& p = ptset_0_.p(i);
+    // translate a point from ptset_0
+    vgl_point_3d<T> tp(p.x()+tx, p.y()+ty, p.z()+tz), cp;
+    // find the closest point from ptset_1
+    if(!knn_.closest_point(tp, cp)){
+      std::cout << "KNN index failed to find neighbors - fatal" << std::endl;
+      return -1;
+    }
+    // is the closest point within c_tol?
+    if(vgl_distance(tp, cp)<= c_tol)
+      ncon++;
+  }
+  return ncon;
+}
+
+template <typename T>
+bool bsgm_align_pointsets_3d<T>::search(T rad, T inc, T tx0, T ty0, T tz0, T con_tol,
+                                        T& max_tx, T& max_ty, T& max_tz, size_t& max_con,
+                                        bool verbose)
+{
+  size_t max_consensus = 0;
+  max_tx = rad; max_ty = rad; max_tz = rad;
+  for (T tx = tx0-rad; tx <= tx0+rad; tx += inc) {
+    for (T ty = ty0-rad; ty <= ty0+rad; ty += inc) {
+      size_t max_z_con = 0;
+      for (T tz = tz0-rad; tz <= tz0+rad; tz += inc) {
+        size_t  con = this->consensus(tx, ty, tz, con_tol);
+        if (con == -1)
+          return false;
+        if (con > max_consensus) {
+          max_consensus = con;
+          max_tx = tx;  max_ty = ty; max_tz = tz;
+        }
+        if (con > max_z_con)
+          max_z_con = con;
+      }
+      if(verbose) std::cout << max_z_con << ' ';
+    }
+    if(verbose) std::cout << std::endl;
+  }
+  return true;
+}
+
+template <typename T>
+bool bsgm_align_pointsets_3d<T>::find_translation(bool verbose)
+{
+  vul_timer t;
+  T sd = params_.point_sample_dist_;
+  T cdm = params_.consen_dist_mul_;
+  T c_inc = sd*params_.coarse_inc_mul_;
+  T f_inc = sd*params_.fine_inc_mul_;
+  T c_rad = sd*params_.coarse_radius_mul_;
+  T f_rad = sd*params_.fine_radius_mul_;
+  T f_con_tol = cdm*f_inc;
+  T c_con_tol = cdm*c_inc;
+  // ultra fine search parameters
+  T uf_inc = f_inc*T(1)/T(4);
+  T uf_rad = f_inc*T(5)/T(4);
+
+  // coarse search
+  if(verbose) std::cout << "coarse search" << std::endl;
+  T max_tx = c_rad, max_ty = c_rad, max_tz = c_rad;
+  T tx0 = T(0),  ty0 = T(0), tz0 = T(0);
+  size_t max_consensus = 0;
+  if(!search(c_rad, c_inc, tx0, ty0, tz0, c_con_tol, max_tx, max_ty, max_tz, max_consensus, verbose))
+    return false;
+  if(max_tx == -c_rad || max_tx == c_rad ||
+     max_ty == -c_rad || max_ty == c_rad ||
+     max_tz == -c_rad || max_tz == c_rad){
+    std::cout << "Coarse search finished at search bounds" << std::endl;
+    return false;
+  }
+  // fine search
+  if(verbose) std::cout << "\nfine search" << std::endl;
+  T max_ftx = max_tx, max_fty = max_ty, max_ftz = max_tz;
+  if(!search(f_rad, f_inc, max_tx, max_ty, max_tz, f_con_tol, max_ftx, max_fty, max_ftz, max_consensus, verbose))
+    return false;
+
+  // ultra fine search
+  if(verbose) std::cout << "\nultra fine search" << std::endl;
+  max_consensus = 0;
+  T u_max_ftx = max_ftx, u_max_fty = max_fty, u_max_ftz = max_ftz;
+  if(!search(uf_rad, uf_inc, max_ftx, max_fty, max_ftz, f_con_tol, u_max_ftx, u_max_fty, u_max_ftz, max_consensus, verbose))
+    return false;
+
+  std::cout << "\ntranslation:0->1 ( " << u_max_ftx << ' ' << u_max_fty << ' ' << u_max_ftz << ")" << std::endl;
+  translation_.set(u_max_ftx, u_max_fty, u_max_ftz);
+  std::cout << "find pairwise dsm translation in " << t.real()/1000.0f << " secs." << std::endl;
+  return true;
+}
+
+#define BSGM_ALIGN_POINTSETS_3D_INSTANIATE(T) \
+  template class bsgm_align_pointsets_3d<T>

--- a/contrib/brl/bseg/bsgm/bsgm_pairwise_dsm.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_pairwise_dsm.cxx
@@ -1,0 +1,157 @@
+// This is brl/bseg/bsgm/bsgm_pairwise_dsm.cxx
+
+#include "bsgm_pairwise_dsm.h"
+#include "bsgm_multiscale_disparity_estimator.h"
+#include <limits>
+#include <vil/vil_convert.h>
+#include <vnl/vnl_math.h>
+#include <vgl/vgl_box_3d.h>
+#include <vgl/vgl_point_3d.h>
+#include <vgl/vgl_distance.h>
+#include <bvgl/bvgl_k_nearest_neighbors_3d.h>
+#include <bpgl/algo/bpgl_heightmap_from_disparity.h>
+#include <bpgl/algo/bpgl_gridding.h>
+
+
+void bsgm_pairwise_dsm::compute_byte()
+{
+  vil_convert_stretch_range(rip_.rectified_fview0(), rect_bview0_);
+  vil_convert_stretch_range(rip_.rectified_fview1(), rect_bview1_);
+  ni_ = rect_bview0_.ni();
+  nj_ = rect_bview0_.nj();
+}
+
+vil_image_view<vxl_byte> bsgm_pairwise_dsm::invalid_map() const
+{
+  vil_image_view<vxl_byte> ret;
+  vil_convert_cast(invalid_map_, ret);
+  return ret;
+}
+
+vil_image_view<vxl_byte> bsgm_pairwise_dsm::rev_invalid_map() const
+{
+  vil_image_view<vxl_byte> ret;
+  vil_convert_cast(invalid_map_reverse_, ret);
+  return ret;
+}
+
+bool bsgm_pairwise_dsm::compute_disparity()
+{
+  vxl_byte border_val = 0;
+
+  compute_invalid_map(rect_bview0_, rect_bview1_, invalid_map_, min_disparity_, num_disparities(),border_val);
+
+  bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_, num_disparities(), num_active_disparities());
+
+  float invalid_disp = NAN;//required for Dan's implementation of triangulation
+  bool good = mde.compute(rect_bview0_, rect_bview1_, invalid_map_, min_disparity_,
+                          invalid_disp, params_.multi_scale_mode_, disp_r_);
+  return good;
+}
+
+bool bsgm_pairwise_dsm::compute_rev_disparity()
+{
+  vxl_byte border_val = 0;
+
+  compute_invalid_map(rect_bview1_, rect_bview0_, invalid_map_reverse_, min_disparity_, num_disparities(),border_val);
+
+  bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_, num_disparities(), num_active_disparities());
+
+  float invalid_disp = NAN;//required for Dan's implementation of triangulation
+  bool good = mde.compute(rect_bview1_, rect_bview0_, invalid_map_reverse_, min_disparity_,
+                          invalid_disp, params_.multi_scale_mode_, disp_r_reverse_);
+  return good;
+}
+
+void bsgm_pairwise_dsm::compute_dsm_and_ptset(vgl_box_3d<double> const& scene_box)
+{
+  vgl_point_3d<double> pmin = scene_box.min_point(), pmax = scene_box.max_point();
+  vgl_point_3d<float> pminf(pmin.x(), pmin.y(), pmin.z()), pmaxf(pmax.x(), pmax.y(), pmax.z());
+  vgl_box_3d<float> fbox;
+  fbox.add(pminf), fbox.add(pmaxf);
+  float samp_dist = params_.point_sample_dist_;
+  //
+  //                              img0               img1     v
+  // in sgm disparity estimation img_targ(x,y) <-> img_ref( x + disp_target(x,y), y )
+  // the heightmap code requires  img1(u, v) <--> img0(u - disparity, v)
+  // thus the order is reversed                          ^
+  //
+  height_map_ =  bpgl_heightmap_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, scene_box, samp_dist);
+
+  vgl_point_2d<float> ul(pminf.x(), pmaxf.y());
+  std::vector<vgl_point_3d<float> > pts3d;
+  ///  bpgl_gridding::pointset_from_grid(height_map_, ul, samp_dist, pts3d);
+  bpgl_pointset_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, fbox, samp_dist, pts3d);
+  ptset_ = vgl_pointset_3d<float>(pts3d);
+}
+
+void bsgm_pairwise_dsm::consistent_heightmap(vgl_box_3d<double> const& scene_box)
+{
+  size_t n = consist_ptset_.size();
+  if(n == 0)
+    return;
+  std::vector<vgl_point_2d<double> > triangulated_xy;
+  std::vector<float> height_values;
+  for(size_t i = 0; i<n; ++i){
+    const vgl_point_3d<float>& p = consist_ptset_.p(i);
+    triangulated_xy.emplace_back(p.x(), p.y());
+    height_values.push_back(p.z());
+  }
+  vgl_point_2d<double> upper_left(scene_box.min_x(), scene_box.max_y());
+  size_t ni = height_map_.ni(), nj = height_map_.nj();
+  double gsd = params_.point_sample_dist_;
+  size_t n_nbr = params_.num_nearest_nbrs_;
+  double max_d = params_.max_consist_dist_;
+  bpgl_gridding::linear_interp<double, float> interp_fun(max_d, NAN);
+  consist_height_map_ = bpgl_gridding::grid_data_2d(triangulated_xy, height_values,
+                                                    upper_left, ni, nj, gsd,
+                                                    interp_fun, n_nbr);
+}
+
+bool bsgm_pairwise_dsm::consistent_pointset()
+{
+  size_t n = ptset_.size(), n_nbrs = params_.num_nearest_nbrs_;
+  if(n == 0)
+    return false;
+  consist_ptset_.clear();
+  bvgl_k_nearest_neighbors_3d<float> knn(ptset_reverse_);
+  float davg = 0.0f, dsq = 0.0f, dz_avg = 0.0f, dz_sq = 0.0f;
+  float nstat = 0.0f;
+  for(size_t i = 0; i<n; ++i){
+	  const vgl_point_3d<float>& p = ptset_.p(i);
+	  vgl_point_3d<float> cp;
+    if(!knn.closest_point(p, cp)){
+      std::cout << "KNN index failed to find neighbors - fatal" << std::endl;
+      return false;
+    }
+    float d = vgl_distance(p, cp);
+    if(d >params_.max_consist_dist_)
+      continue;
+    consist_ptset_.add_point(p);
+  }
+  return true;
+}
+
+bool bsgm_pairwise_dsm::compute_consistent_dsm_and_ptset(vgl_box_3d<double> const& scene_box)
+{
+  vgl_point_3d<double> pmin = scene_box.min_point(), pmax = scene_box.max_point();
+  vgl_point_3d<float> pminf(pmin.x(), pmin.y(), pmin.z()), pmaxf(pmax.x(), pmax.y(), pmax.z());
+  vgl_box_3d<float> fbox;
+  fbox.add(pminf), fbox.add(pmaxf);
+  float samp_dist = params_.point_sample_dist_;
+  //
+  //                              img0               img1     v
+  // in sgm disparity estimation img_targ(x,y) <-> img_ref( x + disp_target(x,y), y )
+  // the heightmap code requires  img1(u, v) <--> img0(u - disparity, v)
+  // thus the order is reversed                          ^
+  //
+  height_map_ =  bpgl_heightmap_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, scene_box, samp_dist);
+  height_map_reverse_ =  bpgl_heightmap_from_disparity(rip_.rect_acam0(), rip_.rect_acam1(), disp_r_reverse_, scene_box, samp_dist);
+
+  std::vector<vgl_point_3d<float> > pts3d, pts3d_reverse;
+  bpgl_pointset_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, fbox, samp_dist, pts3d);
+  bpgl_pointset_from_disparity(rip_.rect_acam0(), rip_.rect_acam1(), disp_r_reverse_, fbox, samp_dist, pts3d_reverse);
+  ptset_ = vgl_pointset_3d<float>(pts3d);
+  ptset_reverse_ = vgl_pointset_3d<float>(pts3d_reverse);
+  return this->consistent_pointset();
+}

--- a/contrib/brl/bseg/bsgm/bsgm_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_pairwise_dsm.h
@@ -1,0 +1,166 @@
+// This is brl/bseg/bsgm/bsgm_pairwise_dsm.h
+#ifndef bsgm_pairwise_dsm_h_
+#define bsgm_pairwise_dsm_h_
+
+//:
+// \file
+// \brief A class to provide a convenient interface to compute a pairwise dsm
+// \author J.L. Mundy
+// \date February 11, 2019
+//
+// \verbatim
+//  Modifications
+//   <none yet>
+// \endverbatim
+// uses the SGM algorithm to compute a pair of disparity images, normal and reverse.
+// the reverse disparity image is computed by simply flipping the order of the
+// images passed to the SGM algorithm. The forward and reverse disparity images are
+// converted to a 3-d pointset by finding the 3-d points that produce the observed
+// disparities.  The forward and reverse pointsets are then pruned to remove any
+// point in the forward pointset that does not have a nearby point in the reverse pointset.
+// This consistency check is done in 3-d coordinates since the 3-d distance between points
+// is invariant to camera viewpoint while image disparity distances are not. For example,
+// the tolerance for consistent disparities will be much tighter for image pairs that have
+// nearly the same viewpoint.
+//
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <math.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vgl/vgl_point_2d.h>
+#include <vgl/vgl_pointset_3d.h>
+#include <vil/vil_image_view.h>
+#include <bpgl/algo/bpgl_rectify_affine_image_pair.h>
+#include "bsgm_disparity_estimator.h" // for disparity_estimator_params
+
+
+struct pairwise_params{
+  pairwise_params():active_disparity_factor_(0.5),downscale_exponent_(2), multi_scale_mode_(1),
+    point_sample_dist_(0.5f), max_consist_dist_(3.75*point_sample_dist_), num_nearest_nbrs_(5){}
+
+  bsgm_disparity_estimator_params de_params_; // internal disparity estimator params
+  float active_disparity_factor_; // what fraction of full disparity range is used for fine search
+  int downscale_exponent_;   // in coarse to fine disparity, what is the downsample ratio as 2^exponent
+  int multi_scale_mode_;     // see disparity_estimator
+  float point_sample_dist_;  // the height map grid spacing, also relates to consistent distance tolerance
+  float max_consist_dist_;   // the max distance between consistent forward/reverse 3-d points
+  size_t num_nearest_nbrs_;  // number of nearest neighbors in the pointset to find closest and to interpolate
+};
+
+
+class bsgm_pairwise_dsm
+{
+ public:
+  bsgm_pairwise_dsm(){}
+
+  bsgm_pairwise_dsm(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+                      vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1)
+  {
+    rip_.set_images_and_cams(resc0, acam0, resc1, acam1);
+  }
+
+  //: minimum dispartity to start search along an epipolar line
+  void set_min_disparity(int min_disparity){min_disparity_ = min_disparity;}
+
+  //: maximum dispartity to end search along an epipolar line
+  void set_max_disparity(int max_disparity){max_disparity_ = max_disparity;}
+
+  int min_disparity() const{return min_disparity_;}
+  int max_disparity() const{return max_disparity_;}
+  int num_disparities() { return (max_disparity_-min_disparity_); }
+
+  //: how many disparity values are searched around the coarse search result
+  int num_active_disparities() {
+    return static_cast<int>(num_disparities()*params_.active_disparity_factor_); }
+
+  //: estimate the forward disparities(arg order rectified image0:image1)
+  bool compute_disparity();
+  //: estimate the reverse disparities(arg order rectified image1:image0)
+  bool compute_rev_disparity();
+
+  //: compute height map and pointset, forward order only
+  void compute_dsm_and_ptset(vgl_box_3d<double> const& scene_box);
+
+  //: comptute forward and reverse heightmaps, pointsets and consistency filtered results
+  bool consistent_pointset();
+  void consistent_heightmap(vgl_box_3d<double> const& scene_box);
+  bool compute_consistent_dsm_and_ptset(vgl_box_3d<double> const& scene_box);
+
+  //: main process method
+  bool process(vgl_box_3d<double> const& scene_box, bool with_consistency_check = true)
+  {
+    if(!rip_.process(scene_box))
+      return false;
+    this->compute_byte();
+    if(with_consistency_check){
+      if(!compute_disparity())
+        return false;
+      if(!compute_rev_disparity())
+        return false;
+      if(!compute_consistent_dsm_and_ptset(scene_box))
+        return false;
+      this->consistent_heightmap(scene_box);
+    }else{
+      if(!compute_disparity())
+        return false;
+      compute_dsm_and_ptset(scene_box);
+    }
+    return true;
+  }
+
+  //: rectified images and cams
+  const vil_image_view<vxl_byte>& rectified_bview0()const  {return rect_bview0_;}
+  const vil_image_view<vxl_byte>& rectified_bview1()const  {return rect_bview1_;}
+  const vpgl_affine_camera<double>& rectified_acam0()const {return rip_.rect_acam0();}
+  const vpgl_affine_camera<double>& rectified_acam1()const {return rip_.rect_acam1();}
+
+  //: disparity results
+  vil_image_view<vxl_byte> invalid_map() const;
+  vil_image_view<vxl_byte> rev_invalid_map() const;
+  const vil_image_view<float>& disparity()const {return disp_r_;}
+  const vil_image_view<float>& rev_disparity()const {return disp_r_reverse_;}
+
+  //: triangulation results
+  // uses rectified cams to reconstruct 3-d scene geometry
+  // produces a 3-d pointset and a z(x,y) heightmap
+  const vil_image_view<float>& heightmap()const {return height_map_;}
+  const vil_image_view<float>& rev_heightmap()const {return height_map_reverse_;}
+  const vil_image_view<float>& consist_heightmap()const {return consist_height_map_;}
+  const vgl_pointset_3d<float> ptset() const {return ptset_;}
+  const vgl_pointset_3d<float> rev_ptset() const {return ptset_reverse_;}
+  const vgl_pointset_3d<float> consist_ptset() const {return consist_ptset_;}
+
+  // for debug purposes
+  bool load_images_and_cams(std::string const& image0_path, std::string const& cam0_path,
+                            std::string const& image1_path, std::string const& cam1_path)
+  {
+    return rip_.load_images_and_cams(image0_path, cam0_path, image1_path, cam1_path);
+  }
+
+ private:
+  void compute_byte();
+  pairwise_params params_;
+  bpgl_rectify_affine_image_pair rip_;
+  size_t ni_;
+  size_t nj_;
+  int min_disparity_;
+  int max_disparity_;
+  vil_image_view<vxl_byte> rect_bview0_;
+  vil_image_view<vxl_byte> rect_bview1_;
+  vil_image_view<bool> invalid_map_;
+  vil_image_view<bool> invalid_map_reverse_;
+  vil_image_view<float> disp_r_;
+  vil_image_view<float> disp_r_reverse_;
+  vil_image_view<float> height_map_;
+  vil_image_view<float> height_map_reverse_;
+  vil_image_view<float> consist_height_map_;
+  vgl_pointset_3d<float> ptset_;
+  vgl_pointset_3d<float> ptset_reverse_;
+  vgl_pointset_3d<float> consist_ptset_;
+};
+
+#endif // bsgm_pairwise_dsm_h_

--- a/contrib/brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.h
@@ -1,0 +1,73 @@
+// This is brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.h
+#ifndef bsgm_prob_align_pointsets_3d_h_
+#define bsgm_prob_align_pointsets_3d_h_
+
+#include <iostream>
+#include <vector>
+#include <vgl/vgl_pointset_3d.h>
+#include <vgl/vgl_vector_3d.h>
+#include <bvgl/bvgl_k_nearest_neighbors_3d.h>
+
+template <typename T>
+struct prob_alignment_params
+{
+  prob_alignment_params():point_sample_dist_(T(1)/T(2)), coarse_inc_mul_(T(10)), fine_inc_mul_(T(5)/T(2)),
+    coarse_radius_mul_(T(40)), fine_radius_mul_(coarse_inc_mul_*T(5)/T(4)), consen_dist_mul_(T(1.25)),//1.5
+    max_n_pts_(10000) {}//10000
+
+  T point_sample_dist_; //sets the spatial resolution for the search space
+  T coarse_inc_mul_;    //the translation vector increment for coarse search
+  T fine_inc_mul_;      //the translation vector increment for fine search
+  T coarse_radius_mul_; //the coarse search radius
+  T fine_radius_mul_;   //the fine search radius
+
+  T consen_dist_mul_;   //the max distance a transformed point from pointset 0
+                        //can be from the nearest point in the pointset 1 (2)
+  size_t max_n_pts_;    // the maximum number of points in pointset 0 to be tested for consensus
+                        // with respect to pointset 1
+};
+
+template <typename T>
+class bsgm_prob_align_pointsets_3d
+{
+ public:
+  bsgm_prob_align_pointsets_3d(vgl_pointset_3d<T> const& ptset_0, vgl_pointset_3d<T> const& ptset_1):
+    ptset_0_(ptset_0), ptset_1_(ptset_1)
+  {
+    descending_prob_sort(ptset_0_);
+    descending_prob_sort(ptset_1_);
+    knn_ = bvgl_k_nearest_neighbors_3d<T>(ptset_1_);
+  }
+
+  //: the function for computing the consensus for a transformation of pointset 1
+  // the value is the number of nearest points in pointset 1 within c_tol of each
+  // transformed point from pointset 0.
+  T total_prob(T tx, T ty, T tz, T c_tol);
+
+  //: a loop that scans the search space looking for the maximum consensus
+  // rad, inc the radius and increment for the search
+  // tx0, ty0, tz0 - the center of the search space
+  // con_tol the distance tolerance for consensus
+  // max_tx, max_ty, max_tz the result of the search for maximum consensus, max_con
+  bool search(T rad, T inc, T tx0, T ty0, T tz0, T con_tol,
+              T& max_tx, T& max_ty, T& max_tz, T& max_con, bool verbose = false);
+
+  //: the main process method. If verbose is true a series of array showing the search are printed
+  bool find_translation(bool verbose = false);
+
+  vgl_vector_3d<T> translation() const {return translation_;}
+
+ private:
+  static bool prob_greater(std::pair<size_t, T> const& a, std::pair<size_t, T> const& b){
+    return a.second > b.second;
+  }
+  void descending_prob_sort(vgl_pointset_3d<T>& prob_ptset);
+  prob_alignment_params<T> params_;
+  vgl_pointset_3d<T> ptset_0_;
+  vgl_pointset_3d<T> ptset_1_;
+  bvgl_k_nearest_neighbors_3d<T> knn_;
+  vgl_vector_3d<T> translation_;
+};
+
+
+#endif // bsgm_align_pointsets_3d_h_

--- a/contrib/brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.hxx
@@ -1,0 +1,144 @@
+// This is brl/bseg/bsgm/bsgm_prob_align_pointsets_3d.hxx
+#include "bsgm_prob_align_pointsets_3d.h"
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <vgl/vgl_distance.h>
+#include <vul/vul_timer.h>
+
+template <typename T>
+void bsgm_prob_align_pointsets_3d<T>::descending_prob_sort(vgl_pointset_3d<T>& prob_ptset)
+{
+  std::vector<std::pair<size_t, T> > indexed_probs;
+  size_t n = prob_ptset.size();
+  size_t max_n = params_.max_n_pts_;
+  if(max_n > (n-1))
+    max_n = (n-1);
+  for(size_t i = 0; i<n; ++i){
+    T pr = prob_ptset.sc(i);
+    indexed_probs.emplace_back(i, pr);
+  }
+  std::sort(indexed_probs.begin(), indexed_probs.end(), bsgm_prob_align_pointsets_3d<T>::prob_greater);
+  std::vector<vgl_point_3d<T> > pts;
+  std::vector<T> probs;
+  for(size_t i = 0; i<=max_n; ++i){
+    const vgl_point_3d<T>& p =prob_ptset.p(indexed_probs[i].first);
+    pts.emplace_back(p.x(), p.y(), p.z());
+    probs.push_back(indexed_probs[i].second);
+  }
+  prob_ptset.clear();
+  prob_ptset.set_points_with_scalars(pts, probs);
+}
+
+template <typename T>
+T bsgm_prob_align_pointsets_3d<T>::total_prob(T tx, T ty, T tz, T c_tol)
+{
+  float total_prob = 0;
+  size_t n = ptset_0_.size();
+  for(size_t i = 0; i<n; ++i){
+    const vgl_point_3d<T>& p = ptset_0_.p(i);
+    // translate a point from ptset_0
+    vgl_point_3d<T> tp(p.x()+tx, p.y()+ty, p.z()+tz);
+    // find the closest point from ptset_1
+    unsigned int indx = 0;
+    if(!knn_.closest_index(tp, indx)){
+      std::cout << "KNN index failed to find neighbors - fatal" << std::endl;
+      return -1;
+    }
+    const vgl_point_3d<T>& cp = ptset_1_.p(indx);
+    T prob_nbr = ptset_1_.sc(indx);
+    // is the closest point within c_tol?
+    if(vgl_distance(tp, cp)<= c_tol){
+      total_prob += prob_nbr;
+    }
+  }
+  return total_prob;
+}
+
+template <typename T>
+bool bsgm_prob_align_pointsets_3d<T>::search(T rad, T inc, T tx0, T ty0, T tz0, T con_tol,
+                                             T& max_tx, T& max_ty, T& max_tz, T& max_prob,
+                                             bool verbose)
+{
+  max_prob = 0.0f;
+  max_tx = rad; max_ty = rad; max_tz = rad;
+  for (T tx = tx0-rad; tx <= tx0+rad; tx += inc) {
+    for (T ty = ty0-rad; ty <= ty0+rad; ty += inc) {
+      float max_z_prob = 0.0f;
+      for (T tz = tz0-rad; tz <= tz0+rad; tz += inc) {
+        float tprob = this->total_prob(tx, ty, tz, con_tol);
+        if (tprob > max_prob) {
+          max_prob = tprob;
+          max_tx = tx;  max_ty = ty; max_tz = tz;
+        }
+        if (tprob > max_z_prob)
+          max_z_prob = tprob;
+      }
+      if(verbose) std::cout << max_z_prob << ' ';
+    }
+    if(verbose) std::cout << std::endl;
+  }
+  return true;
+}
+
+template <typename T>
+bool bsgm_prob_align_pointsets_3d<T>::find_translation(bool verbose)
+{
+  vul_timer t;
+  T sd = params_.point_sample_dist_;
+  T cdm = params_.consen_dist_mul_;
+  T c_inc = sd*params_.coarse_inc_mul_;
+  T f_inc = sd*params_.fine_inc_mul_;
+  T c_rad = sd*params_.coarse_radius_mul_;
+  T f_rad = sd*params_.fine_radius_mul_;
+  T f_con_tol = cdm*f_inc;
+  T c_con_tol = cdm*c_inc;
+  // ultra fine search parameters
+  T uf_inc = f_inc*T(1)/T(4);
+  T uf_rad = f_inc*T(5)/T(4);
+  // coarse search
+  if(verbose) std::cout << "coarse search" << std::endl;
+  if(verbose) std::cout << "max pts = "<< params_.max_n_pts_ << " ctol = " << c_con_tol << std::endl;
+  T max_tx = c_rad, max_ty = c_rad, max_tz = c_rad;
+  T tx0 = T(0),  ty0 = T(0), tz0 = T(0);
+  T max_prob = 0.0f;
+  if(!search(c_rad, c_inc, tx0, ty0, tz0, c_con_tol, max_tx, max_ty, max_tz, max_prob, verbose))
+    return false;
+  if(max_tx == -c_rad || max_tx == c_rad ||
+     max_ty == -c_rad || max_ty == c_rad ||
+     max_tz == -c_rad || max_tz == c_rad){
+    std::cout << "Coarse search finished at search bounds" << std::endl;
+    return false;
+  }
+  if(verbose) std::cout << "coarse rad = " << c_rad << " coarse inc = " << c_inc << std::endl;
+  if(verbose) std::cout << "trans( " << max_tx << ' ' << max_ty << ' ' << max_tz << ")" <<std::endl;
+  if(verbose) std::cout << "max prob " << max_prob << std::endl;
+  // fine search
+  max_prob = 0.0f;
+  if(verbose) std::cout << "\nfine search" << std::endl;
+  if(verbose) std::cout << " ctol = " << f_con_tol << std::endl;
+  T max_ftx = max_tx, max_fty = max_ty, max_ftz = max_tz;
+  if(!search(f_rad, f_inc, max_tx, max_ty, max_tz, f_con_tol, max_ftx, max_fty, max_ftz, max_prob, verbose))
+    return false;
+
+  if(verbose) std::cout << "fine rad = " << f_rad << " fine inc = " << f_inc << std::endl;
+  if(verbose) std::cout << "trans( " << max_ftx << ' ' << max_fty << ' ' << max_ftz << ")" <<std::endl;
+  if(verbose) std::cout << "max prob " << max_prob << std::endl;
+  // ultra fine search
+  if(verbose) std::cout << "\nultra fine search" << std::endl;
+  if(verbose) std::cout << " ctol = " << f_con_tol << std::endl;
+  max_prob = 0.0f;
+  T u_max_ftx = max_ftx, u_max_fty = max_fty, u_max_ftz = max_ftz;
+  if(!search(uf_rad, uf_inc, max_ftx, max_fty, max_ftz, f_con_tol, u_max_ftx, u_max_fty, u_max_ftz, max_prob, verbose))
+    return false;
+
+  if(verbose) std::cout << "ultra fine rad = " << uf_rad << " ultra fine inc = " << uf_inc << std::endl;
+  std::cout << "\ntranslation:0->1 ( " << u_max_ftx << ' ' << u_max_fty << ' ' << u_max_ftz << ")" << std::endl;
+  if(verbose) std::cout << "max prob " << max_prob << std::endl;
+  translation_.set(u_max_ftx, u_max_fty, u_max_ftz);
+  std::cout << "find pairwise dsm translation in " << t.real()/1000.0f << " secs." << std::endl;
+  return true;
+}
+
+#define BSGM_PROB_ALIGN_POINTSETS_3D_INSTANIATE(T) \
+  template class bsgm_prob_align_pointsets_3d<T>

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.cxx
@@ -1,0 +1,200 @@
+// This is brl/bseg/bsgm/bsgm_prob_pairwise_dsm.cxx
+
+#include "bsgm_prob_pairwise_dsm.h"
+#include "bsgm_multiscale_disparity_estimator.h"
+#include <limits>
+#include <vil/vil_convert.h>
+#include <vnl/vnl_math.h>
+#include <vgl/vgl_box_3d.h>
+#include <vgl/vgl_point_3d.h>
+#include <vgl/vgl_distance.h>
+#include <bvrml/bvrml_write.h> // for custom color map
+#include <bvgl/bvgl_k_nearest_neighbors_3d.h>
+#include <bpgl/algo/bpgl_heightmap_from_disparity.h>
+#include <bpgl/algo/bpgl_gridding.h>
+
+void bsgm_prob_pairwise_dsm::compute_byte()
+{
+  vil_convert_stretch_range(rip_.rectified_fview0(), rect_bview0_);
+  vil_convert_stretch_range(rip_.rectified_fview1(), rect_bview1_);
+  ni_ = rect_bview0_.ni();
+  nj_ = rect_bview0_.nj();
+}
+
+vil_image_view<vxl_byte> bsgm_prob_pairwise_dsm::invalid_map() const
+{
+  vil_image_view<vxl_byte> ret;
+  vil_convert_cast(invalid_map_, ret);
+  return ret;
+}
+
+vil_image_view<vxl_byte> bsgm_prob_pairwise_dsm::rev_invalid_map() const
+{
+  vil_image_view<vxl_byte> ret;
+  vil_convert_cast(invalid_map_reverse_, ret);
+  return ret;
+}
+
+bool bsgm_prob_pairwise_dsm::compute_disparity()
+{
+  vxl_byte border_val = 0;
+
+  compute_invalid_map(rect_bview0_, rect_bview1_, invalid_map_, min_disparity_, num_disparities(),border_val);
+
+  bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_, num_disparities(), num_active_disparities());
+
+  float invalid_disp = NAN;//required for Dan's implementation of triangulation
+  bool good = mde.compute(rect_bview0_, rect_bview1_, invalid_map_, min_disparity_,
+                          invalid_disp, params_.multi_scale_mode_, disp_r_);
+  return good;
+}
+
+bool bsgm_prob_pairwise_dsm::compute_rev_disparity()
+{
+  vxl_byte border_val = 0;
+
+  compute_invalid_map(rect_bview1_, rect_bview0_, invalid_map_reverse_, min_disparity_, num_disparities(),border_val);
+
+  bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_, num_disparities(), num_active_disparities());
+
+  float invalid_disp = NAN;//required for Dan's implementation of triangulation
+  bool good = mde.compute(rect_bview1_, rect_bview0_, invalid_map_reverse_, min_disparity_,
+                          invalid_disp, params_.multi_scale_mode_, disp_r_reverse_);
+  return good;
+}
+
+void bsgm_prob_pairwise_dsm::compute_dsm_and_ptset(vgl_box_3d<double> const& scene_box)
+{
+  vgl_point_3d<double> pmin = scene_box.min_point(), pmax = scene_box.max_point();
+  vgl_point_3d<float> pminf(pmin.x(), pmin.y(), pmin.z()), pmaxf(pmax.x(), pmax.y(), pmax.z());
+  vgl_box_3d<float> fbox;
+  fbox.add(pminf), fbox.add(pmaxf);
+  float samp_dist = params_.point_sample_dist_;
+  //
+  //                              img0               img1     v
+  // in sgm disparity estimation img_targ(x,y) <-> img_ref( x + disp_target(x,y), y )
+  // the heightmap code requires  img1(u, v) <--> img0(u - disparity, v)
+  // thus the order is reversed                          ^
+  //
+  height_map_ =  bpgl_heightmap_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, scene_box, samp_dist);
+
+  vgl_point_2d<float> ul(pminf.x(), pmaxf.y());
+  std::vector<vgl_point_3d<float> > pts3d;
+  ///  bpgl_gridding::pointset_from_grid(height_map_, ul, samp_dist, pts3d);
+  bpgl_pointset_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, fbox, samp_dist, pts3d);
+  ptset_ = vgl_pointset_3d<float>(pts3d);
+}
+
+void bsgm_prob_pairwise_dsm::prob_heightmap(vgl_box_3d<double> const& scene_box)
+{
+  size_t n = prob_ptset_.size();
+  if(n == 0)
+    return;
+  std::vector<vgl_point_2d<double> > triangulated_xy;
+  std::vector<float> height_values, prob_values;
+  for(size_t i = 0; i<n; ++i){
+    const vgl_point_3d<float>& p = prob_ptset_.p(i);
+    triangulated_xy.emplace_back(p.x(), p.y());
+    height_values.push_back(p.z());
+    prob_values.push_back(prob_ptset_.sc(i));
+  }
+  vgl_point_2d<double> upper_left(scene_box.min_x(), scene_box.max_y());
+  size_t ni = height_map_.ni(), nj = height_map_.nj();
+  double gsd = params_.point_sample_dist_;
+  size_t n_nbr = params_.num_nearest_nbrs_;
+  double max_d = 2.0*gsd;
+
+  bpgl_gridding::linear_interp<double, float> interp_fun(max_d, NAN);
+  prob_height_map_z_ = bpgl_gridding::grid_data_2d(triangulated_xy, height_values,
+                                                   upper_left, ni, nj, gsd,
+                                                   interp_fun, n_nbr);
+  prob_height_map_prob_ = bpgl_gridding::grid_data_2d(triangulated_xy, prob_values,
+                                                      upper_left, ni, nj, gsd,
+                                                      interp_fun, n_nbr);
+}
+
+bool bsgm_prob_pairwise_dsm::compute_pointset_prob()
+{
+  float sdsq = params_.std_dev_;
+  prob_distr_ = bsta_histogram<float>(0.0f, 1.0f, 100);
+  float norm = sqrt(2.0)/(sdsq*sqrt(3.14159));
+  sdsq *= sdsq;
+  size_t n = ptset_.size(), n_nbrs = params_.num_nearest_nbrs_;
+  if(n == 0)
+    return false;
+  prob_ptset_.clear();
+  bvgl_k_nearest_neighbors_3d<float> knn(ptset_reverse_);
+  float davg = 0.0f, dsq = 0.0f, dz_avg = 0.0f, dz_sq = 0.0f;
+  float nstat = 0.0f;
+  for(size_t i = 0; i<n; ++i){
+    const vgl_point_3d<float>& p = ptset_.p(i);
+    vgl_point_3d<float> cp;
+    if(!knn.closest_point(p, cp)){
+      std::cout << "KNN index failed to find neighbors - fatal" << std::endl;
+      return false;
+    }
+    float d = vgl_distance(p, cp);
+    float prob = norm*exp(-d*d/sdsq);
+    prob_distr_.upcount(prob, 1.0);
+    prob_ptset_.add_point_with_scalar(p, prob);
+  }
+  return true;
+}
+
+bool bsgm_prob_pairwise_dsm::compute_dsm_and_ptset_prob(vgl_box_3d<double> const& scene_box)
+{
+  vgl_point_3d<double> pmin = scene_box.min_point(), pmax = scene_box.max_point();
+  vgl_point_3d<float> pminf(pmin.x(), pmin.y(), pmin.z()), pmaxf(pmax.x(), pmax.y(), pmax.z());
+  vgl_box_3d<float> fbox;
+  fbox.add(pminf), fbox.add(pmaxf);
+  float samp_dist = params_.point_sample_dist_;
+  //
+  //                              img0               img1     v
+  // in sgm disparity estimation img_targ(x,y) <-> img_ref( x + disp_target(x,y), y )
+  // the heightmap code requires  img1(u, v) <--> img0(u - disparity, v)
+  // thus the order is reversed                          ^
+  //
+  height_map_ =  bpgl_heightmap_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, scene_box, samp_dist);
+  height_map_reverse_ =  bpgl_heightmap_from_disparity(rip_.rect_acam0(), rip_.rect_acam1(), disp_r_reverse_, scene_box, samp_dist);
+
+  std::vector<vgl_point_3d<float> > pts3d, pts3d_reverse;
+  bpgl_pointset_from_disparity(rip_.rect_acam1(), rip_.rect_acam0(), disp_r_, fbox, samp_dist, pts3d);
+  bpgl_pointset_from_disparity(rip_.rect_acam0(), rip_.rect_acam1(), disp_r_reverse_, fbox, samp_dist, pts3d_reverse);
+  ptset_ = vgl_pointset_3d<float>(pts3d);
+  ptset_reverse_ = vgl_pointset_3d<float>(pts3d_reverse);
+  return this->compute_pointset_prob();
+}
+
+static void map_prob_to_color(float prob, float& r, float& g, float& b)
+{
+    if(prob<0.0f) prob=0.0f;
+    else if(prob>1.0f) prob=1.0f;
+    float ncolors = static_cast<float>(bvrml_custom_color::heatmap_custom_size);
+    size_t color_index = static_cast<size_t>(prob*(ncolors-1));
+    if(color_index>=bvrml_custom_color::heatmap_custom_size)
+      color_index = bvrml_custom_color::heatmap_custom_size - 1;
+    r = static_cast<float>(bvrml_custom_color::heatmap_custom[color_index][0]);
+    g = static_cast<float>(bvrml_custom_color::heatmap_custom[color_index][1]);
+    b = static_cast<float>(bvrml_custom_color::heatmap_custom[color_index][2]);
+}
+
+bool bsgm_prob_pairwise_dsm::save_prob_ptset_color(std::string const& path) const
+{
+  size_t n = prob_ptset_.size();
+  float max = prob_distr_.value_with_area_above(0.05f);
+  std::ofstream ostr(path.c_str());
+  if(!ostr){
+    std::cout << "Can't open " << path << " to write color ptset" << std::endl;
+    return false;
+  }
+  for(size_t i = 0; i<n; ++i){
+    float prob = prob_ptset_.sc(i);
+    float norm_prob = prob/max;
+    float r, g, b;
+    map_prob_to_color(norm_prob, r, g, b);
+    const vgl_point_3d<float>& p = prob_ptset_.p(i);
+    ostr << p.x() << ' ' << p.y() << ' ' << p.z() << ' ' << r << ' ' << g << ' ' << b << std::endl;
+  }
+  ostr.close();
+  return true;
+}

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
@@ -1,0 +1,171 @@
+// This is brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+#ifndef bsgm_prob_pairwise_dsm_h
+#define bsgm_prob_pairwise_dsm_h
+
+//:
+// \file
+// \brief A class to provide a convenient interface to compute a pairwise dsm
+// \author J.L. Mundy
+// \date February 11, 2019
+//
+// \verbatim
+//  Modifications
+//   <none yet>
+// \endverbatim
+// uses the SGM algorithm to compute a pair of disparity images, normal and reverse.
+// the reverse disparity image is computed by simply flipping the order of the
+// images passed to the SGM algorithm. The forward and reverse disparity images are
+// converted to a 3-d pointset by finding the 3-d points that produce the observed
+// disparities.  A probability is applied to each forward 3-d point based on the 3-d distance
+// between a forward point and the closest point from the reverse reconstruction
+//
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <math.h>
+#include <vpgl/vpgl_affine_camera.h>
+#include <vgl/vgl_point_2d.h>
+#include <vgl/vgl_pointset_3d.h>
+#include <vil/vil_image_view.h>
+#include <bpgl/algo/bpgl_rectify_affine_image_pair.h>
+#include <bsta/bsta_histogram.h>
+#include "bsgm_disparity_estimator.h" // for disparity_estimator_params
+
+
+struct pairwise_params{
+  pairwise_params():active_disparity_factor_(0.5),downscale_exponent_(2), multi_scale_mode_(1),
+    point_sample_dist_(0.5f), std_dev_(3.75*point_sample_dist_), num_nearest_nbrs_(5){}
+
+  bsgm_disparity_estimator_params de_params_; // internal disparity estimator params
+  float active_disparity_factor_; // what fraction of full disparity range is used for fine search
+  int downscale_exponent_;   // in coarse to fine disparity, what is the downsample ratio as 2^exponent
+  int multi_scale_mode_;     // see disparity_estimator
+  float point_sample_dist_;  // the height map grid spacing, also relates to consistent distance tolerance
+  float std_dev_;            // the standard deviation of consistent disparity point distances
+  size_t num_nearest_nbrs_;  // number of nearest neighbors in the pointset to find closest and to interpolate
+};
+
+
+class bsgm_prob_pairwise_dsm
+{
+ public:
+  bsgm_prob_pairwise_dsm(){}
+
+  bsgm_prob_pairwise_dsm(vil_image_resource_sptr const& resc0, vpgl_affine_camera<double> const& acam0,
+                      vil_image_resource_sptr const& resc1, vpgl_affine_camera<double> const& acam1)
+  {
+    rip_.set_images_and_cams(resc0, acam0, resc1, acam1);
+  }
+
+  //: minimum dispartity to start search along an epipolar line
+  void set_min_disparity(int min_disparity){min_disparity_ = min_disparity;}
+
+  //: maximum dispartity to end search along an epipolar line
+  void set_max_disparity(int max_disparity){max_disparity_ = max_disparity;}
+
+  int min_disparity() const{return min_disparity_;}
+  int max_disparity() const{return max_disparity_;}
+  int num_disparities() { return (max_disparity_-min_disparity_); }
+
+  //: how many disparity values are searched around the coarse search result
+  int num_active_disparities() {
+    return static_cast<int>(num_disparities()*params_.active_disparity_factor_); }
+
+  //: estimate the forward disparities(arg order rectified image0:image1)
+  bool compute_disparity();
+  //: estimate the reverse disparities(arg order rectified image1:image0)
+  bool compute_rev_disparity();
+
+  //: compute height map and pointset, forward order only
+  void compute_dsm_and_ptset(vgl_box_3d<double> const& scene_box);
+
+  //: comptute forward and reverse heightmaps, pointsets and consistency filtered results
+  bool compute_pointset_prob();
+  void prob_heightmap(vgl_box_3d<double> const& scene_box);
+  bool compute_dsm_and_ptset_prob(vgl_box_3d<double> const& scene_box);
+
+  //: main process method
+  bool process(vgl_box_3d<double> const& scene_box, bool with_consistency_check = true)
+  {
+    if(!rip_.process(scene_box))
+      return false;
+    this->compute_byte();
+    if(with_consistency_check){
+      if(!compute_disparity())
+        return false;
+      if(!compute_rev_disparity())
+        return false;
+      if(!compute_dsm_and_ptset_prob(scene_box))
+        return false;
+      this->prob_heightmap(scene_box);
+    }else{
+      if(!compute_disparity())
+        return false;
+      compute_dsm_and_ptset(scene_box);
+    }
+    return true;
+  }
+
+  //: rectified images and cams
+  const vil_image_view<vxl_byte>& rectified_bview0()const  {return rect_bview0_;}
+  const vil_image_view<vxl_byte>& rectified_bview1()const  {return rect_bview1_;}
+  const vpgl_affine_camera<double>& rectified_acam0()const {return rip_.rect_acam0();}
+  const vpgl_affine_camera<double>& rectified_acam1()const {return rip_.rect_acam1();}
+
+  //: disparity results
+  vil_image_view<vxl_byte> invalid_map() const;
+  vil_image_view<vxl_byte> rev_invalid_map() const;
+  const vil_image_view<float>& disparity()const {return disp_r_;}
+  const vil_image_view<float>& rev_disparity()const {return disp_r_reverse_;}
+
+  //: triangulation results
+  // uses rectified cams to reconstruct 3-d scene geometry
+  // produces a 3-d pointset and a z(x,y) heightmap
+  const vil_image_view<float>& heightmap()const {return height_map_;}
+  const vil_image_view<float>& rev_heightmap()const {return height_map_reverse_;}
+  const vil_image_view<float>& prob_heightmap_z()const {return prob_height_map_z_;}
+  const vil_image_view<float>& prob_heightmap_prob()const { return prob_height_map_prob_; }
+  const vgl_pointset_3d<float> ptset() const {return ptset_;}
+  const vgl_pointset_3d<float> rev_ptset() const {return ptset_reverse_;}
+  const vgl_pointset_3d<float> prob_ptset() const {return prob_ptset_;}
+  bsta_histogram<float> prob_pdf() const {return prob_distr_;}
+
+  //: apply a color map to the probabilty values and
+  //  output a color point cloud as ascii
+  bool save_prob_ptset_color(std::string const& path) const;
+
+  // for debug purposes
+  bool load_images_and_cams(std::string const& image0_path, std::string const& cam0_path,
+                            std::string const& image1_path, std::string const& cam1_path)
+  {
+    return rip_.load_images_and_cams(image0_path, cam0_path, image1_path, cam1_path);
+  }
+
+ private:
+  void compute_byte();
+  pairwise_params params_;
+  bpgl_rectify_affine_image_pair rip_;
+  size_t ni_;
+  size_t nj_;
+  int min_disparity_;
+  int max_disparity_;
+  vil_image_view<vxl_byte> rect_bview0_;
+  vil_image_view<vxl_byte> rect_bview1_;
+  vil_image_view<bool> invalid_map_;
+  vil_image_view<bool> invalid_map_reverse_;
+  vil_image_view<float> disp_r_;
+  vil_image_view<float> disp_r_reverse_;
+  vil_image_view<float> height_map_;
+  vil_image_view<float> height_map_reverse_;
+  vil_image_view<float> prob_height_map_z_;
+  vil_image_view<float> prob_height_map_prob_;
+  vgl_pointset_3d<float> ptset_;
+  vgl_pointset_3d<float> ptset_reverse_;
+  bsta_histogram<float> prob_distr_;
+  vgl_pointset_3d<float> prob_ptset_;
+};
+
+#endif // bsgm_prob_pairwise_dsm_h_


### PR DESCRIPTION
BRL new features & bugfixes:
- brl/bsgm: align 3D pointsets (directly & using probability scalar)
- bugfix - correct test references for brl/bpgl/algo
- brl/bpgl/algo: rectify affine image pair using vpgl_equi_rectification
- bpgl_rectify_affine_image_pair python adaptor
- brl/bsgm: pairwise digital surface model from rectified images