### PR TITLE
rational cam print & contrib update

### DIFF
--- a/contrib/brl/bpro/bprb/bprb_batch_process_manager.h
+++ b/contrib/brl/bpro/bprb/bprb_batch_process_manager.h
@@ -79,6 +79,9 @@ class bprb_batch_process_manager : public bprb_process_manager<bprb_batch_proces
   //: set verbose off
   bool not_verbose() {verbose_ = false; return verbose_;}
 
+  //: return current verbosity
+  bool get_verbose() {return verbose_;}
+
   //: Debug purposes
   void print_db();
 

--- a/contrib/brl/bpro/bpro_batch/bpro_batch.cxx
+++ b/contrib/brl/bpro/bpro_batch/bpro_batch.cxx
@@ -45,6 +45,7 @@ static PyObject *run_process(PyObject *self, PyObject *args);
 static PyObject *finish_process(PyObject *self, PyObject *args);
 static PyObject *verbose(PyObject *self, PyObject *args);
 static PyObject *not_verbose(PyObject *self, PyObject *args);
+static PyObject *get_verbose(PyObject *self, PyObject *args);
 static PyObject *commit_output(PyObject *self, PyObject *args);
 static PyObject *set_input_from_db(PyObject* self, PyObject *args);
 static PyObject *remove_data(PyObject *self, PyObject *args);
@@ -551,6 +552,12 @@ PyObject *not_verbose(PyObject * /*self*/, PyObject * /*args*/)
 {
   bool result = bprb_batch_process_manager::instance()->not_verbose();
   verbose_state = result;
+  return Py_BuildValue("b", result);
+}
+
+PyObject *get_verbose(PyObject * /*self*/, PyObject * /*args*/)
+{
+  bool result = bprb_batch_process_manager::instance()->get_verbose();
   return Py_BuildValue("b", result);
 }
 

--- a/contrib/brl/bpro/bpro_batch/bpro_defs.h
+++ b/contrib/brl/bpro/bpro_batch/bpro_defs.h
@@ -28,6 +28,7 @@ py_funcs("run_process",run_process,METH_VARARGS,"run_process() run the current p
 py_funcs("finish_process",finish_process,METH_VARARGS,"finish_process() finish the current process"),
 py_funcs("verbose",verbose,METH_VARARGS,"verbose() print process info"),
 py_funcs("not_verbose",not_verbose,METH_VARARGS,"not_verbose() stop process info"),
+py_funcs("get_verbose",get_verbose,METH_VARARGS,"get_verbose() current process info verbosity"),
 py_funcs("commit_output",commit_output,METH_VARARGS,"commit_output(i) put output i in the database"),
 py_funcs("set_input_from_db",set_input_from_db,METH_VARARGS,"set_input_from_db(i, i) set input i of the current process to db id value"),
 py_funcs("remove_data",remove_data,METH_VARARGS,"remove_data(i) remove data with id from db"),

--- a/contrib/brl/bseg/brip/brip_roi.cxx
+++ b/contrib/brl/bseg/brip/brip_roi.cxx
@@ -60,19 +60,19 @@ vsol_box_2d_sptr brip_roi::clip_to_image_bounds(const vsol_box_2d_sptr& box)
   //clip to image bounds
   if (x0 < 0)
     x0 = 0;
-  if ((unsigned int)x0 >= n_image_cols_)
+  if (x0 >= (int)n_image_cols_)
     x0 = n_image_cols_-1;
   if (y0 < 0)
     y0 = 0;
-  if ((unsigned int)y0 >= n_image_rows_)
+  if (y0 >= (int)n_image_rows_)
     y0 = n_image_rows_-1;
   if (xm < 0)
     xm = 0;
-  if ((unsigned int)xm >= n_image_cols_)
+  if (xm >= (int)n_image_cols_)
     xm = n_image_cols_-1;
   if (ym < 0)
     ym = 0;
-  if ((unsigned int)ym >= n_image_rows_)
+  if (ym >= (int)n_image_rows_)
     ym = n_image_rows_-1;
   vsol_box_2d_sptr cbox = new vsol_box_2d();
   cbox->add_point(x0, y0);


### PR DESCRIPTION
CORE VPGL:
- minor change to vpgl_rational_camera print function, increasing precision of output

CONTRIB BRL:
- brip_roi - favor unsigned->int casting (likely safer, as the int values could be negative while the unsigned values are likely to be relatively small)
- adaptor process bugfix - allow rational_cam to have non-integer offset values during crop operation 
- adaptor process - get adaptor verbosity 