### PR TITLE
CONTRIB BRL: update isfm python adaptors

### DIFF
--- a/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/vpgl_adaptor.py
@@ -1361,40 +1361,56 @@ def isfm_rational_camera(trackfile, output_folder, pixel_radius):
 
 
 # geo-register a rational camera to group of geo-registered cameras
-def isfm_rational_camera_seed(track_file, out_folder, dem_folder, ll_lon=0.0, ll_lat=0.0, ur_lon=0.0, ur_lat=0.0, height_diff=20.0, pixel_radius=2.0, enforce_existing=False):
+def isfm_rational_camera_seed(track_file, out_folder,
+                              ll_lon, ll_lat, ll_elev,
+                              ur_lon, ur_lat, ur_elev,
+                              pixel_radius=2.0, enforce_existing=False,
+                              verbose = False,
+                              ):
     batch.init_process("vpglIsfmRationalCameraSeedProcess")
     batch.set_input_string(0, track_file)
     batch.set_input_string(1, out_folder)
-    batch.set_input_string(2, dem_folder)
-    batch.set_input_float(3, ll_lon)
-    batch.set_input_float(4, ll_lat)
-    batch.set_input_float(5, ur_lon)
-    batch.set_input_float(6, ur_lat)
-    batch.set_input_double(7, height_diff)
-    batch.set_input_float(8, pixel_radius)
+    batch.set_input_double(2, ll_lon)
+    batch.set_input_double(3, ll_lat)
+    batch.set_input_double(4, ll_elev)
+    batch.set_input_double(5, ur_lon)
+    batch.set_input_double(6, ur_lat)
+    batch.set_input_double(7, ur_elev)
+    batch.set_input_double(8, pixel_radius)
     batch.set_input_bool(9, enforce_existing)
+    batch.set_input_bool(10, verbose)
+
     status = batch.run_process()
     return status
 
 
-def isfm_rational_camera_with_init(track_file, dem_folder, ll_lon=0.0, ll_lat=0.0, ur_lon=0.0, ur_lat=0.0, height_diff=20.0, pixel_radius=2.0):
+def isfm_rational_camera_with_init(track_file,
+                                   ll_lon, ll_lat, ll_elev,
+                                   ur_lon, ur_lat, ur_elev,
+                                   pixel_radius=2.0,
+                                   verbose = False,
+                                   ):
     batch.init_process("vpglIsfmRationalCameraWithInitialProcess")
     batch.set_input_string(0, track_file)
-    batch.set_input_string(1, dem_folder)
-    batch.set_input_double(2, ll_lon)
-    batch.set_input_double(3, ll_lat)
+    batch.set_input_double(1, ll_lon)
+    batch.set_input_double(2, ll_lat)
+    batch.set_input_double(3, ll_elev)
     batch.set_input_double(4, ur_lon)
     batch.set_input_double(5, ur_lat)
-    batch.set_input_double(6, height_diff)
-    batch.set_input_float(7, pixel_radius)
+    batch.set_input_double(6, ur_elev)
+    batch.set_input_double(7, pixel_radius)
+    batch.set_input_bool(8, verbose)
+
     if not batch.run_process():
         return None, -1.0, -1.0
     (id, type) = batch.commit_output(0)
     cam = dbvalue(id, type)
     (id, type) = batch.commit_output(1)
-    error = batch.get_output_float(id)
+    error = batch.get_output_double(id)
+    batch.remove_data(id)
     (id, type) = batch.commit_output(2)
-    inliers = batch.get_output_float(id)
+    inliers = batch.get_output_double(id)
+    batch.remove_data(id)
     return cam, error, inliers
 
 

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_isfm_rational_camera_seed_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_isfm_rational_camera_seed_process.cxx
@@ -3,8 +3,6 @@
 #include <sstream>
 #include <fstream>
 #include <iomanip>
-#include <vil/vil_config.h>
-#if HAS_GEOTIFF
 #include <bprb/bprb_func_process.h>
 //:
 // \file
@@ -19,91 +17,64 @@
 //  Modifications
 //  Yi Dong, Aug, 2015, remove image dependency
 // \endverbatim
-
+//
 #include <bprb/bprb_parameters.h>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
-#include <vpgl/vpgl_rational_camera.h>
-#include <vpgl/vpgl_local_rational_camera.h>
+
 #include <vul/vul_file.h>
-#include <vul/vul_awk.h>
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_point_3d.h>
-#include <vpgl/file_formats/vpgl_geo_camera.h>
+#include <vgl/vgl_box_3d.h>
+#include <vgl/vgl_distance.h>
+#include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/vpgl_local_rational_camera.h>
 #include <vpgl/algo/vpgl_rational_adjust_onept.h>
 #include <vpgl/algo/vpgl_rational_adjust_multipt.h>
-#include <vul/vul_file_iterator.h>
-#include <vil/vil_load.h>
-#include <vil/vil_image_view.h>
-#include <vil/vil_crop.h>
-#include <vgl/vgl_distance.h>
-#include <vgl/vgl_intersection.h>
-#include <brad/brad_image_metadata.h>
+
 
 //: take a list of rational cameras and a list of 2-d image correspondences of the same 3-d point location
 //  find that 3-d location using back-projection and project that point back to images such that each camera can
 //  be corrected by adjusting its 2-d image offsets, in a RANSAC scheme
 namespace vpgl_isfm_rational_camera_seed_process_globals
 {
-  unsigned n_inputs_  = 10;
+  unsigned n_inputs_  = 11;
   unsigned n_outputs_ = 0;
-
-  //: find the min and max height in a given region from height map resources
-  bool find_min_max_height(double const& ll_lon, double const& ll_lat, double const& uu_lon, double const& uu_lat,
-                           std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                           double& min, double& max);
-  void crop_and_find_min_max(std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                             unsigned const& img_id, int const& i0, int const& j0, int const& crop_ni, int const& crop_nj,
-                             double& min, double& max);
-
-  //: return the overlapped region of multiple 2-d bounding box
-  vgl_box_2d<double> intersection(std::vector<vgl_box_2d<double> > const& boxes);
-
-  //: calculate the relative diameter used in back-projection
-  //  Relative diameter is used to define the initial search range in Amoeba algorithm (check vnl/algo/vnl_amoeba.h for more details)
-  //bool obtain_relative_diameter(std::vector<std::string> const& sat_res,
-  //                              double& relative_diameter);
-  bool obtain_relative_diameter(double const& ll_lon, double const& ll_lat,
-                                double const& ur_lon, double const& ur_lat,
-                                double& relative_diameter);
-
-  //: calculate the 3-d initial point from the overlapped region of satellite images
-  //bool initial_point_by_overlap_region(std::vector<std::string> const& sat_res,
-  //                                     std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-  //                                     vgl_point_3d<double>& init_pt,
-  //                                     double& zmin, double& zmax,
-  //                                     double const& height_diff = 20.0);
-  bool initial_point_by_overlap_region(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                                       std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-                                       vgl_point_3d<double>& init_pt,
-                                       double& zmin, double& zmax,
-                                       double const& height_diff = 20.0);
 }
