### PR TITLE
Unify bproj plane interface

### DIFF
--- a/contrib/brl/bpro/core/bbas_pro/processes/bbas_camera_angles_process.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/processes/bbas_camera_angles_process.cxx
@@ -88,8 +88,8 @@ bool bbas_camera_angles_process(bprb_func_process& pro)
   vgl_point_3d<double> focus_pt_low(pt_x, pt_y, z_low);
   vgl_plane_3d<double> plane_high(0.0, 0.0, 1.0, -z_high);
   vgl_plane_3d<double> plane_low(0.0, 0.0, 1.0, -z_low);
-  vpgl_backproject::bproj_plane(camera.ptr(), img_pt, plane_high, focus_pt_high, focus_pt_high);
-  vpgl_backproject::bproj_plane(camera.ptr(), img_pt, plane_low, focus_pt_low, focus_pt_low);
+  vpgl_backproject::bproj_plane(*camera, img_pt, plane_high, focus_pt_high, focus_pt_high);
+  vpgl_backproject::bproj_plane(*camera, img_pt, plane_low, focus_pt_low, focus_pt_low);
 
   // camera direction is vector from point_low to point_high (assuming camera is far above focus_pt with up ==  +z)
   vgl_vector_3d<double> cam_direction = focus_pt_high - focus_pt_low;

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_get_backproject_ray_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_get_backproject_ray_process.cxx
@@ -128,7 +128,7 @@ bool vpgl_get_rpc_backproject_ray_process(bprb_func_process& pro)
 
   vgl_point_3d<double> point;
 
