### PR TITLE
ENH: CircleCI caching and build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: Build
           working_directory: /build
-          command: ninja
+          command: set -x && ninja -j${NINJA_JOBS:-$((`nproc` / 2))}
       - save_cache:
           key: vxl_bin-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - vxl_bin-{{ .Branch }}
-            - vxl_bin
+            - vxl_bin-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
+            - vxl_bin-{{ .Environment.CACHE_VERSION }}-
       - run:
           name: Fix times on source
           command: |
@@ -47,7 +47,7 @@ jobs:
           working_directory: /build
           command: ninja
       - save_cache:
-          key: vxl_bin-{{ .Branch }}-{{ epoch }}
+          key: vxl_bin-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
           paths:
             - /build
       - run:


### PR DESCRIPTION
## PR Checklist
:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
:no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
:no_entry_sign: Adds tests and baseline comparison (quantitative).
:no_entry_sign: Adds Documentation.

## PR Description
Update circleci scripts (not used by vxl/vxl, but enabled in some forks)
- Users with "enable pipelines" set to ON in advanced settings are currently unable to clear the circleci cache (clearing the cache forces a rebuild of all VXL).  Users may now change their `CACHE_VERSION` build environment variable to generate a new cache.
- ninja build using all available processors may run out of memory on circleci.  Cutting build jobs in half appears to solve this issue.  Users may further reduce ninja jobs via the `NINJA_JOBS` build environment variable.