+
 
 bool vpgl_isfm_rational_camera_seed_process_cons(bprb_func_process& pro)
 {
   using namespace vpgl_isfm_rational_camera_seed_process_globals;
 
-  std::vector<std::string> input_types(n_inputs_);
-  input_types[0] = "vcl_string"; // a file that lists the name to a input camera, file path of the satellite image on each line and i and j coordinate of the 3D world point
-                                 // format of the file:
-                                 // n  # number of correspondences for each frame,
-                                 // full_path_cam_name_1 i_11 j_11 i_12 j_12 ... i_1n j_1n
-                                 // full_path_cam_name_2 i_21 j_21 i_22 j_22 ... i_2n j_2n
-  input_types[1] = "vcl_string"; // output folder
-  input_types[2] = "vcl_string"; // aster dem folder
-  input_types[3] = "float";      // lower left longitude
-  input_types[4] = "float";      // lower right latitude
-  input_types[5] = "float";      // upper left longitude
-  input_types[6] = "float";      // upper right latitude
-  input_types[7] = "double";     // extra elevation value added onto height search space
-  input_types[8] = "float";      // pixel radius for the disagreement among inliers, e.g., 2 pixels
-  input_types[9] = "bool";       // option to enforce having at least 2 existing corrected cameras in output folder
+  // inputs
+  unsigned i = 0;
+  std::vector<std::string> input_types_(n_inputs_);
+  input_types_[i++] = "vcl_string"; // a file that lists the name to a input camera, file path of the satellite
+                                    // image on each line and i and j coordinate of the 3D world point
+                                    // format of the file:
+                                    // n  # number of correspondences for each frame,
+                                    // full_path_cam_name_1 i_11 j_11 i_12 j_12 ... i_1n j_1n
+                                    // full_path_cam_name_2 i_21 j_21 i_22 j_22 ... i_2n j_2n
+  input_types_[i++] = "vcl_string"; // output folder
+  input_types_[i++] = "double";     // lower left longitude
+  input_types_[i++] = "double";     // lower right latitude
+  input_types_[i++] = "double";     // lower right elevation (meters)
+  input_types_[i++] = "double";     // upper left longitude
+  input_types_[i++] = "double";     // upper right latitude
+  input_types_[i++] = "double";     // upper right elevation (meters)
+  input_types_[i++] = "double";     // pixel radius for the disagreement among inliers, e.g., 2 pixels
+  input_types_[i++] = "bool";       // option to enforce having at least 2 existing corrected cameras in output folder
+  input_types_[i++] = "bool";       // verbose
 
-  std::vector<std::string> output_types(n_outputs_);
-  return pro.set_input_types(input_types) && pro.set_output_types(output_types);
+  // outputs
+  std::vector<std::string> output_types_(n_outputs_);
+
+  // return
+  return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
 }
+
 
 //: execute the process
 bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
@@ -118,25 +89,54 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
   unsigned in_i = 0;
   std::string input_txt  = pro.get_input<std::string>(in_i++);
   std::string out_folder = pro.get_input<std::string>(in_i++);
-  std::string dem_folder = pro.get_input<std::string>(in_i++);
-  auto lower_left_lon  = pro.get_input<float>(in_i++);
-  auto lower_left_lat  = pro.get_input<float>(in_i++);
-  auto upper_right_lon = pro.get_input<float>(in_i++);
-  auto upper_right_lat = pro.get_input<float>(in_i++);
-  auto height_diff    = pro.get_input<double>(in_i++);
-  auto pixel_radius    = pro.get_input<float>(in_i++);
-  bool enforce_existing = pro.get_input<bool>(in_i++);
+  auto lower_left_lon    = pro.get_input<double>(in_i++);
+  auto lower_left_lat    = pro.get_input<double>(in_i++);
+  auto lower_left_elev   = pro.get_input<double>(in_i++);
+  auto upper_right_lon   = pro.get_input<double>(in_i++);
+  auto upper_right_lat   = pro.get_input<double>(in_i++);
+  auto upper_right_elev  = pro.get_input<double>(in_i++);
+  auto pixel_radius      = pro.get_input<double>(in_i++);
+  auto enforce_existing  = pro.get_input<bool>(in_i++);
+  auto verbose           = pro.get_input<bool>(in_i++);
 
   if (enforce_existing)
-    std::cout << "!!!!!!! enforce to have at least 2 existing images!\n";
+    std::cout << pro.name() << ": require more than 2 pre-existing corrected cameras" << std::endl;
   else
-    std::cout << "!!!!!!! DO NOT enforce to have at least 2 existing images!\n";
+    std::cout << pro.name() << ": DO NOT require pre-existing corrected cameras" << std::endl;
 
