### PR TITLE
Move VXL_USE_GEOTIFF option up to top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,9 @@ mark_as_advanced(VXL_BUILD_NONDEPRECATED_ONLY)
 CMAKE_DEPENDENT_OPTION(VXL_BUILD_CORE_PROBABILITY "Build VXL's probability libraries (Experimental)" ON
                        "VXL_BUILD_CORE_NUMERICS;NOT VXL_BUILD_CORE_NUMERICS_ONLY" OFF)
 
+option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" True)
+mark_as_advanced(VXL_USE_GEOTIFF)
+
 # Build the core vxl + support libraries
 add_subdirectory(vcl)
 add_subdirectory(v3p)

--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -159,8 +159,6 @@ if(TIFF_FOUND)
     file_formats/vil_tiff_header.cxx file_formats/vil_tiff_header.h
   )
 
-  option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" True)
-  mark_as_advanced(VXL_USE_GEOTIFF)
   include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)
   if(GEOTIFF_FOUND)
     if( VXL_USING_NATIVE_GEOTIFF )


### PR DESCRIPTION
Without VXL_USE_GEOTIFF set to true, the v3p geotiff library will not be built.

However, core/vil/CMakeLists.txt is processed after v3p by cmake, so it's too late to set VXL_USE_GEOTIFF there.

Prior to this change, vxl would fail to build on my mac without manually setting VXL_USE_GEOTIFF on the cmake command line.