### PR TITLE
STYLE: Prefer c++11 'using' to 'typedef'

### DIFF
--- a/core/examples/vnl_calc/vnl_calc.cxx
+++ b/core/examples/vnl_calc/vnl_calc.cxx
@@ -64,7 +64,7 @@ void cantshift(const std::string& arg)
   std::exit (-1);
 }
 
-typedef vnl_matrix<double> Matrix;
+using Matrix = vnl_matrix<double>;
 
 template class mystack<Matrix>;
 

--- a/core/testlib/testlib_main.cxx
+++ b/core/testlib/testlib_main.cxx
@@ -115,7 +115,7 @@ testlib_main( int argc, char* argv[] )
 
   // Assume the index type for vector<string> and
   // vector<TestMainFunction> are the same.
-  typedef std::vector<std::string>::size_type vec_size_t;
+  using vec_size_t = std::vector<std::string>::size_type;
 
   // Error check.
   if ( testlib_test_func_.size() != testlib_test_name_.size() ) {

--- a/core/vbl/examples/vbl_smart_ptr_example.cxx
+++ b/core/vbl/examples/vbl_smart_ptr_example.cxx
@@ -40,7 +40,7 @@ class example_sp : public vbl_ref_count
   }
 };
 
-typedef vbl_smart_ptr<example_sp> example_sp_sptr;
+using example_sp_sptr = vbl_smart_ptr<example_sp>;
 
 //== end of example_sp.h ==//
 

--- a/core/vbl/io/Templates/vsl_vector_io+vbl_triple+uint.uint.uint--.cxx
+++ b/core/vbl/io/Templates/vsl_vector_io+vbl_triple+uint.uint.uint--.cxx
@@ -3,5 +3,5 @@
 #include <vbl/io/vbl_io_triple.hxx>
 typedef vbl_triple<unsigned int, unsigned int, unsigned int> vbl_triple_iii;
 VSL_VECTOR_IO_INSTANTIATE(vbl_triple_iii);
-typedef std::vector<vbl_triple_iii>  vector_triple_uuu;
+using vector_triple_uuu = std::vector<vbl_triple_iii>;
 VSL_VECTOR_IO_INSTANTIATE(vector_triple_uuu);

--- a/core/vbl/io/tests/vbl_io_test_classes.cxx
+++ b/core/vbl/io/tests/vbl_io_test_classes.cxx
@@ -16,7 +16,7 @@ VBL_SMART_PTR_INSTANTIATE(impl);
 VBL_IO_SMART_PTR_INSTANTIATE(impl);
 
 
-typedef vbl_smart_ptr<impl> base_sptr;
+using base_sptr = vbl_smart_ptr<impl>;
 
 // Remember, the template instances must be in
 // Templates, but they use these classes, so the class