-  vgl_box_2d<double> overlap_region(lower_left_lon, upper_right_lon, lower_left_lat, upper_right_lat);
-  if (overlap_region.is_empty()) {
-    std::cerr << pro.name() << ": the pre-defined overlap region is empty!!\n";
+  // 3D region from inputs
+  vgl_box_3d<double> region_3d(lower_left_lon, lower_left_lat, lower_left_elev,
+                           upper_right_lon, upper_right_lat, upper_right_elev);
+  if (region_3d.is_empty()) {
+    std::cerr << pro.name() << ": invalid 3D extents" << std::endl;
     return false;
   }
+
+  // min/max elevation
+  double zmin = region_3d.min_z();
+  double zmax = region_3d.max_z();
+
+  // initial guess point (bottom center of 3D region)
+  vgl_point_3d<double> initial_pt(region_3d.centroid_x(), region_3d.centroid_y(), region_3d.min_z());
+
+  // searching diameter
+  double width  = region_3d.width();
+  double height = region_3d.height();
+  double diagonal = std::sqrt(width*width + height*height);
+
+  double relative_diameter;
+  if (region_3d.centroid_x() > region_3d.centroid_y())
+    relative_diameter = 0.5*diagonal/region_3d.centroid_y();
+  else
+    relative_diameter = 0.5*diagonal/region_3d.centroid_x();
+
+  // verbose report
+  if (verbose) {
+    std::cout << "initial 3D point for back projection: " << initial_pt << "\n"
+              << "elevation range: [" << zmin << ',' << zmax << ']' << "\n"
+              << "relative diameter: " << relative_diameter << std::endl;
+  }
+
   // read the track file
   std::ifstream ifs(input_txt.c_str());
   if (!ifs) {
@@ -161,9 +161,6 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
     if (cam_file.size() < 2)
       break;
     std::string out_cam_file = out_folder + vul_file::strip_extension(vul_file::basename(cam_file)) + "_local_corrected.rpb";
-    std::cout << "reading camera: " << cam_file << std::endl;
-    std::cout << "output camera: " << out_cam_file << std::endl;
-
     std::vector<vgl_point_2d<double> > corrs_frame;
     for (unsigned ii = 0; ii < n; ii++) {
       double i, j;
@@ -178,36 +175,17 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
   ifs.close();
 
   // print out
-  for (unsigned i = 0; i < in_cam_files.size(); i++)
-  {
-    std::cout << "============ " << i << " ============" << std::endl;
-    std::cout << in_cam_files[i] << std::endl;
-    std::cout << out_cam_files[i] << std::endl;
-    for (unsigned k = 0; k < n; k++) {
-      std::cout << '[' << corrs[i][k].x() << ',' << corrs[i][k].y() << "] ";
+  if (verbose) {
+    for (unsigned i = 0; i < in_cam_files.size(); i++)
+    {
+      std::cout << "============ " << i << " ============" << std::endl;
+      std::cout << in_cam_files[i] << std::endl;
+      std::cout << out_cam_files[i] << std::endl;
+      for (unsigned k = 0; k < n; k++) {
+        std::cout << '[' << corrs[i][k].x() << ',' << corrs[i][k].y() << "] ";
+      }
+      std::cout << '\n' << std::flush;
     }
-    std::cout << '\n' << std::flush;
-  }
-
-  // load aster dem resources
-  std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> > dem_infos;
-  std::string file_glob = dem_folder + "/*.tif";
-  for (vul_file_iterator fn = file_glob.c_str(); fn; ++fn)
-  {
-    std::string filename = fn();
-    vil_image_view_base_sptr img_r = vil_load(filename.c_str());
-    vpgl_geo_camera* cam;
-    vpgl_lvcs_sptr lvcs_dummy = new vpgl_lvcs;
-    vil_image_resource_sptr img_res = vil_load_image_resource(filename.c_str());
-    if (!vpgl_geo_camera::init_geo_camera(img_res, lvcs_dummy, cam)) {
-      std::cerr << pro.name() << ": Given height map " << filename << " is NOT a GeoTiff!\n";
-      return false;
-    }
-    dem_infos.emplace_back(img_r, cam);
-  }
-  if (dem_infos.empty()) {
-    std::cerr << pro.name() << ": No image in the folder: " << dem_folder << std::endl;
-    return false;
   }
 
   // define camera weight
@@ -216,6 +194,7 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
   std::vector<vpgl_local_rational_camera<double> > local_cams;
   std::vector<std::vector<vgl_point_2d<double> > > new_corrs;
   unsigned cnt_exist = 0;
+
   // now determine which cameras already exist
   for (unsigned i = 0; i < out_cam_files.size(); i++)
   {
@@ -250,6 +229,7 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
     std::cerr << pro.name() << ": enforcing condition to have at least 2 pre-existing corrected cameras! EXITING since there is: " << cnt_exist << " cameras.\n";
     return false;
   }
+
   // re-distribute weight parameters if there is no corrected camera
   if (cnt_exist == 0) {
     cam_weights.assign(cam_weights.size(), 1.0f/cams.size());
@@ -260,32 +240,16 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
       return false;
     }
   }
-  std::cout << "Assigned camera weights: \n";
-  for (unsigned i = 0; i < cams.size(); i++)
-    std::cout << in_cam_files[i] << " weight: " << cam_weights[i] << std::endl;
-  std::cout << "camera size: " << cams.size() << " corrs size: " << new_corrs.size() << std::endl;
-  std::cout.flush();
 
-  // calculate the initial guessing point
-  vgl_point_3d<double> initial_pt;
-  double zmin, zmax;
-  if (!initial_point_by_overlap_region(lower_left_lon, lower_left_lat, upper_right_lon, upper_right_lat, dem_infos, initial_pt, zmin, zmax, height_diff)) {
-    std::cerr << pro.name() << ": Evaluating initial point failed!\n";
-    return false;
-  }
-
-  // calculate the relative diameter given the fact that all correspondence must be inside the overlapped region of all cameras
-  double relative_diameter;
-  if (!obtain_relative_diameter(lower_left_lon, lower_left_lat, upper_right_lon, upper_right_lat, relative_diameter)) {
-    std::cerr << pro.name() << ": Evaluating relative diameter failed!\n";
-    return false;
+  if (verbose) {
+    std::cout << cams.size() << " cameras, " << new_corrs.size() << " correspondences" << "\n";
+    std::cout << "Assigned camera weights: \n";
+    for (unsigned i = 0; i < cams.size(); i++)
+      std::cout << "--" << in_cam_files[i] << " weight: " << cam_weights[i] << "\n";
+    std::cout.flush();
   }
 
   // adjust using each correspondence and save the offsets
-  std::cout << "Executing adjust image offsets..." << std::endl;
-  std::cout << "initial 3-d point for back projection: " << initial_pt << std::endl;
-  std::cout << "height value (using " << height_diff << " meter height difference): [" << zmin << ',' << zmax << ']' << std::endl;
-  std::cout << "relative diameter: " << relative_diameter << std::endl;
   std::vector<std::vector<vgl_vector_2d<double> > > cam_trans;
   std::vector<unsigned> corrs_ids;
   for (unsigned i = 0; i < n; i++)
@@ -293,48 +257,33 @@ bool vpgl_isfm_rational_camera_seed_process(bprb_func_process& pro)
     // re-arrange the correspondence
     std::vector<vgl_point_2d<double> > corrs_i;
     corrs_i.reserve(new_corrs.size());
-for (auto & new_corr : new_corrs)
+    for (auto & new_corr : new_corrs)
       corrs_i.push_back(new_corr[i]);
     std::vector<vgl_vector_2d<double> > cam_trans_i;
     vgl_point_3d<double> intersection;
     if (!vpgl_rational_adjust_onept::adjust_with_weights(cams, cam_weights, corrs_i, initial_pt, zmin, zmax, cam_trans_i, intersection, relative_diameter))
     {
+      // if (verbose) {
+      //   std::cout << "correspondence adjustment failed for correspondence: " << std::endl;
+      //   for (auto & ii : corrs_i)
+      //     std::cout << "[" << ii.x() << "," << ii.y() << "]\t";
+      //   std::cout << '\n';
+      // }
       continue;
-#if 1
-      std::cout << "correspondence adjustment failed for correspondence: " << std::endl;
-      for (auto & ii : corrs_i)
-        std::cout << "[" << ii.x() << "," << ii.y() << "]\t";
-      std::cout << '\n';
-#endif
     }
     cam_trans.push_back(cam_trans_i);
     corrs_ids.push_back(i);
-#if 0
-    std::cout << i << " --> correspondence: ";
-    for (unsigned i = 0; i < corrs_i.size(); i++) {
-        std::cout << "[" << corrs_i[i].x() << "," << corrs_i[i].y() << "]\t";
-    }
-    std::cout << " --> project to 3D intersection point: [" << std::setprecision(12) << intersection.y()
-                                                         << "," << std::setprecision(12) << intersection.x()
-                                                         << "," << std::setprecision(12) << intersection.z()
-                                                         << "], giving offset: ";
-    std::cout << " --> camera translation: ";
-    for (unsigned i = 0; i < cam_trans_i.size(); i++) {
-      std::cout << "[" << cam_trans_i[i].x() << "," << cam_trans_i[i].y() << "]\t";
-    }
-    std::cout << '\n';
-#endif
   }
-
-  std::cout << "out of " << n << " correspondences " << cam_trans.size() << " of them back-projected to 3-d world point successfully:";
-  for (unsigned int corrs_id : corrs_ids)
-    std::cout << ' ' << corrs_id;
-  std::cout << '\n';
 
   if (!cam_trans.size()) {
-    std::cout << "out of " << n << " correspondences " << cam_trans.size() << " of them yielded corrections! exit without any correction!\n";
+    std::cerr << pro.name() << ": No valid corrections" << std::endl;
     return false;
   }
+
+  std::cout << cam_trans.size() << " of " << n << " correspondences back-projected successfully:\n";
+  for (unsigned int corrs_id : corrs_ids)
+    std::cout << ' ' << corrs_id;
+  std::cout << std::endl;
 
   // find the inliers
   std::vector<unsigned> inlier_cnts(cam_trans.size(), 0);
@@ -367,29 +316,31 @@ for (auto & new_corr : new_corrs)
       max_i = i;
     }
   }
-  std::cout << "out of " << cam_trans.size() << " valid correspondences, " << max << " of them yield constant translations using " << pixel_radius << " pixel radius" << std::endl;
+
   // check whether the inliers count is sufficient
   double inlier_ratio = (double)max / cam_trans.size();
   if (inlier_ratio < 0.1) {
-    std::cout << pro.name() << ": less than 10% of correspondence yield constant translations due to bad correspondence, correction failed" << std::endl;
+    std::cerr << pro.name() << ": correction failed (less than 10%% of correspondence yield constant translation)" << std::endl;
     return false;
   }
 
-#if 1
-  std::cout << "correspondence that provides inliers: " << std::endl;
+  std::cout << max << " of " << cam_trans.size() << " valid correspondences yield constant translation for " << pixel_radius << " pixel radius" << std::endl;
   for (unsigned int j : inliers[max_i])
-    std::cout << j << ' ';
-  std::cout << '\n';
-#endif
+    std::cout << ' ' << j;
+  std::cout << std::endl;
 
   // use the correspondence with the most number of inliers to correct the cameras
-  std::cout << "correction offset: " << std::endl;
-  for (unsigned k = 0; k < cams.size(); k++)
-    std::cout << "camera " << k << " --> offset_u: " << cam_trans[max_i][k].x() << " offset_v: " << cam_trans[max_i][k].y() << std::endl;
+  std::cout << "\nCOARSE SEED TRANSLATION\n";
+  for (unsigned k = 0; k < cams.size(); k++) {
+    std::cout << "  camera " << k << " [u,v] --> ["
+              << cam_trans[max_i][k].x() << ","
+              << cam_trans[max_i][k].y() << "]\n";
+  }
+  std::cout << std::endl;
+
   for (unsigned k = 0; k < cams.size(); k++) {
     double u_off, v_off;
     cams[k].image_offset(u_off, v_off);
-    local_cams[k].set_image_offset(u_off + cam_trans[max_i][k].x(), v_off + cam_trans[max_i][k].y());
     cams[k].set_image_offset(u_off + cam_trans[max_i][k].x(), v_off + cam_trans[max_i][k].y());
   }
 
@@ -409,13 +360,13 @@ for (auto & new_corr : new_corrs)
     return false;
   }
 
-#if 0
-  std::cout << " after refinement: \n";
-  for (unsigned i = 0; i < intersections.size(); i++)
-    std::cout << "after adjustment 3D intersection point: " << intersections[i].y() << "," << intersections[i].x()
-                                                           << "," << intersections[i].z()
-                                                           << std::endl;
-#endif
+  std::cout << "\nREFINED SEED TRANSLATION\n";
+  for (unsigned k = 0; k < cams.size(); k++) {
+    std::cout << "  camera " << k << " [u,v] --> ["
+              << cam_trans[max_i][k].x() + cam_trans_inliers[k].x() << ","
+              << cam_trans[max_i][k].y() + cam_trans_inliers[k].y() << "]\n";
+  }
+  std::cout << std::endl;
 
   // further correction using refined offset values
   for (unsigned i = 0; i < cams.size(); i++)
@@ -427,256 +378,3 @@ for (auto & new_corr : new_corrs)
   }
   return true;
 }
