### PR TITLE
BUG: Test syntax had incorrect values

### DIFF
--- a/core/vpgl/algo/tests/test_camera_compute.cxx
+++ b/core/vpgl/algo/tests/test_camera_compute.cxx
@@ -291,7 +291,7 @@ static void test_compute_affine()
 	  for (size_t c = 0; c < 2; ++c) {
 		  er0 += fabs(Mgt[r][c] - Mfitted[r][c]);
 	  }
-  good = good && er0 < 1,0e-6;
+  good = good && er0 < 1.0e-6;
   TEST("compute affine camera from pts", good, true);
 }
 


### PR DESCRIPTION
1,0e-6 is the value 1 and the value 0e-6.  1.0e-6 was intended.
