### PR TITLE
Fix vpgl algo test failures

### DIFF
--- a/core/vpgl/algo/tests/test_affine_tensor_transfer.cxx
+++ b/core/vpgl/algo/tests/test_affine_tensor_transfer.cxx
@@ -383,6 +383,10 @@ static void test_affine_tensor_transfer()
   vpgl_affine_fundamental_matrix<double> aF12, aF13, vF12, vF13;
   bool good12 = aT.fmatrix_12(aF12);
   bool good13 = aT.fmatrix_13(aF13);
+
+  TEST("fmatrix_12 success", good12, true);
+  TEST("fmatrix_13 success", good13, true);
+
   vpgl_affine_rectification::compute_affine_f(&acam0, &acam1, vF12);
   vpgl_affine_rectification::compute_affine_f(&acam0, &acam2, vF13);
   vnl_matrix_fixed<double, 3,3> vFm12 = vF12.get_matrix();

--- a/core/vpgl/vpgl_affine_tri_focal_tensor.hxx
+++ b/core/vpgl/vpgl_affine_tri_focal_tensor.hxx
@@ -16,7 +16,7 @@ void vpgl_affine_tri_focal_tensor<Type>::set(const vpgl_affine_camera<Type>& c1,
 
 template<class Type>
 bool affine(vpgl_proj_camera<Type> const& pcam, vpgl_affine_camera<Type>& acam ){
-  Type tol = vgl_tolerance<Type>::position;
+  Type tol = Type(2)*vgl_tolerance<Type>::position;
   vnl_matrix_fixed<Type, 3, 4> M = pcam.get_matrix();
   // swap cols 3 and 4
   vnl_vector_fixed<Type, 3> col2 = M.get_column(2);
@@ -59,7 +59,7 @@ bool proj(vpgl_affine_camera<Type> const& acam, vpgl_proj_camera<Type>& pcam){
 template<class Type>
 bool affine(vpgl_fundamental_matrix<Type> const& F, vpgl_affine_fundamental_matrix<Type>& aF )
 {
-  Type tol = vgl_tolerance<Type>::position;
+  Type tol = Type(2)*vgl_tolerance<Type>::position;
   vnl_matrix_fixed<Type, 3, 3> M = F.get_matrix();
   Type max = M.absolute_value_max();
   if(max < tol)


### PR DESCRIPTION
The test_affine_tensor_transfer test in vpgl/algo was spuriously failing ~1% of the time due to some non-determinism inside vpgl_affine_camera_convert.  The failing tests were due to some very strict tolerances that are relaxed slightly by this changeset.