-
-#if 0
-bool vpgl_isfm_rational_camera_seed_process_globals::initial_point_by_overlap_region(std::vector<std::string> const& sat_res,
-                                                                                     std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-                                                                                     vgl_point_3d<double>& init_pt,
-                                                                                     double& zmin, double& zmax, double const& height_diff)
-{
-  // obtain the overlapped region
-  std::vector<vgl_box_2d<double> > img_footprints;
-  for (std::vector<std::string>::const_iterator vit = sat_res.begin(); vit != sat_res.end(); ++vit)
-  {
-    brad_image_metadata meta(*vit);
-    double ll_lon = meta.lower_left_.x();
-    double ll_lat = meta.lower_left_.y();
-    double ur_lon = meta.upper_right_.x();
-    double ur_lat = meta.upper_right_.y();
-    vgl_box_2d<double> img_box(ll_lon, ur_lon, ll_lat, ur_lat);
-    img_footprints.push_back(img_box);
-  }
-  vgl_box_2d<double> overlap_region = vpgl_isfm_rational_camera_seed_process_globals::intersection(img_footprints);
-  if (overlap_region.is_empty())
-    return false;
-  // find the min and max elevation value of the overlap region
-  double min_elev = 10000.0, max_elev = -10000.0;
-  if (!vpgl_isfm_rational_camera_seed_process_globals::find_min_max_height(overlap_region.min_x(), overlap_region.min_y(), overlap_region.max_x(), overlap_region.max_y(),
-                                                                           dem_infos, min_elev, max_elev))
-    return false;
-  zmin = min_elev - 10 - height_diff;
-  zmax = max_elev + 10 + height_diff;
-  init_pt.set(overlap_region.centroid_x(), overlap_region.centroid_y(), zmin);
-  return true;
-}
-#endif
-
-bool vpgl_isfm_rational_camera_seed_process_globals::initial_point_by_overlap_region(double const& ll_lon, double const& ll_lat,
-                                                                                     double const& ur_lon, double const& ur_lat,
-                                                                                     std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-                                                                                     vgl_point_3d<double>& init_pt,
-                                                                                     double& zmin, double& zmax, double const& height_diff)
-{
-  vgl_box_2d<double> overlap_region(ll_lon, ur_lon, ll_lat, ur_lat);
-  if (overlap_region.is_empty())
-    return false;
-  // find the min and max elevation value of the overlap region
-  double min_elev = 10000.0, max_elev = -10000.0;
-  if (!vpgl_isfm_rational_camera_seed_process_globals::find_min_max_height(overlap_region.min_x(), overlap_region.min_y(), overlap_region.max_x(), overlap_region.max_y(),
-                                                                          dem_infos, min_elev, max_elev))
-    return false;
-  zmin = min_elev - 10 - height_diff;
-  zmax = max_elev + 10 + height_diff;
-  init_pt.set(overlap_region.centroid_x(), overlap_region.centroid_y(), zmin);
-  return true;
-}
-
-#if 0
-bool vpgl_isfm_rational_camera_seed_process_globals::obtain_relative_diameter(std::vector<std::string> const& sat_res,
-                                                                              double& relative_diameter)
-{
-  relative_diameter = 1.0;
-  // obtain the overlap region
-  std::vector<vgl_box_2d<double> > img_footprints;
-  for (std::vector<std::string>::const_iterator vit = sat_res.begin(); vit != sat_res.end(); ++vit)
-  {
-    brad_image_metadata meta(*vit);
-    double ll_lon = meta.lower_left_.x();
-    double ll_lat = meta.lower_left_.y();
-    double ur_lon = meta.upper_right_.x();
-    double ur_lat = meta.upper_right_.y();
-    vgl_box_2d<double> img_box(ll_lon, ur_lon, ll_lat, ur_lat);
-    img_footprints.push_back(img_box);
-  }
-  vgl_box_2d<double> overlap_region = vpgl_isfm_rational_camera_seed_process_globals::intersection(img_footprints);
-  if (overlap_region.is_empty())
-    return false;
-  double width  = overlap_region.width();
-  double height = overlap_region.height();
-  // calculate the diameter by the diagonal
-  double diagonal = std::sqrt(width*width + height*height);
-  if (overlap_region.centroid_x() > overlap_region.centroid_y())
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_y();
-  else
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_x();
-
-  return true;
-}
-#endif
-
-bool vpgl_isfm_rational_camera_seed_process_globals::obtain_relative_diameter(double const& ll_lon, double const& ll_lat,
-                                                                              double const& ur_lon, double const& ur_lat,
-                                                                              double& relative_diameter)
-{
-  vgl_box_2d<double> overlap_region(ll_lon, ur_lon, ll_lat, ur_lat);
-  if (overlap_region.is_empty())
-    return false;
-  double width  = overlap_region.width();
-  double height = overlap_region.height();
-  // calculate the diameter by the diagonal
-  double diagonal = std::sqrt(width*width + height*height);
-  if (overlap_region.centroid_x() > overlap_region.centroid_y())
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_y();
-  else
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_x();
-  return true;
-}
-
-vgl_box_2d<double> vpgl_isfm_rational_camera_seed_process_globals::intersection(std::vector<vgl_box_2d<double> > const& boxes)
-{
-  if (boxes.size() == 2) {
-    return vgl_intersection(boxes[0], boxes[1]);
-  }
-  std::vector<vgl_box_2d<double> > new_boxes;
-  vgl_box_2d<double> box = vgl_intersection(boxes[0], boxes[1]);
-  if (box.is_empty())
-    return box;
-  new_boxes.push_back(box);
-  for (unsigned i = 2; i < boxes.size(); i++)
-    new_boxes.push_back(boxes[i]);
-  return vpgl_isfm_rational_camera_seed_process_globals::intersection(new_boxes);
-}
-
-bool vpgl_isfm_rational_camera_seed_process_globals::find_min_max_height(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                                                                         std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                                                                         double& min, double& max)
-{
-  // find the corner points
-  std::vector<std::pair<unsigned, std::pair<int, int> > > corners;
-  std::vector<vgl_point_2d<double> > pts;
-  pts.emplace_back(ll_lon, ur_lat);
-  pts.emplace_back(ur_lon, ll_lat);
-  pts.emplace_back(ll_lon, ll_lat);
-  pts.emplace_back(ur_lon, ur_lat);
-  for (auto & pt : pts)
-  {
-    // find the image
-    for (unsigned j = 0; j < (unsigned)infos.size(); j++)
-    {
-      double u, v;
-      infos[j].second->global_to_img(pt.x(), pt.y(), 0, u, v);
-      int uu = (int)std::floor(u+0.5);
-      int vv = (int)std::floor(v+0.5);
-      if (uu < 0 || vv < 0 || uu >= (int)infos[j].first->ni() || vv >= (int)infos[j].first->nj())
-        continue;
-      std::pair<unsigned, std::pair<int, int> > pp(j, std::pair<int, int>(uu, vv));
-      corners.push_back(pp);
-      break;
-    }
-  }
-  if (corners.size() != 4) {
-    std::cerr << "Cannot locate all 4 corners among given DEM tiles!\n";
-    return false;
-  }
-  // case 1 all corners are in the same image
-  if (corners[0].first == corners[1].first) {
-    // crop the image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = corners[1].second.first-corners[0].second.first+1;
-    int crop_nj = corners[1].second.second-corners[0].second.second+1;
-    vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 2: two corners are in the same image
-  if (corners[0].first == corners[2].first && corners[1].first == corners[3].first) {
-    // crop the first image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = infos[corners[0].first].first->ni() - corners[0].second.first;
-    int crop_nj = corners[2].second.second-corners[0].second.second+1;
-    vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-    // crop the second image
-    i0 = 0;
-    j0 = corners[3].second.second;
-    crop_ni = corners[3].second.first + 1;
-    crop_nj = corners[1].second.second-corners[3].second.second+1;
-    vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 3: two corners are in the same image
-  if (corners[0].first == corners[3].first && corners[1].first == corners[2].first) {
-    // crop the first image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = corners[3].second.first - corners[0].second.first + 1;
-    int crop_nj = infos[corners[0].first].first->nj() - corners[0].second.second;
-    vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-    // crop the second image
-    i0 = corners[2].second.first;
-    j0 = 0;
-    crop_ni = corners[1].second.first - corners[2].second.first + 1;
-    crop_nj = corners[2].second.second + 1;
-    vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 4: all corners are in a different image
-  // crop the first image, image of corner 0
-  int i0 = corners[0].second.first;
-  int j0 = corners[0].second.second;
-  int crop_ni = infos[corners[0].first].first->ni() - corners[0].second.first;
-  int crop_nj = infos[corners[0].first].first->nj() - corners[0].second.second;
-  vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the second image, image of corner 1
-  i0 = 0;
-  j0 = 0;
-  crop_ni = corners[1].second.first + 1;
-  crop_nj = corners[1].second.second + 1;
-  vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the third image, image of corner 2
-  i0 = corners[2].second.first;
-  j0 = 0;
-  crop_ni = infos[corners[2].first].first->ni() - corners[2].second.first;
-  crop_nj = corners[2].second.second + 1;
-  vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[2].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the fourth image, image of corner 3
-  i0 = 0;
-  j0 = corners[3].second.second;
-  crop_ni = corners[3].second.first + 1;
-  crop_nj = infos[corners[3].first].first->nj() - corners[3].second.second;
-  vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(infos, corners[3].first, i0, j0, crop_ni, crop_nj, min, max);
-  return true;
-}
-
-void vpgl_isfm_rational_camera_seed_process_globals::crop_and_find_min_max(std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                                                                           unsigned const& img_id, int const& i0, int const& j0, int const& crop_ni, int const& crop_nj,
-                                                                           double& min, double& max)
-{
-  if (auto* img = dynamic_cast<vil_image_view<vxl_int_16>*>(infos[img_id].first.ptr()))
-  {
-    vil_image_view<vxl_int_16> img_crop = vil_crop(*img, i0, crop_ni, j0, crop_nj);
-    for (unsigned ii = 0; ii < img_crop.ni(); ii++) {
-      for (unsigned jj = 0; jj < img_crop.nj(); jj++) {
-        if (min > img_crop(ii, jj)) min = img_crop(ii,jj);
-        if (max < img_crop(ii, jj)) max = img_crop(ii,jj);
-      }
-    }
-  }
-  else if (auto* img = dynamic_cast<vil_image_view<float>*>(infos[img_id].first.ptr()))
-  {
-    vil_image_view<float> img_crop = vil_crop(*img, i0, crop_ni, j0, crop_nj);
-    for (unsigned ii = 0; ii < img_crop.ni(); ii++) {
-      for (unsigned jj = 0; jj < img_crop.nj(); jj++) {
-        if (min > img_crop(ii, jj)) min = img_crop(ii,jj);
-        if (max < img_crop(ii, jj)) max = img_crop(ii,jj);
-      }
-    }
-  }
-  return;
-}
-#endif

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_isfm_rational_camera_with_initial_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_isfm_rational_camera_with_initial_process.cxx
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
-#include <vil/vil_config.h>
-#if HAS_GEOTIFF
 #include <bprb/bprb_func_process.h>
 //:
 // \file
@@ -25,71 +23,51 @@
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
-#include <vpgl/vpgl_rational_camera.h>
-#include <vpgl/vpgl_local_rational_camera.h>
+
+#include <vul/vul_file.h>
 #include <vgl/vgl_point_2d.h>
 #include <vgl/vgl_point_3d.h>
-#include <vpgl/file_formats/vpgl_geo_camera.h>
+#include <vgl/vgl_box_3d.h>
+#include <vpgl/vpgl_rational_camera.h>
+#include <vpgl/vpgl_local_rational_camera.h>
 #include <vpgl/algo/vpgl_rational_adjust_onept.h>
 #include <vpgl/algo/vpgl_rational_adjust_multipt.h>
-#include <vul/vul_file_iterator.h>
-#include <vil/vil_load.h>
-#include <vil/vil_image_view.h>
-#include <vil/vil_crop.h>
-#include <vgl/vgl_distance.h>
-#include <vgl/vgl_intersection.h>
-#include <vul/vul_file.h>
-#include <brad/brad_image_metadata.h>
+
 
 namespace vpgl_isfm_rational_camera_with_initial_process_globals
 {
-  unsigned n_inputs_  = 8;
+  unsigned n_inputs_  = 9;
   unsigned n_outputs_ = 3;
-
-  //: find the min and max height in a given region from height map resources
-  bool find_min_max_height(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                           std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                           double& min, double& max);
-  void crop_and_find_min_max(std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                             unsigned const& img_id, int const& i0, int const& j0, int const& crop_ni, int const& crop_nj,
-                             double& min, double& max);
-
-  //: return the overlapped region of multiple 2-d bounding box
-  vgl_box_2d<double> intersection(std::vector<vgl_box_2d<double> > const& boxes);
-
-  //: calculate the relative diameter used in back-projection
-  //  Relative diameter is used to define the initial search range in Amoeba algorithm (check vnl/algo/vnl_amoeba.h for more details)
-  bool obtain_relative_diameter(double const& ll_lon, double const& ll_lat,
-                                double const& ur_lon, double const& ur_lat,
-                                double& relative_diameter);
-
-  //: calculate the 3-d initial point from the overlapped region of satellite images
-  bool initial_point_by_overlap_region(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                                       std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-                                       vgl_point_3d<double>& init_pt,
-                                       double& zmin, double& zmax,
-                                       double const& height_diff = 20.0);
 }
+
 
 bool vpgl_isfm_rational_camera_with_initial_process_cons(bprb_func_process& pro)
 {
   using namespace vpgl_isfm_rational_camera_with_initial_process_globals;
+
+  // inputs
+  unsigned i = 0;
   std::vector<std::string> input_types_(n_inputs_);
-  input_types_[0] = "vcl_string";  // track file
-  input_types_[1] = "vcl_string";  // ASTER DEM height map folder
-  input_types_[2] = "double";      // lower left longitude
-  input_types_[3] = "double";      // lower right latitude
-  input_types_[4] = "double";      // upper left longitude
-  input_types_[5] = "double";      // upper right latitude
-  input_types_[6] = "double";      // extra elevation value added onto height search space
-  input_types_[7] = "float";       // radius in pixels for the disagreement among inliers, e.g. 2 pixels
+  input_types_[i++] = "vcl_string"; // track file
+  input_types_[i++] = "double";     // lower left longitude
+  input_types_[i++] = "double";     // lower right latitude
+  input_types_[i++] = "double";     // lower right elevation (meters)
+  input_types_[i++] = "double";     // upper left longitude
+  input_types_[i++] = "double";     // upper right latitude
+  input_types_[i++] = "double";     // upper right elevation (meters)
+  input_types_[i++] = "double";     // radius in pixels for the disagreement among inliers, e.g. 2 pixels
+  input_types_[i++] = "bool";       // verbose
+
+  // outputs
+  i = 0;
   std::vector<std::string> output_types_(n_outputs_);
-  output_types_[0] = "vpgl_camera_double_sptr";  // corrected camera
-  output_types_[1] = "float";                    // projection error
-  output_types_[2] = "float";                    // inlier in percentage
+  output_types_[i++] = "vpgl_camera_double_sptr";   // corrected camera
+  output_types_[i++] = "double";                    // projection error
+  output_types_[i++] = "double";                    // inlier in percentage
 
   return pro.set_input_types(input_types_) && pro.set_output_types(output_types_);
 }
+
 
 bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
 {
@@ -100,16 +78,52 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
     std::cerr << pro.name() << ": Wrong inputs" << std::endl;
     return false;
   }
+
   // get the inputs
   unsigned in_i = 0;
-  std::string trackfile   = pro.get_input<std::string>(in_i++);
-  std::string dem_folder  = pro.get_input<std::string>(in_i++);
-  auto lower_left_lon  = pro.get_input<double>(in_i++);
-  auto lower_left_lat  = pro.get_input<double>(in_i++);
-  auto upper_right_lon = pro.get_input<double>(in_i++);
-  auto upper_right_lat = pro.get_input<double>(in_i++);
-  auto height_diff     = pro.get_input<double>(in_i++);
-  auto pixel_radius     = pro.get_input<float>(in_i++);
+  std::string trackfile  = pro.get_input<std::string>(in_i++);
+  auto lower_left_lon    = pro.get_input<double>(in_i++);
+  auto lower_left_lat    = pro.get_input<double>(in_i++);
+  auto lower_left_elev   = pro.get_input<double>(in_i++);
+  auto upper_right_lon   = pro.get_input<double>(in_i++);
+  auto upper_right_lat   = pro.get_input<double>(in_i++);
+  auto upper_right_elev  = pro.get_input<double>(in_i++);
+  auto pixel_radius      = pro.get_input<double>(in_i++);
+  auto verbose           = pro.get_input<bool>(in_i++);
+
+  // 3D region from inputs
+  vgl_box_3d<double> region_3d(lower_left_lon, lower_left_lat, lower_left_elev,
+                           upper_right_lon, upper_right_lat, upper_right_elev);
+  if (region_3d.is_empty()) {
+    std::cerr << pro.name() << ": invalid 3D extents" << std::endl;
+    return false;
+  }
+
+  // min/max elevation
+  double zmin = region_3d.min_z();
+  double zmax = region_3d.max_z();
+
+  // initial guess point (bottom center of 3D region)
+  vgl_point_3d<double> initial_pt(region_3d.centroid_x(), region_3d.centroid_y(), region_3d.min_z());
+
+  // searching diameter
+  double width  = region_3d.width();
+  double height = region_3d.height();
+  double diagonal = std::sqrt(width*width + height*height);
+
+  double relative_diameter;
+  if (region_3d.centroid_x() > region_3d.centroid_y())
+    relative_diameter = 0.5*diagonal/region_3d.centroid_y();
+  else
+    relative_diameter = 0.5*diagonal/region_3d.centroid_x();
+
+  // verbose report
+  if (verbose) {
+    std::cout << "initial 3D point for back projection: " << initial_pt << "\n"
+              << "elevation range: [" << zmin << ',' << zmax << ']' << "\n"
+              << "relative diameter: " << relative_diameter << std::endl;
+  }
+
 
   // read the track file
   std::ifstream ifs(trackfile.c_str());
@@ -139,6 +153,7 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
       return false;
     }
   }
+
   // read tracks
   std::vector<std::vector<vgl_point_2d<double> > > tracks;
   std::vector<std::vector<int> > trackimgids;
@@ -162,9 +177,9 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
     tracks.push_back(pts);
   }
 
