### PR TITLE
ENH: vpgl_lvcs const correctness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 2.0.2.1 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vpgl/vpgl_local_rational_camera.hxx
+++ b/core/vpgl/vpgl_local_rational_camera.hxx
@@ -77,8 +77,7 @@ void vpgl_local_rational_camera<T>::project(
 {
   // first, convert to global geographic coordinates
   double lon, lat, gz;
-  vpgl_lvcs& non_const_lvcs = const_cast<vpgl_lvcs&>(lvcs_);
-  non_const_lvcs.local_to_global(x, y, z, vpgl_lvcs::wgs84, lon, lat, gz);
+  lvcs_.local_to_global(x, y, z, vpgl_lvcs::wgs84, lon, lat, gz);
 
   // then, project global to 2D
   vpgl_rational_camera<T>::project((T)lon, (T)lat, (T)gz, u, v);

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -23,23 +23,21 @@ vpgl_lvcs::cs_names vpgl_lvcs::str_to_enum(const char* s)
   return vpgl_lvcs::NumNames;
 }
 
-void vpgl_lvcs::set_angle_conversions(AngUnits ang_unit, double& to_radians,
-                                      double& to_degrees) const
+void vpgl_lvcs::get_angle_conversions(double& to_radians, double& to_degrees) const
 {
   to_radians=1.0;
   to_degrees=1.0;
-  if (ang_unit == DEG)
+  if (geo_angle_unit_ == DEG)
     to_radians = DEGREES_TO_RADIANS;
   else
     to_degrees = RADIANS_TO_DEGREES;
 }
 
-void vpgl_lvcs::set_length_conversions(LenUnits len_unit, double& to_meters,
-                                       double& to_feet) const
+void vpgl_lvcs::get_length_conversions(double& to_meters, double& to_feet) const
 {
   to_meters = 1.0;
   to_feet = 1.0;
-  if (len_unit == FEET)
+  if (localXYZUnit_ == FEET)
     to_meters = FEET_TO_METERS;
   else
     to_feet = METERS_TO_FEET;
@@ -120,9 +118,8 @@ vpgl_lvcs::vpgl_lvcs(double orig_lat, double orig_lon, double orig_elev,
    theta_(theta)
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                              local_to_degrees);
-  this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+  this->get_angle_conversions(local_to_radians, local_to_degrees);
+  this->get_length_conversions(local_to_meters, local_to_feet);
 
   if (cs_name == vpgl_lvcs::utm) {
     //: the origin is still given in wgs84
@@ -152,9 +149,8 @@ vpgl_lvcs::vpgl_lvcs(double orig_lat, double orig_lon, double orig_elev,
     geo_angle_unit_(ang_unit), localXYZUnit_(len_unit), lox_(0), loy_(0), theta_(0)
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                              local_to_degrees);
-  this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+  this->get_angle_conversions(local_to_radians, local_to_degrees);
+  this->get_length_conversions(local_to_meters, local_to_feet);
 
   if (cs_name == vpgl_lvcs::utm) {
     //: the origin is still given in wgs84
@@ -187,9 +183,8 @@ vpgl_lvcs::vpgl_lvcs(double lat_low, double lon_low,
   localCSOriginLon_ = average_lon;
 
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                              local_to_degrees);
-  this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+  this->get_angle_conversions(local_to_radians, local_to_degrees);
+  this->get_length_conversions(local_to_meters, local_to_feet);
 
   if (cs_name == vpgl_lvcs::utm) {
     //: the origin is still given in wgs84
@@ -234,8 +229,8 @@ void vpgl_lvcs::compute_scale()
   double grs80_x, grs80_y, grs80_z;          // GRS80 coords of the origin
   double grs80_x1, grs80_y1, grs80_z1;
   double to_meters, to_feet, to_radians, to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, to_radians, to_degrees);
-  this->set_length_conversions(localXYZUnit_, to_meters, to_feet);
+  this->get_angle_conversions(to_radians, to_degrees);
+  this->get_length_conversions(to_meters, to_feet);
   // Convert origin to WGS84
   switch (local_cs_name_)
   {
@@ -370,9 +365,8 @@ void vpgl_lvcs::local_to_global(const double pointin_x,
                                ) const
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                              local_to_degrees);
-  this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+  this->get_angle_conversions(local_to_radians, local_to_degrees);
+  this->get_length_conversions(local_to_meters, local_to_feet);
 
   double local_lat, local_lon, local_elev;
   double global_lat, global_lon, global_elev;
@@ -575,9 +569,8 @@ void vpgl_lvcs::global_to_local(const double pointin_lon,
                                ) const
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-  this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                              local_to_degrees);
-  this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+  this->get_angle_conversions(local_to_radians, local_to_degrees);
+  this->get_length_conversions(local_to_meters, local_to_feet);
   double global_lat, global_lon, global_elev;
   double local_lat, local_lon, local_elev;
 
@@ -852,9 +845,8 @@ void vpgl_lvcs::read(std::istream& strm)
 
   if (local_cs_name_ == vpgl_lvcs::utm) {
     double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
-    this->set_angle_conversions(geo_angle_unit_, local_to_radians,
-                                local_to_degrees);
-    this->set_length_conversions(localXYZUnit_, local_to_meters, local_to_feet);
+    this->get_angle_conversions(local_to_radians, local_to_degrees);
+    this->get_length_conversions(local_to_meters, local_to_feet);
 
     //: the origin is still given in wgs84
     vpgl_utm u;

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -24,7 +24,7 @@ vpgl_lvcs::cs_names vpgl_lvcs::str_to_enum(const char* s)
 }
 
 void vpgl_lvcs::set_angle_conversions(AngUnits ang_unit, double& to_radians,
-                                      double& to_degrees)
+                                      double& to_degrees) const
 {
   to_radians=1.0;
   to_degrees=1.0;
@@ -35,7 +35,7 @@ void vpgl_lvcs::set_angle_conversions(AngUnits ang_unit, double& to_radians,
 }
 
 void vpgl_lvcs::set_length_conversions(LenUnits len_unit, double& to_meters,
-                                       double& to_feet)
+                                       double& to_feet) const
 {
   to_meters = 1.0;
   to_feet = 1.0;
@@ -204,19 +204,19 @@ vpgl_lvcs::vpgl_lvcs(double lat_low, double lon_low,
   this->compute_scale();
 }
 
-double vpgl_lvcs::radians_to_degrees(const double val)
+double vpgl_lvcs::radians_to_degrees(const double val) const
 {
   return val*RADIANS_TO_DEGREES;
 }
 
-void  vpgl_lvcs::radians_to_degrees(double& x, double& y, double& z)
+void  vpgl_lvcs::radians_to_degrees(double& x, double& y, double& z) const
 {
   x = x * RADIANS_TO_DEGREES;
   y = y * RADIANS_TO_DEGREES;
   z = z * RADIANS_TO_DEGREES;
 }
 
-void vpgl_lvcs::degrees_to_dms(double geoval, int& degrees, int& minutes, double& seconds)
+void vpgl_lvcs::degrees_to_dms(double geoval, int& degrees, int& minutes, double& seconds) const
 {
   double fmin = std::fabs(geoval - (int)geoval)*60.0;
   int isec = (int) ((fmin - (int)fmin)*60.0 + .5);
@@ -367,7 +367,7 @@ void vpgl_lvcs::local_to_global(const double pointin_x,
                                 double& pointout_z,
                                 AngUnits output_ang_unit,
                                 LenUnits output_len_unit
-                               )
+                               ) const
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
   this->set_angle_conversions(geo_angle_unit_, local_to_radians,
@@ -571,7 +571,8 @@ void vpgl_lvcs::global_to_local(const double pointin_lon,
                                 double& pointout_y,
                                 double& pointout_z,
                                 AngUnits input_ang_unit,
-                                LenUnits input_len_unit)
+                                LenUnits input_len_unit
+                               ) const
 {
   double local_to_meters, local_to_feet, local_to_radians, local_to_degrees;
   this->set_angle_conversions(geo_angle_unit_, local_to_radians,
@@ -898,7 +899,7 @@ void vpgl_lvcs::write(std::ostream& strm)  // write just "read" would read
 
 //------------------------------------------------------------
 //: Transform from local co-ordinates to north=y,east=x.
-void vpgl_lvcs::local_transform(double& x, double& y)
+void vpgl_lvcs::local_transform(double& x, double& y) const
 {
   double theta=theta_;
   if (geo_angle_unit_ == DEG)
@@ -926,7 +927,7 @@ void vpgl_lvcs::local_transform(double& x, double& y)
 
 //------------------------------------------------------------
 //: Transform from north=y,east=x aligned axes to local co-ordinates.
-void vpgl_lvcs::inverse_local_transform(double& x, double& y)
+void vpgl_lvcs::inverse_local_transform(double& x, double& y) const
 {
   double theta=theta_;
   if (geo_angle_unit_ == DEG)

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -91,27 +91,28 @@ class vpgl_lvcs : public vbl_ref_count
                        cs_names cs_name,        // this is output global cs
                        double& lon, double& lat, double& gz,
                        AngUnits output_ang_unit=DEG,
-                       LenUnits output_len_unit=METERS);
+                       LenUnits output_len_unit=METERS) const;
 
   void global_to_local(const double lon, const double lat, const double gz,
                        cs_names cs_name,        // this is input global cs
                        double& lx, double& ly, double& lz,
                        AngUnits output_ang_unit=DEG,
-                       LenUnits output_len_unit=METERS);
+                       LenUnits output_len_unit=METERS) const;
 
-  void radians_to_degrees(double& lon, double& lat, double& z);
-  double radians_to_degrees(const double val);
-  void degrees_to_dms(double, int& degrees, int& minutes, double& seconds);
-  void radians_to_dms(double, int& degrees, int& minutes, double& seconds);
+  void radians_to_degrees(double& lon, double& lat, double& z) const;
+  double radians_to_degrees(const double val) const;
+  void degrees_to_dms(double, int& degrees, int& minutes, double& seconds) const;
+  void radians_to_dms(double, int& degrees, int& minutes, double& seconds) const;
   // uses the units defined for *this lvcs, e.g. deg and meters. computes cartesian vector (p1 - p0)
   void angle_diff_to_cartesian_vector(const double lon0, const double lat0, const double lon1, const double lat1,
-                                                 double& cart_dx, double& cart_dy) {
-  double l0x, l0y, l0z, l1x, l1y, l1z;
-  this->global_to_local(lon0, lat0, 0.0, local_cs_name_, l0x, l0y, l0z);
-  this->global_to_local(lon1, lat1, 0.0, local_cs_name_, l1x, l1y, l1z);
-  cart_dx = l1x-l0x;
-  cart_dy = l1y-l0y;
-}
+                                      double& cart_dx, double& cart_dy) const
+  {
+    double l0x, l0y, l0z, l1x, l1y, l1z;
+    this->global_to_local(lon0, lat0, 0.0, local_cs_name_, l0x, l0y, l0z);
+    this->global_to_local(lon1, lat1, 0.0, local_cs_name_, l1x, l1y, l1z);
+    cart_dx = l1x-l0x;
+    cart_dy = l1y-l0y;
+  }
 
   // accessors
   void get_origin(double& lat, double& lon, double& elev) const;
@@ -146,12 +147,12 @@ class vpgl_lvcs : public vbl_ref_count
 
  protected:
   void compute_scale();
-  void local_transform(double& x, double& y);
-  void inverse_local_transform(double& x, double& y);
+  void local_transform(double& x, double& y) const;
+  void inverse_local_transform(double& x, double& y) const;
   void set_angle_conversions(AngUnits ang_unit, double& to_radians,
-                             double& to_degrees);
+                             double& to_degrees) const;
   void set_length_conversions(LenUnits len_unit, double& to_meters,
-                              double& to_feet);
+                              double& to_feet) const;
  private:
 
   // Data Members--------------------------------------------------------------
@@ -230,7 +231,7 @@ inline void vpgl_lvcs::set_origin(const double lon, const double lat, const doub
     localCSOriginElev_ = elev;
 }
 
-inline void vpgl_lvcs::radians_to_dms(double rad, int& degrees, int& minutes, double& seconds)
+inline void vpgl_lvcs::radians_to_dms(double rad, int& degrees, int& minutes, double& seconds) const
 {
   degrees_to_dms(radians_to_degrees(rad), degrees,  minutes, seconds);
 }

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -149,10 +149,8 @@ class vpgl_lvcs : public vbl_ref_count
   void compute_scale();
   void local_transform(double& x, double& y) const;
   void inverse_local_transform(double& x, double& y) const;
-  void set_angle_conversions(AngUnits ang_unit, double& to_radians,
-                             double& to_degrees) const;
-  void set_length_conversions(LenUnits len_unit, double& to_meters,
-                              double& to_feet) const;
+  void get_angle_conversions(double& to_radians, double& to_degrees) const;
+  void get_length_conversions(double& to_meters, double& to_feet) const;
  private:
 
   // Data Members--------------------------------------------------------------


### PR DESCRIPTION
## PR Checklist
🚫 Makes breaking changes to vxl/core API that requires semantic versioning increase
✅ Makes design changes to existing vxl/core API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative)
🚫 Adds Documentation

## PR Description
- Update `vpgl_lvcs` functions for const correctness (ensure all functions which do not change the state of the object instance are const)
- Update `vpgl_lvcs` protected member functions (change name from `set_*_conversions` to `get_*_conversions` and use protected member variables directly)
- Eliminate (now) unnecessary `const_cast` from `vpgl_local_rational_camera`
- tweak version number - now v2.0.2.1