-  vpgl_backproject::bproj_plane(cam,
+  vpgl_backproject::bproj_plane(*cam,
                                 vgl_point_2d<double>(u,v),
                                 vgl_plane_3d<double>(0, 0, 1, -altitude),
                                 vgl_point_3d<double>(x0, y0, z0),

--- a/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rational_camera_process.cxx
+++ b/contrib/brl/bpro/core/vpgl_pro/processes/vpgl_rational_camera_process.cxx
@@ -101,7 +101,7 @@ bool vpgl_rational_cam_img_to_global_process(bprb_func_process& pro)
   vgl_point_3d<double> world_pt(0.0, 0.0, 0.0);
   vgl_plane_3d<double> pl(0, 0, 1, -pl_elev);
   vgl_point_3d<double> initial_pt(init_lon, init_lat, init_elev);
-  if (!vpgl_backproject::bproj_plane(rat_cam, image_pt, pl, initial_pt, world_pt, error_tol)) {
+  if (!vpgl_backproject::bproj_plane(*rat_cam, image_pt, pl, initial_pt, world_pt, error_tol)) {
     std::cerr << pro.name() << ": back projection failed at given error initial gauss and error tolerance: " << error_tol << std::endl;
     return false;
   }

--- a/contrib/brl/bseg/bvxm/pro/processes/bvxm_detect_scale_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/processes/bvxm_detect_scale_process.cxx
@@ -82,7 +82,7 @@ bool bvxm_detect_scale_process(bprb_func_process& pro)
   vgl_point_2d<double> ul(0,0), lr(ni,nj);
   vgl_point_3d<double> wul, wlr;
 
-  bool success = vpgl_backproject::bproj_plane(camera.ptr(), ul,
+  bool success = vpgl_backproject::bproj_plane(*camera, ul,
                                                world_plane,
                                                world_point,
                                                wul);
@@ -91,7 +91,7 @@ bool bvxm_detect_scale_process(bprb_func_process& pro)
 
   if (!success)
     return false;
-  success = vpgl_backproject::bproj_plane(camera.ptr(), lr,
+  success = vpgl_backproject::bproj_plane(*camera, lr,
                                           world_plane,
                                           world_point,
                                           wlr);

--- a/contrib/brl/bseg/bvxm/pro/processes/bvxm_rpc_registration_process.cxx
+++ b/contrib/brl/bseg/bvxm/pro/processes/bvxm_rpc_registration_process.cxx
@@ -197,7 +197,7 @@ bool bvxm_rpc_registration_process(bprb_func_process& pro)
     vgl_plane_3d<double> curr_plane(0.0,0.0,1.0,-0.001);
     vgl_point_3d<double> init_point(0.0,0.0,0.001);
     vgl_point_3d<double> world_point;
-    vpgl_backproject::bproj_plane(cam_input_temp,origin_2d,curr_plane,init_point,world_point);
+    vpgl_backproject::bproj_plane(*cam_input_temp,origin_2d,curr_plane,init_point,world_point);
 
     vgl_vector_3d<double> motion_plane_normal = world_point - origin_3d;
     motion_plane_normal = normalize(motion_plane_normal);
@@ -206,7 +206,7 @@ bool bvxm_rpc_registration_process(bprb_func_process& pro)
     init_point.set(origin_3d.x(),origin_3d.y(),origin_3d.z());
     vgl_point_3d<double> moved_origin;
     vgl_point_2d<double> origin_2d_shift(origin_2d.x()+best_offset_u,origin_2d.y()+best_offset_v);
-    vpgl_backproject::bproj_plane(cam_input_temp,origin_2d_shift,motion_plane,init_point,moved_origin);
+    vpgl_backproject::bproj_plane(*cam_input_temp,origin_2d_shift,motion_plane,init_point,moved_origin);
 
     vgl_vector_3d<double> motion = moved_origin - origin_3d;
 

--- a/core/vpgl/algo/tests/test_camera_homographies.cxx
+++ b/core/vpgl/algo/tests/test_camera_homographies.cxx
@@ -34,8 +34,7 @@ static void test_camera_homographies()
   std::cout << "img_pt_act_scene" << pact << std::endl;
   vgl_point_3d<double> p3d_act;
   vgl_plane_3d<double> gpl(vgl_vector_3d<double>(0, 0, 1), vgl_point_3d<double>(0, 0, 0));
-  vpgl_camera<double>* c_ptr = dynamic_cast<vpgl_camera<double>*>(&c);
-  bool good = vpgl_backproject::bproj_plane(c_ptr, pact, gpl, vgl_point_3d<double>(0,0,0), p3d_act);
+  bool good = vpgl_backproject::bproj_plane(c, pact, gpl, vgl_point_3d<double>(0,0,0), p3d_act);
   if(good){
     std::cout << "Actual world point " << p3d_act << std::endl;
   }

--- a/core/vpgl/algo/vpgl_backproject.cxx
+++ b/core/vpgl/algo/vpgl_backproject.cxx
@@ -28,6 +28,27 @@ bool vpgl_backproject::bproj_plane(vpgl_generic_camera<double> const& gcam,
     return true;
 }
 
+
+bool vpgl_backproject::bproj_plane(vpgl_proj_camera<double> const& pcam,
+                                   vnl_double_2 const& image_point,
+                                   vnl_double_4 const& plane,
+                                   vnl_double_3 const& initial_guess,
+                                   vnl_double_3& world_point,
+                                   double error_tol,
+                                   double relative_diameter)
+{
+    vgl_ray_3d<double> ray =
+      pcam.backproject_ray(vgl_homg_point_2d<double>(image_point[0], image_point[1]));
+    vgl_plane_3d<double> gplane(plane[0], plane[1], plane[2], plane[3]);
+
+    vgl_point_3d<double> ipt;
+    if (!vgl_intersection<double>(ray, gplane, ipt))
+      return false;
+    world_point[0]=ipt.x(); world_point[1]=ipt.y(); world_point[2]=ipt.z();
+    return true;
+}
+
+
 //: Backproject an image point onto a plane, start with initial_guess
 bool vpgl_backproject::bproj_plane(vpgl_camera<double> const& cam,
                                    vnl_double_2 const& image_point,

--- a/core/vpgl/algo/vpgl_backproject.cxx
+++ b/core/vpgl/algo/vpgl_backproject.cxx
@@ -10,8 +10,26 @@
 #include <vpgl/vpgl_generic_camera.h>
 #include <vnl/vnl_random.h>
 
+bool vpgl_backproject::bproj_plane(vpgl_generic_camera<double> const& gcam,
+                                   vnl_double_2 const& image_point,
+                                   vnl_double_4 const& plane,
+                                   vnl_double_3 const& initial_guess,
+                                   vnl_double_3& world_point,
+                                   double error_tol,
+                                   double relative_diameter)
+{
+    vgl_ray_3d<double> ray;
+    vgl_point_3d<double> ipt;
+    vgl_plane_3d<double> gplane(plane[0], plane[1], plane[2], plane[3]);
+    ray = gcam.ray(image_point[0], image_point[1]);
+    if (!vgl_intersection<double>(ray, gplane, ipt))
+      return false;
+    world_point[0]=ipt.x(); world_point[1]=ipt.y(); world_point[2]=ipt.z();
+    return true;
+}
+
 //: Backproject an image point onto a plane, start with initial_guess
-bool vpgl_backproject::bproj_plane(const vpgl_camera<double>* cam,
+bool vpgl_backproject::bproj_plane(vpgl_camera<double> const& cam,
                                    vnl_double_2 const& image_point,
                                    vnl_double_4 const& plane,
                                    vnl_double_3 const& initial_guess,
@@ -20,17 +38,10 @@ bool vpgl_backproject::bproj_plane(const vpgl_camera<double>* cam,
                                    double relative_diameter)
 {
   // special case of a generic camera
-  if (cam->type_name()=="vpgl_generic_camera")
+  if (cam.type_name()=="vpgl_generic_camera")
   {
-    vgl_ray_3d<double> ray;
-    vgl_point_3d<double> ipt;
-    vgl_plane_3d<double> gplane(plane[0], plane[1], plane[2], plane[3]);
-    const auto* gcam = dynamic_cast<const vpgl_generic_camera<double>*>(cam);
-    ray = gcam->ray(image_point[0], image_point[1]);
-    if (!vgl_intersection<double>(ray, gplane, ipt))
-      return false;
-    world_point[0]=ipt.x(); world_point[1]=ipt.y(); world_point[2]=ipt.z();
-    return true;
+    auto gcam = dynamic_cast<vpgl_generic_camera<double> const&>(cam);
+    return vpgl_backproject::bproj_plane(gcam, image_point, plane, initial_guess, world_point, error_tol, relative_diameter);
   }
   // general case
   vpgl_invmap_cost_function cf(image_point, plane, cam);
@@ -45,7 +56,7 @@ bool vpgl_backproject::bproj_plane(const vpgl_camera<double>* cam,
   x1 = x;
   cf.point_3d(x1, world_point);
   double u=0, v=0, X=world_point[0], Y=world_point[1], Z=world_point[2];
-  cam->project(X, Y, Z, u, v);
+  cam.project(X, Y, Z, u, v);
    vnl_double_2 final_proj;
    final_proj[0]=u; final_proj[1]=v;
   double err = (final_proj-image_point).magnitude();
@@ -58,55 +69,6 @@ bool vpgl_backproject::bproj_plane(const vpgl_camera<double>* cam,
   return true;
 }
 
-  // vgl interface
-
-//: Backproject an image point onto a plane, start with initial_guess
-bool vpgl_backproject::bproj_plane(const vpgl_camera<double>*  cam,
-                                   vgl_point_2d<double> const& image_point,
-                                   vgl_plane_3d<double> const& plane,
-                                   vgl_point_3d<double> const& initial_guess,
-                                   vgl_point_3d<double>& world_point,
-                                   double error_tol,
-                                   double relative_diameter)
-{
-  //simply convert to vnl interface
-  vnl_double_2 ipt;
-  vnl_double_3 ig, wp;
-  vnl_double_4 pl;
-  ipt[0]=image_point.x(); ipt[1]=image_point.y();
-  pl[0]=plane.a(); pl[1]=plane.b(); pl[2]=plane.c(); pl[3]=plane.d();
-  ig[0]=initial_guess.x();  ig[1]=initial_guess.y();  ig[2]=initial_guess.z();
-  bool success = vpgl_backproject::bproj_plane(cam, ipt, pl, ig, wp, error_tol, relative_diameter);
-  world_point.set(wp[0], wp[1], wp[2]);
-  return success;
-}
-
-
-//: Backproject an image point onto a world plane
-bool vpgl_backproject::bproj_plane(vpgl_rational_camera<double> const& rcam,
-                                   vnl_double_2 const& image_point,
-                                   vnl_double_4 const& plane,
-                                   vnl_double_3 const& initial_guess,
-                                   vnl_double_3& world_point,
-                                   double error_tol,
-                                   double relative_diameter)
-{
-  const auto*  cam = static_cast<const vpgl_camera<double>* >(&rcam);
-  return bproj_plane(cam, image_point, plane, initial_guess, world_point, error_tol, relative_diameter);
-}
-
-//: Backproject an image point onto a world plane
-bool vpgl_backproject::bproj_plane(vpgl_rational_camera<double> const& rcam,
-                                   vgl_point_2d<double> const& image_point,
-                                   vgl_plane_3d<double> const& plane,
-                                   vgl_point_3d<double> const& initial_guess,
-                                   vgl_point_3d<double>& world_point,
-                                   double error_tol,
-                                   double relative_diameter)
-{
-  const auto* const cam = static_cast<const vpgl_camera<double>* >(&rcam);
-  return bproj_plane(cam, image_point, plane, initial_guess, world_point, error_tol, relative_diameter);
-}
 
 //Only the direction of the vector is important so it can be
 //normalized to a unit vector. Two rays can be constructed, one through
@@ -127,31 +89,4 @@ vpgl_backproject::bproj_point_vector(vpgl_proj_camera<double> const& cam,
   plane = vgl_plane_3d<double>(hpl);
   //might add checks for ideal plane later
   return true;
-}
-
-
-//: Use backprojection to determine direction to camera from 3-d point
-bool vpgl_backproject::direction_to_camera(vpgl_local_rational_camera<double> const& cam,
-                                           vgl_point_3d<double> const& point,
-                                           vgl_vector_3d<double> &to_camera,
-                                           double error_tol,
-                                           double relative_diameter)
-{
-  // assumes that camera is above point of interest
-  // project point to image, and backproject to another z-plane, vector points to sensor
-  vgl_point_2d<double> img_pt = cam.project(point);
-  constexpr double z_off = 10.0;
-  vgl_plane_3d<double> plane_high(0,0,1,-(point.z()+z_off));
-  vgl_point_3d<double> point_high;
-  vgl_point_3d<double> guess(point.x(),point.y(),point.z() + z_off);
-  if (!bproj_plane(cam, img_pt, plane_high, guess, point_high, error_tol, relative_diameter)) {
-    return false;
-  }
-  // this assumes camera z > point.z
-  to_camera = point_high - point;
-  // normalize vector
-  normalize(to_camera);
-
-  return true;
-
 }

--- a/core/vpgl/algo/vpgl_backproject.h
+++ b/core/vpgl/algo/vpgl_backproject.h
@@ -14,11 +14,13 @@
 
 #include <vpgl/vpgl_rational_camera.h>
 #include <vpgl/vpgl_local_rational_camera.h>
+#include <vpgl/vpgl_generic_camera.h>
 #include <vpgl/vpgl_proj_camera.h>
 #include <vgl/vgl_fwd.h>
 #include <vnl/vnl_double_2.h>
 #include <vnl/vnl_double_3.h>
 #include <vnl/vnl_double_4.h>
+#include <vgl/vgl_plane_3d.h>
 
 class vpgl_backproject
 {
@@ -30,7 +32,7 @@ class vpgl_backproject
   // vnl interface
 
   //:Backproject an image point onto a plane, start with initial_guess
-  static bool bproj_plane(const vpgl_camera<double>* cam,
+  static bool bproj_plane(vpgl_camera<double> const& cam,
                           vnl_double_2 const& image_point,
                           vnl_double_4 const& plane,
                           vnl_double_3 const& initial_guess,
@@ -38,34 +40,24 @@ class vpgl_backproject
                           double error_tol = 0.05,
                           double relative_diameter = 1.0);
 
-       // === vgl interface ===
+
+            // +++ concrete camera interfaces +++
 
   //:Backproject an image point onto a plane, start with initial_guess
-  static bool bproj_plane(const vpgl_camera<double>*  cam,
-                          vgl_point_2d<double> const& image_point,
-                          vgl_plane_3d<double> const& plane,
-                          vgl_point_3d<double> const& initial_guess,
-                          vgl_point_3d<double>& world_point,
-                          double error_tol = 0.05,
-                          double relative_diameter = 1.0);
-
-            // +++ concrete rational camera interfaces +++
-
-       // === vnl interface ===
-
-  //:Backproject an image point onto a plane, start with initial_guess
-  static bool bproj_plane(vpgl_rational_camera<double> const& rcam,
+  static bool bproj_plane(vpgl_generic_camera<double> const& cam,
                           vnl_double_2 const& image_point,
                           vnl_double_4 const& plane,
                           vnl_double_3 const& initial_guess,
                           vnl_double_3& world_point,
                           double error_tol = 0.05,
                           double relative_diameter = 1.0);
+
 
        // ==== vgl interface ===
 
-  //:Backproject an image point onto a plane, start with initial_guess
-  static bool bproj_plane(vpgl_rational_camera<double> const& rcam,
+  //: Backproject an image point onto a plane, start with initial_guess
+  template <class CAM_T>
+  static bool bproj_plane(CAM_T const& cam,
                           vgl_point_2d<double> const& image_point,
                           vgl_plane_3d<double> const& plane,
                           vgl_point_3d<double> const& initial_guess,
@@ -81,7 +73,8 @@ class vpgl_backproject
                                  vgl_plane_3d<double>& plane);
 
   //: Use backprojection to determine direction to camera from 3-d point
-  static bool direction_to_camera(vpgl_local_rational_camera<double> const& cam,
+  template <class CAM_T>
+  static bool direction_to_camera(CAM_T const& cam,
                                   vgl_point_3d<double> const& point,
                                   vgl_vector_3d<double> &to_camera,
                                   double error_tol = 0.05,
@@ -91,5 +84,55 @@ class vpgl_backproject
   //: constructor private - static methods only
   vpgl_backproject();
 };
+
+
+
+//---  Template Definitions ---//
+
+template <class CAM_T>
+bool vpgl_backproject::bproj_plane(CAM_T const& cam,
+                                   vgl_point_2d<double> const& image_point,
+                                   vgl_plane_3d<double> const& plane,
+                                   vgl_point_3d<double> const& initial_guess,
+                                   vgl_point_3d<double>& world_point,
+                                   double error_tol,
+                                   double relative_diameter)
+{
+  //simply convert to vnl interface
+  vnl_double_2 ipt;
+  vnl_double_3 ig, wp;
+  vnl_double_4 pl;
+  ipt[0]=image_point.x(); ipt[1]=image_point.y();
+  pl[0]=plane.a(); pl[1]=plane.b(); pl[2]=plane.c(); pl[3]=plane.d();
+  ig[0]=initial_guess.x();  ig[1]=initial_guess.y();  ig[2]=initial_guess.z();
+  bool success = vpgl_backproject::bproj_plane(cam, ipt, pl, ig, wp, error_tol, relative_diameter);
+  world_point.set(wp[0], wp[1], wp[2]);
+  return success;
+}
+
+template<class CAM_T>
+bool vpgl_backproject::direction_to_camera(CAM_T const& cam,
+                                           vgl_point_3d<double> const& point,
+                                           vgl_vector_3d<double> &to_camera,
+                                           double error_tol,
+                                           double relative_diameter)
+{
+  // assumes that camera is above point of interest
+  // project point to image, and backproject to another z-plane, vector points to sensor
+  vgl_point_2d<double> img_pt = cam.project(point);
+  constexpr double z_off = 10.0;
+  vgl_plane_3d<double> plane_high(0,0,1,-(point.z()+z_off));
+  vgl_point_3d<double> point_high;
+  vgl_point_3d<double> guess(point.x(),point.y(),point.z() + z_off);
+  if (!bproj_plane(cam, img_pt, plane_high, guess, point_high, error_tol, relative_diameter)) {
+    return false;
+  }
+  // this assumes camera z > point.z
+  to_camera = point_high - point;
+  // normalize vector
+  normalize(to_camera);
+
+  return true;
+}
 
 #endif // vpgl_backproject_h_

--- a/core/vpgl/algo/vpgl_backproject.h
+++ b/core/vpgl/algo/vpgl_backproject.h
@@ -52,6 +52,15 @@ class vpgl_backproject
                           double error_tol = 0.05,
                           double relative_diameter = 1.0);
 
+  //:Backproject an image point onto a plane, start with initial_guess
+  static bool bproj_plane(vpgl_proj_camera<double> const& cam,
+                          vnl_double_2 const& image_point,
+                          vnl_double_4 const& plane,
+                          vnl_double_3 const& initial_guess,
+                          vnl_double_3& world_point,
+                          double error_tol = 0.05,
+                          double relative_diameter = 1.0);
+
 
        // ==== vgl interface ===
 

--- a/core/vpgl/algo/vpgl_camera_convert.cxx
+++ b/core/vpgl/algo/vpgl_camera_convert.cxx
@@ -685,13 +685,13 @@ static bool ray_tol(vpgl_local_rational_camera<double> const& rat_cam,
 {
   vgl_point_2d<double> ip(mid_u,mid_v);
   vgl_point_3d<double> high_pt, low_pt, low_pt_pix;
-  if (!vpgl_backproject::bproj_plane(&rat_cam, ip, high, high_guess, high_pt))
+  if (!vpgl_backproject::bproj_plane(rat_cam, ip, high, high_guess, high_pt))
     return false;
-  if (!vpgl_backproject::bproj_plane(&rat_cam, ip, low, low_guess, low_pt))
+  if (!vpgl_backproject::bproj_plane(rat_cam, ip, low, low_guess, low_pt))
     return false;
   //move 1 pixel
   ip.set(mid_u+1.0, mid_v+1.0);
-  if (!vpgl_backproject::bproj_plane(&rat_cam, ip, low, low_pt, low_pt_pix))
+  if (!vpgl_backproject::bproj_plane(rat_cam, ip, low, low_pt, low_pt_pix))
     return false;
   // Ground Sampling Distance
   double gsd = (low_pt-low_pt_pix).length();
@@ -1030,9 +1030,9 @@ bool vpgl_generic_camera_convert::pyramid_est(vpgl_local_rational_camera<double>
                   prev_endpt = prev_org + (prev_dir * ray_len);
               }
               constexpr double error_tol = 0.5; // allow projection error of 0.25 pixel
-              if (!vpgl_backproject::bproj_plane(&rat_cam, ip, high, prev_org, org, error_tol))
+              if (!vpgl_backproject::bproj_plane(rat_cam, ip, high, prev_org, org, error_tol))
                   return false;
-              if (!vpgl_backproject::bproj_plane(&rat_cam, ip, low, prev_endpt, endpt, error_tol))
+              if (!vpgl_backproject::bproj_plane(rat_cam, ip, low, prev_endpt, endpt, error_tol))
                   return false;
               vgl_vector_3d<double> dir = endpt-org;
               ray_pyr[lev][j][i].set(org, dir);
@@ -1208,9 +1208,9 @@ convert_bruteforce( vpgl_local_rational_camera<double> const& rat_cam,
       {
           vgl_point_2d<double> ip(i,j);
           constexpr double error_tol = 0.5; // allow projection error of 0.25 pixel
-          if (!vpgl_backproject::bproj_plane(&rat_cam, ip, high, org, org, error_tol))
+          if (!vpgl_backproject::bproj_plane(rat_cam, ip, high, org, org, error_tol))
               return false;
-          if (!vpgl_backproject::bproj_plane(&rat_cam, ip, low, endpt, endpt, error_tol))
+          if (!vpgl_backproject::bproj_plane(rat_cam, ip, low, endpt, endpt, error_tol))
               return false;
           vgl_vector_3d<double> dir = endpt-org;
           finalrays[j][i].set(org, dir);

--- a/core/vpgl/algo/vpgl_invmap_cost_function.cxx
+++ b/core/vpgl/algo/vpgl_invmap_cost_function.cxx
@@ -12,9 +12,9 @@
 vpgl_invmap_cost_function::
 vpgl_invmap_cost_function(vnl_vector_fixed<double, 2> const& image_point,
                           vnl_vector_fixed<double, 4> const& plane,
-                          const vpgl_camera<double>* const cam)
+                          vpgl_camera<double> const& cam)
  : vnl_cost_function(2), image_point_(image_point),
-   plane_(plane), cam_ptr_(cam), pp_(X_Y)
+   plane_(plane), cam_(cam), pp_(X_Y)
 {
   //determine which parameterization of the plane to use
   // order the plane normals
@@ -29,15 +29,13 @@ vpgl_invmap_cost_function(vnl_vector_fixed<double, 2> const& image_point,
 //: The main function.
 double vpgl_invmap_cost_function::f(vnl_vector<double> const& x)
 {
-  if (!cam_ptr_)
-    return 0;
   // fill out the 3-d point from the parameters
   vnl_vector_fixed<double, 3> p_3d;
   this->point_3d(vnl_vector_fixed<double,2>(x[0],x[1]), p_3d);
 
   // project the current point estimate onto the image
   double u,v,X=p_3d[0],Y=p_3d[1],Z=p_3d[2];
-  cam_ptr_->project(X,Y,Z,u,v);
+  cam_.project(X,Y,Z,u,v);
 vnl_vector_fixed<double, 2> p_2d;
  p_2d[0]=u; p_2d[1]=v;
   // compute the residual

--- a/core/vpgl/algo/vpgl_invmap_cost_function.h
+++ b/core/vpgl/algo/vpgl_invmap_cost_function.h
@@ -12,10 +12,10 @@ class vpgl_invmap_cost_function: public vnl_cost_function
   //: Which parameterization to use for the plane
   enum plane_param{X_Y=0, X_Z, Y_Z};
  public:
-  //: Constructor - rcam pointer is not deleted by this class
+  //: Constructor
   vpgl_invmap_cost_function(vnl_vector_fixed<double, 2> const& image_point,
                             vnl_vector_fixed<double, 4> const& plane,
-                            const vpgl_camera<double>* rcam);
+                            vpgl_camera<double> const& cam);
   ~vpgl_invmap_cost_function() override = default;
   //: The cost function. x is a vector holding the two plane parameters
   double f(vnl_vector<double> const& x) override;
@@ -36,7 +36,7 @@ class vpgl_invmap_cost_function: public vnl_cost_function
   //: plane coefficients
   vnl_vector_fixed<double, 4> plane_;
   //: rational camera
-  const vpgl_camera<double>* cam_ptr_;
+  const vpgl_camera<double> &cam_;
   //: the well-conditioned parameterization
   plane_param pp_;
 };

--- a/core/vpgl/algo/vpgl_ray.cxx
+++ b/core/vpgl/algo/vpgl_ray.cxx
@@ -42,7 +42,7 @@ bool vpgl_ray::ray(const vpgl_camera<double>* cam,
   //backproject onto the shifted plane
   vnl_double_3 shifted_point;
 
-  if (!vpgl_backproject::bproj_plane(cam, image_point, plane, point_3d,
+  if (!vpgl_backproject::bproj_plane(*cam, image_point, plane, point_3d,
                                      shifted_point))
     return false;
   //The ray direction is just the difference
@@ -93,9 +93,9 @@ bool vpgl_ray::ray(const vpgl_camera<double>*  cam,
   vgl_point_3d<double> initial_origin_guess(initial_guess.x(), initial_guess.y(), origin_z);
   vgl_point_3d<double> initial_tip_guess(initial_guess.x(), initial_guess.y(), (origin_z-dz));
   vgl_point_3d<double> origin, ray_tip;
-  if (!vpgl_backproject::bproj_plane(cam, image_pt, origin_plane, initial_origin_guess, origin))
+  if (!vpgl_backproject::bproj_plane(*cam, image_pt, origin_plane, initial_origin_guess, origin))
     return false;
-  if (!vpgl_backproject::bproj_plane(cam, image_pt, tip_plane, initial_tip_guess, ray_tip))
+  if (!vpgl_backproject::bproj_plane(*cam, image_pt, tip_plane, initial_tip_guess, ray_tip))
     return false;
   ray = vgl_ray_3d<double>(origin, ray_tip);
   return true;
@@ -150,10 +150,8 @@ bool vpgl_ray::ray(vpgl_local_rational_camera<double> const& lrcam,
   vgl_plane_3d<double> top_plane(0.0, 0.0, 1.0, -zmax);
   vgl_point_2d<double> image_point(u, v);
   vgl_point_3d<double> initial_guess(0.0, 0.0, zmax);
-  auto* lrcam_ptr =
-    const_cast<vpgl_local_rational_camera<double>*>(&lrcam);
-  auto* cam = static_cast<vpgl_camera<double>*>(lrcam_ptr);
-  if (!vpgl_backproject::bproj_plane(cam, image_point, top_plane,
+
+  if (!vpgl_backproject::bproj_plane(lrcam, image_point, top_plane,
                                      initial_guess, origin))
     return false;
 
@@ -162,7 +160,7 @@ bool vpgl_ray::ray(vpgl_local_rational_camera<double> const& lrcam,
   //
   vgl_plane_3d<double> mid_plane(0.0, 0.0, 1.0, -z_off);
   vgl_point_3d<double> mid_initial_guess(0.0, 0.0, z_off), mid_point;
-  if (!vpgl_backproject::bproj_plane(cam, image_point, mid_plane,
+  if (!vpgl_backproject::bproj_plane(lrcam, image_point, mid_plane,
                                      mid_initial_guess, mid_point))
     return false;
 
@@ -201,13 +199,11 @@ bool vpgl_ray::plane_ray(vpgl_local_rational_camera<double> const& lrcam,
   //vgl_point_2d<double> image_point(u, v);
   vgl_point_3d<double> initial_guess(0.0, 0.0, zmax);
   vgl_point_3d<double> point1,point2;
-  auto* lrcam_ptr =
-    const_cast<vpgl_local_rational_camera<double>*>(&lrcam);
-  auto* cam = static_cast<vpgl_camera<double>*>(lrcam_ptr);
-  if (!vpgl_backproject::bproj_plane(cam, image_point1, top_plane,
+
+  if (!vpgl_backproject::bproj_plane(lrcam, image_point1, top_plane,
                                      initial_guess, point1))
     return false;
-  if (!vpgl_backproject::bproj_plane(cam, image_point2, top_plane,
+  if (!vpgl_backproject::bproj_plane(lrcam, image_point2, top_plane,
                                      initial_guess, point2))
     return false;
 
@@ -216,7 +212,7 @@ bool vpgl_ray::plane_ray(vpgl_local_rational_camera<double> const& lrcam,
   //
   vgl_plane_3d<double> mid_plane(0.0, 0.0, 1.0, -z_off);
   vgl_point_3d<double> mid_initial_guess(0.0, 0.0, z_off), mid_point1;
-  if (!vpgl_backproject::bproj_plane(cam, image_point1, mid_plane,
+  if (!vpgl_backproject::bproj_plane(lrcam, image_point1, mid_plane,
                                      mid_initial_guess, mid_point1))
     return false;
 


### PR DESCRIPTION
Unify vpgl_backproject::bproj_plane() interface to accept references.

- Previously, the generic_camera version accepted the camera as a reference, and the basic version accepted the camera as a pointer.  With the new unified interface, overloading can be used to choose the correct implementation.

- The vgl wrapper interface is converted to a function template so that it doesn't need to be re-written for every camera type overload.

- Only one implementation of vpgl_backproject::direction_to_camera() is needed, as overloading will now be used to call the correct bproj_plane().

- Add a new bproj_plane() overload for projective cameras.