-  std::cout << "correcting camera: " << uncorrectedcam << std::endl;
-  std::cout << "number of tracks: " << n_track << std::endl;
-  std::cout << "number of seed cameras: " << n_seeds << std::endl;
+  std::cout << "correcting camera: " << uncorrectedcam << "\n"
+            << "  number of tracks = " << n_track << "\n"
+            << "  number of seed cameras = " << n_seeds << std::endl;
 
   // load all seed cameras
   std::vector<vpgl_local_rational_camera<double>*> lcams;
@@ -177,40 +192,10 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
     lcams.push_back(ratcam);
   }
 
-  // load aster dem resource
-  std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> > dem_infos;
-  std::string file_glob = dem_folder + "/*.tif";
-  for (vul_file_iterator fn = file_glob.c_str(); fn; ++fn)
-  {
-    std::string filename = fn();
-    vil_image_view_base_sptr img_r = vil_load(filename.c_str());
-    vpgl_geo_camera* cam;
-    vpgl_lvcs_sptr lvcs_dummy = new vpgl_lvcs;
-    vil_image_resource_sptr img_res = vil_load_image_resource(filename.c_str());
-    if (!vpgl_geo_camera::init_geo_camera(img_res, lvcs_dummy, cam)) {
-      std::cerr << pro.name() << ": Given height map " << filename << " is NOT a GeoTiff!\n";
-      return false;
-    }
-    dem_infos.emplace_back(img_r, cam);
-  }
-  if (dem_infos.empty()) {
-    std::cerr << pro.name() << ": No image in the folder: " << dem_folder << std::endl;
-    return false;
-  }
-
-  // define overlap region by input coordinates
-  vgl_box_2d<double> overlap_region(lower_left_lon, upper_right_lon, lower_left_lat, upper_right_lat);
-  if (overlap_region.is_empty()) {
-    std::cerr << pro.name() << ": Missing input search region!\n";
-    return false;
-  }
   // compute translations
   std::vector<vgl_vector_2d<double> > cam_trans;
   std::vector<vgl_point_3d<double> > reconstructed_pts;
   std::vector<vgl_point_2d<double> > img_points;
