### PR TITLE
PERF/ENH: BSGM memory, BPGL rectification

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
@@ -269,7 +269,8 @@ compute_rectification(vgl_box_3d<double>const& scene_box)
   return true;
 }
 
-
+// provide the possibility of NAN as an invalid pixel value. Useful for subsequent
+// processing to avoid the invalid warp regions in the rectified image.
 void bpgl_rectify_affine_image_pair::
 warp_image(vil_image_view<float> fview,
            vnl_matrix_fixed<double, 3, 3> const& H,
@@ -280,7 +281,7 @@ warp_image(vil_image_view<float> fview,
   double dni = static_cast<double>(ni);
   double dnj = static_cast<double>(nj);
   fwarp.set_size(out_ni, out_nj);
-  fwarp.fill(0.0f);
+  fwarp.fill(params_.invalid_pixel_val_);
   vnl_matrix_fixed<double, 3, 3> Hinv = vnl_inverse(H);
   for(size_t j =0; j<out_nj; ++j)
     for(size_t i =0; i<out_ni; ++i){

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
@@ -15,10 +15,11 @@
 #include <vnl/vnl_matrix_fixed.h>
 
 struct rectify_params{
-  rectify_params(): min_disparity_z_(NAN), n_points_(1000), upsample_scale_(1.0){}
+  rectify_params(): min_disparity_z_(NAN), n_points_(1000), upsample_scale_(1.0), invalid_pixel_val_(0.0f){}
   double min_disparity_z_; // horizontal plane where disparity at each pixel is minimum
   size_t n_points_;            // number of points used to create correspondences
   double upsample_scale_;      // scale factor to upsample rectified images
+  float invalid_pixel_val_;
 };
 
 //
@@ -50,10 +51,12 @@ class bpgl_rectify_affine_image_pair
   }
 
   //: set parameter values
-  void set_param_values(double min_disparity_z = NAN, size_t n_points = 1000, double upsample_scale =1.0){
+  void set_param_values(double min_disparity_z = NAN, size_t n_points = 1000,
+                        double upsample_scale =1.0, float invalid_pixel_val = 0.0f){
     params_.min_disparity_z_ = min_disparity_z;
     params_.n_points_ = n_points;
     params_.upsample_scale_ = upsample_scale;
+    params_.invalid_pixel_val_ = invalid_pixel_val;
   }
 
   //: set images & cameras
@@ -103,10 +106,10 @@ class bpgl_rectify_affine_image_pair
   // protected utility methods
   bool compute_rectification(vgl_box_3d<double> const& scene_box);
   void compute_warp_dimensions_offsets();
-  static void warp_image(vil_image_view<float> fview,
-                         vnl_matrix_fixed<double, 3, 3> const& H,
-                         vil_image_view<float>& fwarp,
-                         size_t out_ni, size_t out_nj);
+  void warp_image(vil_image_view<float> fview,
+                  vnl_matrix_fixed<double, 3, 3> const& H,
+                  vil_image_view<float>& fwarp,
+                  size_t out_ni, size_t out_nj);
   void warp_pair();
 
  private:

--- a/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.h
+++ b/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.h
@@ -160,14 +160,10 @@ class bsgm_disparity_estimator
   //: Raw storage for the cost volumes
   // Element x,y,d is at location y*w_*num_disparities + x*num_disparities + d
   std::vector<unsigned short> total_cost_data_;
-  std::vector<unsigned char> census_cost_data_;
-  std::vector<unsigned char> xgrad_cost_data_;
   std::vector<unsigned char> fused_cost_data_;
 
   //: Convenience image of pointers into the cost volumes
   std::vector< std::vector< unsigned short* > > total_cost_;
-  std::vector< std::vector< unsigned char* > > census_cost_;
-  std::vector< std::vector< unsigned char* > > xgrad_cost_;
   std::vector< std::vector< unsigned char* > > fused_cost_;
 
   std::vector< std::vector< unsigned char* > >* active_app_cost_;


### PR DESCRIPTION
## PR Checklist
:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: Makes design changes to existing vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
:no_entry_sign: Adds tests and baseline comparison (quantitative).
:no_entry_sign: Adds Documentation.

## PR Description
Contrib changes as follows:
- BSGM: 2x reduction in `bsgm_disparity_estimator` memory consumption  (eliminating separate census and x-gradient matrices, favoring only a single fused matrix) + additional census cost refactoring 
- BGPL: allow user to define invalid pixel fill value for `bpgl_rectify_affine_image_pair`

