### PR TITLE
BUG: revert std::stod/stoi for c-style code

### DIFF
--- a/contrib/brl/b3p/shapelib/dbfopen.c
+++ b/contrib/brl/b3p/shapelib/dbfopen.c
@@ -109,13 +109,13 @@
  * Avoid crashing if field or record are out of range in dbfread*attribute().
  *
  * Revision 1.22  1999/12/15 13:47:24  warmerda
- * Added stdlib.h to ensure that std::stod() is prototyped.
+ * Added stdlib.h to ensure that atof() is prototyped.
  *
  * Revision 1.21  1999/12/13 17:25:46  warmerda
  * Added support for upper case .DBF extention.
  *
  * Revision 1.20  1999/11/30 16:32:11  warmerda
- * Use std::stod() instead of sscanf().
+ * Use atof() instead of sscanf().
  *
  * Revision 1.19  1999/11/05 14:12:04  warmerda
  * updated license terms
@@ -743,7 +743,7 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
 /* -------------------------------------------------------------------- */
     if ( chReqType == 'N' )
     {
-        dDoubleField = std::stod(pszStringField);
+        dDoubleField = atof(pszStringField);
 
         pReturnField = &dDoubleField;
     }

--- a/v3p/geotiff/bin/csv2html.c
+++ b/v3p/geotiff/bin/csv2html.c
@@ -91,7 +91,7 @@ int main( int nArgc, char ** papszArgv )
                                                sizeof(int) * nColumns);
 
             for( j = 0; j < nColumns; j++ )
-                panColumnList[j] = std::stoi(papszList[j]);
+                panColumnList[j] = atoi(papszList[j]);
 
             CSLDestroy( papszList );
         }
@@ -193,17 +193,17 @@ CSV2HTML( const char * pszFilename, int nColumns, int * panColumns,
         {
             if( EQUALN(papszOptions[i],"CODE=",5) )
             {
-                if( std::stoi(papszOptions[i]+5) != std::stoi(papszFields[0]) )
+                if( atoi(papszOptions[i]+5) != atoi(papszFields[0]) )
                     bDisplay = FALSE;
             }
             else if( EQUALN(papszOptions[i],"CODE<",5) )
             {
-                if( std::stoi(papszOptions[i]+5) <= std::stoi(papszFields[0]) )
+                if( atoi(papszOptions[i]+5) <= atoi(papszFields[0]) )
                     bDisplay = FALSE;
             }
             else if( EQUALN(papszOptions[i],"CODE>",5) )
             {
-                if( std::stoi(papszOptions[i]+5) >= std::stoi(papszFields[0]) )
+                if( atoi(papszOptions[i]+5) >= atoi(papszFields[0]) )
                     bDisplay = FALSE;
             }
             else if( EQUALN(papszOptions[i],"NAMEKEY=",8) )


### PR DESCRIPTION
## PR Checklist
:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning 
:no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning 
:no_entry_sign: Adds tests and baseline comparison (quantitative)
:no_entry_sign: Adds Documentation.

## PR Description
PR #653 converted atoi -> std::stoi and atof -> std::stod.  This change breaks c-style libraries which are unable to access c++ std library features.   Revert c-style libraries to atoi and atof.  

Note this issue was not caught as VXL tests do not build contrib.