-  std::vector<vgl_point_3d<double> > init_pts;
-  std::vector<double> zmin_list;
-  std::vector<double> zmax_list;
   for (unsigned i = 0; i < n_track; i++)
   {
     std::vector<vgl_vector_2d<double> > cam_trans_i;
@@ -226,49 +211,32 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
       corrs.push_back(tracks[i][k]);
     }
 
-    // find the initial guess point
-    vgl_point_3d<double> initial_pt;
-    double zmin, zmax;
-    if (!initial_point_by_overlap_region(lower_left_lon, lower_left_lat, upper_right_lon, upper_right_lat, dem_infos, initial_pt, zmin, zmax, height_diff)) {
-      std::cerr << pro.name() << ": Evaluating initial point for correspondence " << i << " failed!\n";
-      return false;
-    }
-    // find the searching diameter
-    double relative_diameter;
-    if (!obtain_relative_diameter(lower_left_lon, lower_left_lat, upper_right_lon, upper_right_lat, relative_diameter)) {
-      std::cerr << pro.name() << ": Evaluating relative diameter for correspondence " << i << " failed!\n";
-      return false;
-    }
     // search for 3-d intersection
     vgl_point_3d<double> intersection;
     if (!vpgl_rational_adjust_onept::adjust_with_weights(cams, weights, corrs, initial_pt, zmin, zmax, cam_trans_i, intersection, relative_diameter)) {
+      // if (verbose) {
+      //   std::cout << "correspondence adjustment failed for: " << std::endl;
+      //   for (auto & corr : corrs)
+      //     std::cout << "[" << corr.x() << "," << corr.y() << "]\t";
+      //   std::cout << '\n';
+      // }
       continue;
-#if 1
-      std::cout << "correspondence adjustment failed for: " << std::endl;
-      for (auto & corr : corrs)
-        std::cout << "[" << corr.x() << "," << corr.y() << "]\t";
-      std::cout << '\n';
-#endif
     }
