### PR TITLE
COMP: Missing file for install of vxl

### DIFF
--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -157,6 +157,7 @@ set( vcl_sources
   vcl_locale.h
   vcl_map.h
   vcl_memory.h
+  vcl_msvc_warnings.h
   vcl_numeric.h
   vcl_ostream.h
   vcl_queue.h


### PR DESCRIPTION
The vcl_msvc_warnings.h file was missing from the install
process.  This only affects MSVC installed builds.