--- a/core/vbl/tests/vbl_test_shared_pointer.cxx
+++ b/core/vbl/tests/vbl_test_shared_pointer.cxx
@@ -19,7 +19,7 @@ struct some_class
 
 static void test_int()
 {
-  typedef vbl_shared_pointer<int> pi;
+  using pi = vbl_shared_pointer<int>;
 
   pi a(new int(13));
   pi b(new int(24));
@@ -39,7 +39,7 @@ static void test_int()
 
 static void test_class()
 {
-  typedef vbl_shared_pointer<some_class> sp;
+  using sp = vbl_shared_pointer<some_class>;
 
   sp a(new some_class);
   sp b((some_class*)nullptr);
@@ -89,9 +89,9 @@ int derv_class2::cnt = 0;
 
 static void test_derived_class()
 {
-  typedef vbl_shared_pointer<derv_class1> d1p;
-  typedef vbl_shared_pointer<derv_class2> d2p;
-  typedef vbl_shared_pointer<base_class> bp;
+  using d1p = vbl_shared_pointer<derv_class1>;
+  using d2p = vbl_shared_pointer<derv_class2>;
+  using bp = vbl_shared_pointer<base_class>;
 
   {
     std::cout << "Construct with raw derived pointer\n";

--- a/core/vgl/algo/Templates/vgl_rtree+vgl_box_2d+float-.vgl_bbox_2d+float-.vgl_rtree_box_box_2d+float--.cxx
+++ b/core/vgl/algo/Templates/vgl_rtree+vgl_box_2d+float-.vgl_bbox_2d+float-.vgl_rtree_box_box_2d+float--.cxx
@@ -2,8 +2,8 @@
 #include <vgl/vgl_box_2d.h>
 #include <vgl/algo/vgl_rtree_c.h>
 
-typedef vgl_box_2d<float> v;
-typedef vgl_bbox_2d<float> b;
-typedef vgl_rtree_box_box_2d<float> c;
+using v = vgl_box_2d<float>;
+using b = vgl_bbox_2d<float>;
+using c = vgl_rtree_box_box_2d<float>;
 
 VGL_RTREE_INSTANTIATE(v, b, c);

--- a/core/vgl/algo/Templates/vgl_rtree+vgl_point_2d+double-.vgl_box_2d+double-.dummy-.cxx
+++ b/core/vgl/algo/Templates/vgl_rtree+vgl_point_2d+double-.vgl_box_2d+double-.dummy-.cxx
@@ -5,8 +5,8 @@
 #include <vgl/vgl_box_2d.h>
 #include <vgl/algo/vgl_rtree.hxx>
 
-typedef vgl_point_2d<double> V;
-typedef vgl_box_2d<double>   B;
+using V = vgl_point_2d<double>;
+using B = vgl_box_2d<double>;
 
 struct dummy // dummy "namespace", used by some of the rtree methods
 {

--- a/core/vgl/algo/Templates/vgl_rtree+vgl_point_2d+float-.vgl_box_2d+float-.vgl_rtree_point_box_2d+float--.cxx
+++ b/core/vgl/algo/Templates/vgl_rtree+vgl_point_2d+float-.vgl_box_2d+float-.vgl_rtree_point_box_2d+float--.cxx
@@ -3,8 +3,8 @@
 #include <vgl/vgl_box_2d.h>
 #include <vgl/algo/vgl_rtree_c.h>
 
-typedef vgl_point_2d<float> pt;
-typedef vgl_box_2d<float> box;
-typedef vgl_rtree_point_box_2d<float> c;
+using pt = vgl_point_2d<float>;
+using box = vgl_box_2d<float>;
+using c = vgl_rtree_point_box_2d<float>;
 
 VGL_RTREE_INSTANTIATE(pt, box, c);

--- a/core/vgl/algo/tests/test_rtree.cxx
+++ b/core/vgl/algo/tests/test_rtree.cxx
@@ -21,9 +21,9 @@ static void test_point_box()
   // C a helper class that determines bounding predicates so that
   //   V and B can remain unassociated.
   //
-  typedef vgl_rtree_point_box_2d<float> C_; // the helper class
-  typedef C_::v_type V_; // the contained object type
-  typedef C_::b_type B_; // the bounding object type
+  using C_ = vgl_rtree_point_box_2d<float>; // the helper class
+  using V_ = C_::v_type; // the contained object type
+  using B_ = C_::b_type; // the bounding object type
   std::cout << "\n<<<<<<<   test point_box tree >>>>>>>>>>>>>>\n";
   vgl_rtree<V_, B_, C_> tr; // the rtree
 
@@ -104,9 +104,9 @@ static void test_box_box()
   // C a helper class that determines bounding predicates so that
   //   V and B can remain unassociated.
   //
-  typedef vgl_rtree_box_box_2d<float> C_; // the helper class
-  typedef C_::v_type V_; // the contained object type
-  typedef C_::b_type B_; // the bounding object type
+  using C_ = vgl_rtree_box_box_2d<float>; // the helper class
+  using V_ = C_::v_type; // the contained object type
+  using B_ = C_::b_type; // the bounding object type
   std::cout << "\n<<<<<<<   test box_box tree >>>>>>>>>>>>>>\n";
   vgl_rtree<V_, B_, C_> tr; // the rtree
 

--- a/core/vgl/io/vgl_io_polygon.cxx
+++ b/core/vgl/io/vgl_io_polygon.cxx
@@ -41,7 +41,7 @@ void vsl_b_read(vsl_b_istream &is, vgl_polygon<T> & p)
     for (unsigned int i=0;i<num_sheets;i++)
     {
       p.new_sheet();
-      typedef typename vgl_polygon<T>::sheet_t::size_type size_type;
+      using size_type = typename vgl_polygon<T>::sheet_t::size_type;
       size_type npoints;
       vsl_b_read(is, npoints);
       vgl_point_2d<T> point;

--- a/core/vgl/tests/test_polygon_scan_iterator.cxx
+++ b/core/vgl/tests/test_polygon_scan_iterator.cxx
@@ -22,9 +22,9 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 
-typedef vgl_polygon<float>::point_t        Point_type;
-typedef vgl_polygon<float>                 Polygon_type;
-typedef vgl_polygon_scan_iterator<float>   Polygon_scan;
+using Point_type = vgl_polygon<float>::point_t;
+using Polygon_type = vgl_polygon<float>;
+using Polygon_scan = vgl_polygon_scan_iterator<float>;
 
 static void
 test_without_boundary()

--- a/core/vil/Templates/vil_copy+vil_rgb+byte--.cxx
+++ b/core/vil/Templates/vil_copy+vil_rgb+byte--.cxx
@@ -1,5 +1,5 @@
 #include <vxl_config.h>
 #include <vil/vil_rgb.h>
 #include <vil/vil_copy.hxx>
-typedef vil_rgb<vxl_byte> rgb_byte;
+using rgb_byte = vil_rgb<vxl_byte>;
 VIL_COPY_INSTANTIATE(rgb_byte);

--- a/core/vil/algo/vil_blob.cxx
+++ b/core/vil/algo/vil_blob.cxx
@@ -17,8 +17,8 @@ namespace
   // although no code was copied.
   class disjoint_sets
   {
-    typedef unsigned LABEL;
-    typedef unsigned LEN;
+    using LABEL = unsigned int;
+    using LEN = unsigned int;
     struct node
     {
       LABEL parent;

--- a/core/vil/file_formats/vil_jpeg_destination_mgr.cxx
+++ b/core/vil/file_formats/vil_jpeg_destination_mgr.cxx
@@ -29,7 +29,7 @@
 // Adapted by fsm from the FILE * version in jdatadst.c
 
 #define vil_jpeg_OUTPUT_BUF_SIZE  4096 // choose an efficiently fwrite'able size
-typedef vil_jpeg_stream_destination_mgr *vil_jpeg_dstptr;
+using vil_jpeg_dstptr = vil_jpeg_stream_destination_mgr *;
 
 
 //  * Initialize destination --- called by jpeg_start_compress

--- a/core/vil/file_formats/vil_jpeg_source_mgr.cxx
+++ b/core/vil/file_formats/vil_jpeg_source_mgr.cxx
@@ -30,7 +30,7 @@
 // Adapted by fsm from the FILE * version in jdatasrc.c
 
 #define vil_jpeg_INPUT_BUF_SIZE  4096 // choose an efficiently fread'able size
-typedef vil_jpeg_stream_source_mgr *vil_jpeg_srcptr;
+using vil_jpeg_srcptr = vil_jpeg_stream_source_mgr *;
 
 
 // * Initialize source --- called by jpeg_read_header

--- a/core/vil/file_formats/vil_openjpeg.cxx
+++ b/core/vil/file_formats/vil_openjpeg.cxx
@@ -38,7 +38,7 @@ extern "C" {
 #include "vil_openjpeg.h"
 
 
-typedef vbl_smart_ptr<vil_stream> vil_stream_sptr;
+using vil_stream_sptr = vbl_smart_ptr<vil_stream>;
 
 //------------------------------------------------------------------------------
 // Taken from

--- a/core/vil/tests/test_image_loader_robustness.cxx
+++ b/core/vil/tests/test_image_loader_robustness.cxx
@@ -10,7 +10,7 @@
 #include <vil/vil_stream.h>
 #include <testlib/testlib_test.h>
 
-typedef vil_smart_ptr<vil_stream> vil_stream_sptr;
+using vil_stream_sptr = vil_smart_ptr<vil_stream>;
 
 static unsigned long rand_next;
 

--- a/core/vil/tests/test_image_view.cxx
+++ b/core/vil/tests/test_image_view.cxx
@@ -463,7 +463,7 @@ static void test_image_view_assignment_operator()
 
   testlib_test_begin( "Assignment operator" );
 
-  typedef vil_image_view<vxl_byte> byte_view;
+  using byte_view = vil_image_view<vxl_byte>;
 
   // Construct two views with non-zero reference counts
   //

--- a/core/vil1/Templates/vil1_memory_image_of+vil1_rgb+uchar--.cxx
+++ b/core/vil1/Templates/vil1_memory_image_of+vil1_rgb+uchar--.cxx
@@ -5,6 +5,6 @@
 #include <vil1/vil1_rgb.h>
 #include <vil1/vil1_memory_image_of.hxx>
 
-typedef unsigned char byte;
+using byte = unsigned char;
 
 VIL1_MEMORY_IMAGE_OF_INSTANTIATE(vil1_rgb<byte>);

--- a/core/vil1/Templates/vil1_memory_image_of+vil1_rgb+vxl_uint_16--.cxx
+++ b/core/vil1/Templates/vil1_memory_image_of+vil1_rgb+vxl_uint_16--.cxx
@@ -2,6 +2,6 @@
 #include <vil1/vil1_memory_image_of.hxx>
 #include <vxl_config.h>
 
-typedef vxl_uint_16 word;
+using word = vxl_uint_16;
 
 VIL1_MEMORY_IMAGE_OF_INSTANTIATE(vil1_rgb<word>);

--- a/core/vil1/Templates/vil1_ssd+uchar.uchar.int-.cxx
+++ b/core/vil1/Templates/vil1_ssd+uchar.uchar.int-.cxx
@@ -1,6 +1,6 @@
 #include <vil1/vil1_ssd.h>
 #include <vil1/vil1_ssd.hxx>
 
-typedef unsigned char byte;
+using byte = unsigned char;
 
 VIL1_SSD_INSTANTIATE(byte, byte, int);

--- a/core/vil1/examples/vil1_print_section.cxx
+++ b/core/vil1/examples/vil1_print_section.cxx
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
   std::cerr << "image is " << I.width() << 'x' << I.height() << std::endl;
   assert(0<=x0 && 0<=y0 && x0+int(w)<=I.width() && y0+int(h)<=I.height());
 
-  typedef unsigned char byte;
+  using byte = unsigned char;
   if (I.planes()==1 && I.components()==3 && I.bits_per_component()==8)
   {
     std::vector<byte> buf(3*w*h);

--- a/core/vil1/examples/vil1_rgb_example.cxx
+++ b/core/vil1/examples/vil1_rgb_example.cxx
@@ -7,7 +7,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <vil1/vil1_rgb.h>
-typedef vil1_rgb<unsigned char> vil1_rgb_cell;
+using vil1_rgb_cell = vil1_rgb<unsigned char>;
 
 static char* as_hex(vil1_rgb_cell const&);
 

--- a/core/vil1/file_formats/vil1_jpeg_destination_mgr.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_destination_mgr.cxx
@@ -25,7 +25,7 @@
 // Adapted by fsm from the FILE * version in jdatadst.c
 
 #define vil1_jpeg_OUTPUT_BUF_SIZE  4096 // choose an efficiently fwrite'able size
-typedef vil1_jpeg_stream_destination_mgr *vil1_jpeg_dstptr;
+using vil1_jpeg_dstptr = vil1_jpeg_stream_destination_mgr *;
 
 
 //  * Initialize destination --- called by jpeg_start_compress

--- a/core/vil1/file_formats/vil1_jpeg_source_mgr.cxx
+++ b/core/vil1/file_formats/vil1_jpeg_source_mgr.cxx
@@ -25,7 +25,7 @@
 // Adapted by fsm from the FILE * version in jdatasrc.c
 
 #define vil1_jpeg_INPUT_BUF_SIZE  4096 // choose an efficiently fread'able size
-typedef vil1_jpeg_stream_source_mgr *vil1_jpeg_srcptr;
+using vil1_jpeg_srcptr = vil1_jpeg_stream_source_mgr *;
 
 
 // * Initialize source --- called by jpeg_read_header

--- a/core/vil1/tests/test_file_format_read.cxx
+++ b/core/vil1/tests/test_file_format_read.cxx
@@ -25,7 +25,7 @@
 static std::string image_base;
 
 // Set to "double", which is the only type that can (roughly) represent all data types
-typedef double TruePixelType;
+using TruePixelType = double;
 
 class CheckPixel
 {

--- a/core/vil1/vil1_16bit.cxx
+++ b/core/vil1/vil1_16bit.cxx
@@ -7,8 +7,8 @@
 #include <vil1/vil1_stream.h>
 #include <vxl_config.h>
 
-typedef vxl_uint_8  word8;
-typedef vxl_uint_16 word16;
+using word8 = vxl_uint_8;
+using word16 = vxl_uint_16;
 
 unsigned vil1_16bit_read_big_endian(vil1_stream *s)
 {

--- a/core/vil1/vil1_32bit.cxx
+++ b/core/vil1/vil1_32bit.cxx
@@ -8,8 +8,8 @@
 #include <vil1/vil1_stream.h>
 #include <vxl_config.h>
 
-typedef vxl_uint_8  word8;
-typedef vxl_uint_32 word32;
+using word8 = vxl_uint_8;
+using word32 = vxl_uint_32;
 
 unsigned vil1_32bit_read_big_endian(vil1_stream *s)
 {

--- a/core/vil1/vil1_image_as.cxx
+++ b/core/vil1/vil1_image_as.cxx
@@ -22,7 +22,7 @@
 template <class T>
 struct vil1_image_as_impl : public vil1_image_impl, public vil1_memory_image_of_format<T>
 {
-  typedef vil1_memory_image_of_format<T> format;
+  using format = vil1_memory_image_of_format<T>;
   vil1_image image;
   vil1_image_as_impl(vil1_image const &underlying) : image(underlying) { }
   int planes() const override { return 1; }
@@ -256,7 +256,7 @@ template bool convert_rgba_to_rgb( const vil1_image&, void*, int, int, int, int,
 template <> // specialize for byte.
 bool vil1_image_as_impl<vxl_byte>::get_section(void *buf, int x0, int y0, int width, int height) const
 {
-  typedef vxl_byte Outtype;
+  using Outtype = vxl_byte;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -319,7 +319,7 @@ vil1_image vil1_image_as(vil1_image const &image, vxl_byte*)
 template <> // specialize for vxl_uint_16.
 bool vil1_image_as_impl<vxl_uint_16>::get_section(void *buf, int x0, int y0, int width, int height) const
 {
-  typedef vxl_uint_16 Outtype;
+  using Outtype = vxl_uint_16;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -381,7 +381,7 @@ vil1_image vil1_image_as(vil1_image const &image, vxl_uint_16*)
 template <> // specialize for int.
 bool vil1_image_as_impl<int>::get_section(void *buf, int x0, int y0, int width, int height) const
 {
-  typedef int Outtype;
+  using Outtype = int;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -442,7 +442,7 @@ vil1_image vil1_image_as(vil1_image const &image, int*)
 template <> // specialize for float.
 bool vil1_image_as_impl<float>::get_section(void *buf, int x0, int y0, int width, int height) const
 {
-  typedef float Outtype;
+  using Outtype = float;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -503,7 +503,7 @@ vil1_image vil1_image_as(vil1_image const &image, float*)
 template <> // specialize for double.
 bool vil1_image_as_impl<double>::get_section(void *buf, int x0, int y0, int width, int height) const
 {
-  typedef double Outtype;
+  using Outtype = double;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -566,7 +566,7 @@ bool vil1_image_as_impl<vil1_rgb<unsigned char> >::get_section(void *buf,
                                                                int x0, int y0,
                                                                int width, int height) const
 {
-  typedef unsigned char Outtype;
+  using Outtype = unsigned char;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -631,7 +631,7 @@ bool vil1_image_as_impl<vil1_rgb<float> >::get_section(void *buf,
                                                        int x0, int y0,
                                                        int width, int height) const
 {
-  typedef float Outtype;
+  using Outtype = float;
 
   switch ( vil1_pixel_format(image) )
   {
@@ -697,7 +697,7 @@ bool vil1_image_as_impl<vil1_rgb<vxl_uint_16> >::get_section(void *buf,
                                                              int x0, int y0,
                                                              int width, int height) const
 {
-  typedef vxl_uint_16 Outtype;
+  using Outtype = vxl_uint_16;
 
   switch ( vil1_pixel_format(image) )
   {

--- a/core/vnl/Templates/vnl_matrix_exp+vnl_matrix+double--.cxx
+++ b/core/vnl/Templates/vnl_matrix_exp+vnl_matrix+double--.cxx
@@ -1,5 +1,5 @@
 #include <vnl/vnl_matrix_exp.hxx>
 #include <vnl/vnl_matrix.h>
 
-typedef vnl_matrix<double> T;
+using T = vnl_matrix<double>;
 VNL_MATRIX_EXP_INSTANTIATE( T );

--- a/core/vnl/algo/tests/test_qr.cxx
+++ b/core/vnl/algo/tests/test_qr.cxx
@@ -117,7 +117,7 @@ inst(std::complex<double>);
 
 void complex_test()
 {
-  typedef std::complex<double> ct;
+  using ct = std::complex<double>;
 
   vnl_matrix<ct> A(5,4); // #rows must be >= #cols when using netlib QR decomposition
   vnl_vector<ct> b(5);

--- a/core/vnl/algo/tests/test_svd.cxx
+++ b/core/vnl/algo/tests/test_svd.cxx
@@ -16,7 +16,7 @@ template <class T, class S> static
 void test_hilbert(T /*dummy*/, char const* type, S residual)
 {
   std::cout << "----- Testing svd<"<<type<<">(Hilbert_3x3) -----" << std::endl;
-  typedef typename vnl_numeric_traits<T>::abs_t abs_t;
+  using abs_t = typename vnl_numeric_traits<T>::abs_t;
   // Test inversion and recomposition of 5x5 hilbert matrix
   vnl_matrix<T> H(5,5);
   for (int i = 0; i < 5; ++i)

--- a/core/vnl/algo/tests/test_svd_fixed.cxx
+++ b/core/vnl/algo/tests/test_svd_fixed.cxx
@@ -19,7 +19,7 @@ template <class T, class S> static
 void test_hilbert(T /*dummy*/, char const* type, S residual)
 {
   std::cout << "----- Testing svd_fixed<"<<type<<">(Hilbert_3x3) -----" << std::endl;
-  typedef typename vnl_numeric_traits<T>::abs_t abs_t;
+  using abs_t = typename vnl_numeric_traits<T>::abs_t;
   // Test inversion and recomposition of 3x3 hilbert matrix
   vnl_matrix_fixed<T,3,3> H;
   for (int i = 0; i < 3; ++i)

--- a/core/vnl/examples/calculate.cxx
+++ b/core/vnl/examples/calculate.cxx
@@ -48,9 +48,9 @@ vnl_decnum diff(vnl_decnum const& a, vnl_decnum const& b) { return a-b; }
 vnl_decnum fac(vnl_decnum const& a) { if (a<=one) return one; else return a*fac(a-one); }
 vnl_decnum binom(vnl_decnum const& a, vnl_decnum const& b) { if (a<zero || b<zero || a<b) return zero; return fac(a)/fac(a-b)/fac(b); }
 
-typedef vnl_decnum (*fptr1) (vnl_decnum const&);
-typedef vnl_decnum (*fptr2) (vnl_decnum const&,vnl_decnum const&);
-typedef vnl_decnum (*fptr3) (vnl_decnum const&,unsigned long);
+using fptr1 = vnl_decnum (*)(const vnl_decnum &);
+using fptr2 = vnl_decnum (*)(const vnl_decnum &, const vnl_decnum &);
+using fptr3 = vnl_decnum (*)(const vnl_decnum &, unsigned long);
 
 class node
 {

--- a/core/vnl/io/Templates/vsl_map_io+vcl_string.vcl_vector+vnl_vector+double---.cxx
+++ b/core/vnl/io/Templates/vsl_map_io+vcl_string.vcl_vector+vnl_vector+double---.cxx
@@ -6,5 +6,5 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <vnl/io/vnl_io_vector.h>
-typedef std::vector< vnl_vector<double> > value;
+using value = std::vector<vnl_vector<double> >;
 VSL_MAP_IO_INSTANTIATE(std::string, value, std::less<std::string>);

--- a/core/vnl/io/Templates/vsl_vector_io+vcl_vector+vcl_vector+vnl_vector+double----.cxx
+++ b/core/vnl/io/Templates/vsl_vector_io+vcl_vector+vcl_vector+vnl_vector+double----.cxx
@@ -1,5 +1,5 @@
 #include <vsl/vsl_vector_io.hxx>
 #include <vnl/io/vnl_io_vector.h>
 
-typedef std::vector < std::vector< vnl_vector<double> > > cvec_cvec_nvec_double;
+using cvec_cvec_nvec_double = std::vector<std::vector<vnl_vector<double> > >;
 VSL_VECTOR_IO_INSTANTIATE( cvec_cvec_nvec_double );

--- a/core/vnl/tests/test_vnl_index_sort.cxx
+++ b/core/vnl/tests/test_vnl_index_sort.cxx
@@ -82,13 +82,13 @@ int main( int argc, char *argv[] )
 
 int test_vnl_index_sort()
 {
-  typedef double             MeasurementValueType;
-  typedef vnl_vector<MeasurementValueType> MeasurementVectorType;
-  typedef vnl_matrix<MeasurementValueType> MeasurementMatrixType;
+  using MeasurementValueType = double;
+  using MeasurementVectorType = vnl_vector<MeasurementValueType>;
+  using MeasurementMatrixType = vnl_matrix<MeasurementValueType>;
 
-  typedef int                RankValType;
-  typedef vnl_vector<RankValType> IndexVectorType;
-  typedef vnl_matrix<RankValType> IndexMatrixType;
+  using RankValType = int;
+  using IndexVectorType = vnl_vector<RankValType>;
+  using IndexMatrixType = vnl_matrix<RankValType>;
 
   typedef vnl_index_sort<MeasurementValueType, RankValType> IndexSortType;
 

--- a/core/vnl/vnl_bignum.cxx
+++ b/core/vnl/vnl_bignum.cxx
@@ -12,8 +12,8 @@
 
 #include <vnl/vnl_math.h> // for vnl_math::isfinite(double)
 
-typedef unsigned short Counter;
-typedef unsigned short Data;
+using Counter = unsigned short;
+using Data = unsigned short;
 
 //: Creates a zero vnl_bignum.
 

--- a/core/vpdl/tests/test_mixture_of.cxx
+++ b/core/vpdl/tests/test_mixture_of.cxx
@@ -259,7 +259,7 @@ void test_mixture_of_type(T epsilon, const std::string& type_name)
     vpdl_gaussian_indep<T> gauss2(mean2.as_ref(),var2.as_ref());
     vpdl_gaussian_indep<T> gauss3(mean3.as_ref(),var3.as_ref());
 
-    typedef vpdl_gaussian_indep<T> dist_t;
+    using dist_t = vpdl_gaussian_indep<T>;
     vpdl_mixture_of<dist_t> mixture;
 
     TEST(("initial num_components <"+type_name+">").c_str(),

--- a/core/vpdl/tests/test_update_mog.cxx
+++ b/core/vpdl/tests/test_update_mog.cxx
@@ -22,7 +22,7 @@ void test_update_mog_type(T epsilon, const std::string& type_name, T inf)
   data.push_back(vnl_vector_fixed<T,3>(-10,5,0));
 
   typedef vpdt_gaussian<vnl_vector_fixed<T,3>,T> gauss3_t;
-  typedef vpdt_mixture_of<gauss3_t> mog_t;
+  using mog_t = vpdt_mixture_of<gauss3_t>;
 
   vpdt_mog_sg_updater<mog_t> mog_updater(gauss3_t(vnl_vector_fixed<T,3>(0.0),1));
 

--- a/core/vpgl/Templates/vbl_smart_ptr+vpgl_camera+double--.cxx
+++ b/core/vpgl/Templates/vbl_smart_ptr+vpgl_camera+double--.cxx
@@ -1,5 +1,5 @@
 #include <vpgl/vpgl_camera.h>
 #include <vbl/vbl_smart_ptr.hxx>
 
-typedef vpgl_camera<double> vpgl_camera_double;
+using vpgl_camera_double = vpgl_camera<double>;
 VBL_SMART_PTR_INSTANTIATE(vpgl_camera_double);

--- a/core/vpgl/Templates/vbl_smart_ptr+vpgl_camera+float--.cxx
+++ b/core/vpgl/Templates/vbl_smart_ptr+vpgl_camera+float--.cxx
@@ -1,5 +1,5 @@
 #include <vpgl/vpgl_camera.h>
 #include <vbl/vbl_smart_ptr.hxx>
 
-typedef vpgl_camera<float> vpgl_camera_float;
+using vpgl_camera_float = vpgl_camera<float>;
 VBL_SMART_PTR_INSTANTIATE(vpgl_camera_float);

--- a/core/vpgl/io/Templates/vbl_io_smart_ptr+vpgl_camera+double--.cxx
+++ b/core/vpgl/io/Templates/vbl_io_smart_ptr+vpgl_camera+double--.cxx
@@ -2,5 +2,5 @@
 #include <vpgl/io/vpgl_io_camera.h>
 #include <vbl/io/vbl_io_smart_ptr.hxx>
 
-typedef vpgl_camera<double> vpgl_camera_double;
+using vpgl_camera_double = vpgl_camera<double>;
 VBL_IO_SMART_PTR_INSTANTIATE(vpgl_camera_double);

--- a/core/vpgl/io/Templates/vbl_io_smart_ptr+vpgl_camera+float--.cxx
+++ b/core/vpgl/io/Templates/vbl_io_smart_ptr+vpgl_camera+float--.cxx
@@ -2,5 +2,5 @@
 #include <vpgl/io/vpgl_io_camera.h>
 #include <vbl/io/vbl_io_smart_ptr.hxx>
 
-typedef vpgl_camera<float> vpgl_camera_float;
+using vpgl_camera_float = vpgl_camera<float>;
 VBL_IO_SMART_PTR_INSTANTIATE(vpgl_camera_float);

--- a/core/vsl/Templates/vsl_map_io+vcl_string.vcl_vector+float--.cxx
+++ b/core/vsl/Templates/vsl_map_io+vcl_string.vcl_vector+float--.cxx
@@ -6,6 +6,6 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <vsl/vsl_map_io.hxx>
-typedef std::vector<float> vec_float;
-typedef std::less<std::string> comp;
+using vec_float = std::vector<float>;
+using comp = std::less<std::string>;
 VSL_MAP_IO_INSTANTIATE(std::string, vec_float, comp);

--- a/core/vsl/Templates/vsl_map_io+vcl_string.vcl_vector+ulong--.cxx
+++ b/core/vsl/Templates/vsl_map_io+vcl_string.vcl_vector+ulong--.cxx
@@ -6,6 +6,6 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <vsl/vsl_map_io.hxx>
-typedef std::vector<unsigned long> vec_ulong;
-typedef std::less<std::string> comp;
+using vec_ulong = std::vector<unsigned long>;
+using comp = std::less<std::string>;
 VSL_MAP_IO_INSTANTIATE(std::string, vec_ulong, comp);

--- a/core/vsl/vsl_binary_loader_base.cxx
+++ b/core/vsl/vsl_binary_loader_base.cxx
@@ -14,7 +14,7 @@
 static std::vector<vsl_binary_loader_base*> *loader_list_ = nullptr;
 
 
-typedef void (*clear_func_ptr) ();
+using clear_func_ptr = void (*)();
 // List of all extra loaders clear funcs registered()'ed
 // Create on heap so that it can be cleaned up itself
 static std::vector<clear_func_ptr> *extra_loader_clear_list_ = nullptr;

--- a/v3p/netlib/tests/lsmrTest2.cxx
+++ b/v3p/netlib/tests/lsmrTest2.cxx
@@ -54,7 +54,7 @@ int main( int , char * [] )
   bb[2] = 2.0;
 
   //  -3  5
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);

--- a/v3p/netlib/tests/lsqrTest1.cxx
+++ b/v3p/netlib/tests/lsqrTest1.cxx
@@ -214,7 +214,7 @@ int main( int , char * [] )
   double xx[nn];
   xx[0] = 1.0;
   xx[1] = 7.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[4];
   A[0] = &(AA[0]);
@@ -238,7 +238,7 @@ int main( int , char * [] )
   xx[0] = 1.0;
   xx[1] = 7.0;
   xx[2] = 9.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);
@@ -263,7 +263,7 @@ int main( int , char * [] )
   double xx[nn];
   xx[0] = 1.0;
   xx[1] = 7.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);
@@ -290,7 +290,7 @@ int main( int , char * [] )
   double xx[nn];
   xx[0] = 0.0;
   xx[1] = 0.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[4];
   A[0] = &(AA[0]);
@@ -314,7 +314,7 @@ int main( int , char * [] )
   xx[0] = 0.0;
   xx[1] = 0.0;
   xx[2] = 0.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);
@@ -339,7 +339,7 @@ int main( int , char * [] )
   double xx[nn];
   xx[0] = 0.0;
   xx[1] = 0.0;
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);
@@ -368,7 +368,7 @@ int main( int , char * [] )
   bb[1] = 7.0;
   double xx[mm];
   solver.SetStandardErrorEstimatesFlag( false );
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[4];
   A[0] = &(AA[0]);
@@ -393,7 +393,7 @@ int main( int , char * [] )
   solver.SetStandardErrorEstimatesFlag( true );
   double se[nn];
   solver.SetStandardErrorEstimates( se );
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[4];
   A[0] = &(AA[0]);
@@ -420,7 +420,7 @@ int main( int , char * [] )
   solver.SetStandardErrorEstimatesFlag( true );
   double se[nn];
   solver.SetStandardErrorEstimates( se );
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[4];
   A[0] = &(AA[0]);

--- a/v3p/netlib/tests/lsqrTest2.cxx
+++ b/v3p/netlib/tests/lsqrTest2.cxx
@@ -60,7 +60,7 @@ int main( int , char * [] )
   solver.SetStandardErrorEstimates( se );
 
   //  -3  5
-  typedef double * RowType;
+  using RowType = double *;
   RowType A[mm];
   double AA[6];
   A[0] = &(AA[0]);

--- a/vcl/tests/test_deque.cxx
+++ b/vcl/tests/test_deque.cxx
@@ -6,7 +6,7 @@
 
 int test_deque_main(int /*argc*/,char* /*argv*/[])
 {
-  typedef std::deque<int> mydeque;
+  using mydeque = std::deque<int>;
   mydeque dq;
 
   dq.push_front(2);

--- a/vcl/tests/test_list.cxx
+++ b/vcl/tests/test_list.cxx
@@ -7,7 +7,7 @@
 
 int test_list_main(int /*argc*/,char* /*argv*/[])
 {
-  typedef std::list<int> container;
+  using container = std::list<int>;
   container m;
 
   m.push_back(1);

--- a/vcl/tests/test_typename.cxx
+++ b/vcl/tests/test_typename.cxx
@@ -16,14 +16,14 @@ class vcl_test_vec
 template <class T>
 struct vcl_test_type_templ
 {
-  typedef vcl_test_vec<T> type;
+  using type = vcl_test_vec<T>;
 };
 
 template <class T>
 class vcl_test_typename
 {
  public:
-  typedef typename vcl_test_type_templ<T>::type vector;
+  using vector = typename vcl_test_type_templ<T>::type;
   vector v;
 
   vcl_test_typename() { if (vcl_test_typename_func(v) < 1) v = 1; }

--- a/vcl/tests/test_vector.cxx
+++ b/vcl/tests/test_vector.cxx
@@ -26,7 +26,7 @@ int test_vector_main(int /*argc*/,char* /*argv*/[])
 {
   bool fail = false;
   {
-    typedef std::vector<int> container;
+    using container = std::vector<int>;
     container m;
 
     m.push_back(1);


### PR DESCRIPTION
The check converts the usage of typedef with using keyword.

SRCDIR=/Users/johnsonhj/src/vxl #My local SRC
BLDDIR=/Users/johnsonhj/src/vxl-clang #My local BLD

cd /Users/johnsonhj/src/vxl-clang
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-using  -header-filter=.* -fix