+
     img_points.push_back(currpts[i]);
     cam_trans.push_back(cam_trans_i[0]);
     reconstructed_pts.push_back(intersection);
-    init_pts.push_back(initial_pt);
-    zmin_list.push_back(zmin);
-    zmax_list.push_back(zmax);
   }
 
-#if 0
-  std::cout << " ================== back-projection ======================= " << std::endl;
-  for (unsigned k = 0; k < cam_trans.size(); k++) {
-    std::cout << "image point: [" << img_points[k].x() << ',' << img_points[k].y()
-             << "], initial pt: [" << init_pts[k].x() << ',' << init_pts[k].y() << ',' << init_pts[k].z()
-             << "], height range: [" << zmin_list[k] << ',' << zmax_list[k]
-             << "], world point: [" << std::setprecision(10) << reconstructed_pts[k].x() << ',' << std::setprecision(10) << reconstructed_pts[k].y() << ','
-             << std::setprecision(10) << reconstructed_pts[k].z()
-             << "], camera translations: " << cam_trans[k].x() << ',' << cam_trans[k].y() << ']' << std::endl;
-  }
-#endif
+  // if (verbose) {
+  //   std::cout << " ================== back-projection ======================= " << cam_trans.size() << std::endl;
+  //   for (unsigned k = 0; k < cam_trans.size(); k++) {
+  //     std::cout << "image: [" << img_points[k].x() << ',' << img_points[k].y() << "], "
+  //               << "world: [" << reconstructed_pts[k].x() << ',' << reconstructed_pts[k].y() << reconstructed_pts[k].z() << "], "
+  //               << "camera translation: " << cam_trans[k].x() << ',' << cam_trans[k].y() << "]" << std::endl
+  //               ;
+  //   }
+  // }
 
   // remove unrealistic trans
   std::vector<vgl_vector_2d<double> > cam_trans_new;
@@ -316,12 +284,12 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
     sum += cam_trans_new[k];
   sum /= (double)inliers[max_i].size();
 
-  std::cout << "camera: " << uncorrectedcam
-           << " out of " << n_track << " correspondences, inlier cnts using pixel radius: " << pixel_radius << ", "
-           << " number of valid translation: " << cam_trans_new.size()
-           << " inliers size: " << inliers[max_i].size() << "(" << max << ")"
-           << " average offset: " << sum
-           << std::endl;
+  std::cout << "camera: " << uncorrectedcam << "\n"
+            << "  " << n_track << " correspondences for " << pixel_radius << " pixel radius\n"
+            << "  " << cam_trans_new.size() << " valid translations, "
+                    << inliers[max_i].size() << " inliers (max = " << max << ")\n"
+            << "  " << sum << " final translation"
+            << std::endl;
 
   // evaluate the correction error and inlier percentage
   double error = 0.0;
@@ -336,198 +304,10 @@ bool vpgl_isfm_rational_camera_with_initial_process(bprb_func_process& pro)
   double u, v;
   cam->image_offset(u, v);
   cam->set_image_offset(u+sum.x(), v+sum.y());
-  std::cout << "Final Translation is: " << sum << std::endl;
 
   // generate output
   pro.set_output_val<vpgl_camera_double_sptr>(0, cam);
-  pro.set_output_val<float>(1, error);
-  pro.set_output_val<float>(2, inlierpercent);
+  pro.set_output_val<double>(1, error);
+  pro.set_output_val<double>(2, inlierpercent);
   return true;
 }
-
-bool vpgl_isfm_rational_camera_with_initial_process_globals::find_min_max_height(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                                                                                 std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                                                                                 double& min, double& max)
-{
-  // find the corner points
-  std::vector<std::pair<unsigned, std::pair<int, int> > > corners;
-  std::vector<vgl_point_2d<double> > pts;
-  pts.emplace_back(ll_lon, ur_lat);
-  pts.emplace_back(ur_lon, ll_lat);
-  pts.emplace_back(ll_lon, ll_lat);
-  pts.emplace_back(ur_lon, ur_lat);
-  for (auto & pt : pts)
-  {
-    // find the image
-    for (unsigned j = 0; j < (unsigned)infos.size(); j++)
-    {
-      double u, v;
-      infos[j].second->global_to_img(pt.x(), pt.y(), 0, u, v);
-      int uu = (int)std::floor(u+0.5);
-      int vv = (int)std::floor(v+0.5);
-      if (uu < 0 || vv < 0 || uu >= (int)infos[j].first->ni() || vv >= (int)infos[j].first->nj())
-        continue;
-      std::pair<unsigned, std::pair<int, int> > pp(j, std::pair<int, int>(uu, vv));
-      corners.push_back(pp);
-      break;
-    }
-  }
-  if (corners.size() != 4) {
-    std::cerr << "Cannot locate all 4 corners among given DEM tiles!\n";
-    return false;
-  }
-  // case 1 all corners are in the same image
-  if (corners[0].first == corners[1].first) {
-    // crop the image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = corners[1].second.first-corners[0].second.first+1;
-    int crop_nj = corners[1].second.second-corners[0].second.second+1;
-    vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 2: two corners are in the same image
-  if (corners[0].first == corners[2].first && corners[1].first == corners[3].first) {
-    // crop the first image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = infos[corners[0].first].first->ni() - corners[0].second.first;
-    int crop_nj = corners[2].second.second-corners[0].second.second+1;
-    vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-    // crop the second image
-    i0 = 0;
-    j0 = corners[3].second.second;
-    crop_ni = corners[3].second.first + 1;
-    crop_nj = corners[1].second.second-corners[3].second.second+1;
-    vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 3: two corners are in the same image
-  if (corners[0].first == corners[3].first && corners[1].first == corners[2].first) {
-    // crop the first image
-    int i0 = corners[0].second.first;
-    int j0 = corners[0].second.second;
-    int crop_ni = corners[3].second.first - corners[0].second.first + 1;
-    int crop_nj = infos[corners[0].first].first->nj() - corners[0].second.second;
-    vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-    // crop the second image
-    i0 = corners[2].second.first;
-    j0 = 0;
-    crop_ni = corners[1].second.first - corners[2].second.first + 1;
-    crop_nj = corners[2].second.second + 1;
-    vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-    return true;
-  }
-  // case 4: all corners are in a different image
-  // crop the first image, image of corner 0
-  int i0 = corners[0].second.first;
-  int j0 = corners[0].second.second;
-  int crop_ni = infos[corners[0].first].first->ni() - corners[0].second.first;
-  int crop_nj = infos[corners[0].first].first->nj() - corners[0].second.second;
-  vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[0].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the second image, image of corner 1
-  i0 = 0;
-  j0 = 0;
-  crop_ni = corners[1].second.first + 1;
-  crop_nj = corners[1].second.second + 1;
-  vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[1].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the third image, image of corner 2
-  i0 = corners[2].second.first;
-  j0 = 0;
-  crop_ni = infos[corners[2].first].first->ni() - corners[2].second.first;
-  crop_nj = corners[2].second.second + 1;
-  vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[2].first, i0, j0, crop_ni, crop_nj, min, max);
-
-  // crop the fourth image, image of corner 3
-  i0 = 0;
-  j0 = corners[3].second.second;
-  crop_ni = corners[3].second.first + 1;
-  crop_nj = infos[corners[3].first].first->nj() - corners[3].second.second;
-  vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(infos, corners[3].first, i0, j0, crop_ni, crop_nj, min, max);
-  return true;
-}
-
-void vpgl_isfm_rational_camera_with_initial_process_globals::crop_and_find_min_max(std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& infos,
-                                                                                   unsigned const& img_id, int const& i0, int const& j0, int const& crop_ni, int const& crop_nj,
-                                                                                   double& min, double& max)
-{
-  if (auto* img = dynamic_cast<vil_image_view<vxl_int_16>*>(infos[img_id].first.ptr()))
-  {
-    vil_image_view<vxl_int_16> img_crop = vil_crop(*img, i0, crop_ni, j0, crop_nj);
-    for (unsigned ii = 0; ii < img_crop.ni(); ii++) {
-      for (unsigned jj = 0; jj < img_crop.nj(); jj++) {
-        if (min > img_crop(ii, jj)) min = img_crop(ii,jj);
-        if (max < img_crop(ii, jj)) max = img_crop(ii,jj);
-      }
-    }
-  }
-  else if (auto* img = dynamic_cast<vil_image_view<float>*>(infos[img_id].first.ptr()))
-  {
-    vil_image_view<float> img_crop = vil_crop(*img, i0, crop_ni, j0, crop_nj);
-    for (unsigned ii = 0; ii < img_crop.ni(); ii++) {
-      for (unsigned jj = 0; jj < img_crop.nj(); jj++) {
-        if (min > img_crop(ii, jj)) min = img_crop(ii,jj);
-        if (max < img_crop(ii, jj)) max = img_crop(ii,jj);
-      }
-    }
-  }
-  return;
-}
-
-bool vpgl_isfm_rational_camera_with_initial_process_globals::initial_point_by_overlap_region(double const& ll_lon, double const& ll_lat, double const& ur_lon, double const& ur_lat,
-                                                                                             std::vector<std::pair<vil_image_view_base_sptr, vpgl_geo_camera*> >& dem_infos,
-                                                                                             vgl_point_3d<double>& init_pt,
-                                                                                             double& zmin, double& zmax,
-                                                                                             double const& height_diff)
-{
-  vgl_box_2d<double> overlap_region(ll_lon, ur_lon, ll_lat, ur_lat);
-  if (overlap_region.is_empty())
-    return false;
-  // find the min and max elevation value of the overlap region
-  double min_elev = 10000.0, max_elev = -10000.0;
-  if (!vpgl_isfm_rational_camera_with_initial_process_globals::find_min_max_height(overlap_region.min_x(), overlap_region.min_y(), overlap_region.max_x(), overlap_region.max_y(),
-                                                                                   dem_infos, min_elev, max_elev))
-    return false;
-  zmin = min_elev - 10 - height_diff;
-  zmax = max_elev + 10 + height_diff;
-  init_pt.set(overlap_region.centroid_x(), overlap_region.centroid_y(), zmin);
-  return true;
-}
-
-bool vpgl_isfm_rational_camera_with_initial_process_globals::obtain_relative_diameter(double const& ll_lon, double const& ll_lat,
-                                                                                      double const& ur_lon, double const& ur_lat,
-                                                                                      double& relative_diameter)
-{
-  vgl_box_2d<double> overlap_region(ll_lon, ur_lon, ll_lat, ur_lat);
-  if (overlap_region.is_empty())
-    return false;
-  double width  = overlap_region.width();
-  double height = overlap_region.height();
-  // calculate the diameter by the diagonal
-  double diagonal = std::sqrt(width*width + height*height);
-  if (overlap_region.centroid_x() > overlap_region.centroid_y())
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_y();
-  else
-    relative_diameter = 0.5*diagonal/overlap_region.centroid_x();
-  return true;
-}
-
-vgl_box_2d<double> vpgl_isfm_rational_camera_with_initial_process_globals::intersection(std::vector<vgl_box_2d<double> > const& boxes)
-{
-  if (boxes.size() == 2) {
-    return vgl_intersection(boxes[0], boxes[1]);
-  }
-  std::vector<vgl_box_2d<double> > new_boxes;
-  vgl_box_2d<double> box = vgl_intersection(boxes[0], boxes[1]);
-  if (box.is_empty())
-    return box;
-  new_boxes.push_back(box);
-  for (unsigned i = 2; i < boxes.size(); i++)
-    new_boxes.push_back(boxes[i]);
-  return vpgl_isfm_rational_camera_with_initial_process_globals::intersection(new_boxes);
-}
-#endif


### PR DESCRIPTION
update BRL python isfm adaptor processes
- make isfm adaptor process accept 3D region directly
- eliminate requirement for ASTER DEM ingestion
- general code cleanup (e.g., removing #if statements)