### PR TITLE
Gcc 9 compiler warnings

### DIFF
--- a/core/vbl/vbl_local_minima.hxx
+++ b/core/vbl/vbl_local_minima.hxx
@@ -66,8 +66,8 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
   T ll,  lm, lr;
   T dmin;
   //general case
-  if (nr>2&&nc>2)
-    for (unsigned r = 1; r<nr-1; ++r)
+  if (nr>2&&nc>2) {
+    for (unsigned r = 1; r<nr-1; ++r) {
       for (unsigned c = 1; c<nc-1; ++c) {
         // xxxxxxxxxxxxxxxxxxxxxxx
         // xxxx   ul um  ur  xxxxx
@@ -83,19 +83,37 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
         lm = in[r+1][c]   - in[r][c];
         lr = in[r+1][c+1] - in[r][c];
         dmin = mval;
-        if (ul<=thresh) continue; if (ul<dmin) dmin = ul;
-        if (um<=thresh) continue; if (um<dmin) dmin = um;
-        if (ur<=thresh) continue; if (ur<dmin) dmin = ur;
-        if (lf<=thresh) continue; if (lf<dmin) dmin = lf;
-        if (ri<=thresh) continue; if (ri<dmin) dmin = ri;
-        if (ll<=thresh) continue; if (ll<dmin) dmin = ll;
-        if (lm<=thresh) continue; if (lm<dmin) dmin = lm;
-        if (lr<=thresh) continue; if (lr<dmin) dmin = lr;
+        if (ul<=thresh) continue;
+        if (ul<dmin) { dmin = ul; }
+
+        if (um<=thresh) continue;
+        if (um<dmin) { dmin = um; }
+
+        if (ur<=thresh) continue;
+        if (ur<dmin) { dmin = ur; }
+
+        if (lf<=thresh) continue;
+        if (lf<dmin) { dmin = lf; }
+
+        if (ri<=thresh) continue;
+        if (ri<dmin) { dmin = ri; }
+
+        if (ll<=thresh) continue;
+        if (ll<dmin) { dmin = ll; }
+
+        if (lm<=thresh) continue;
+        if (lm<dmin) { dmin = lm; }
+
+        if (lr<=thresh) continue;
+        if (lr<dmin) { dmin = lr; }
+
         if (dmin>thresh) {
           minima[r][c] = dmin;
           minima_found = true;
         }
       }
+    }
+  }
 
   // special cases at the borders
   if (nc>2) {
@@ -110,11 +128,20 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
       lm = in[1][c]     - in[0][c];
       lr = in[1][c+1]   - in[0][c];
       dmin = mval;
-      if (lf<=thresh) continue; if (lf<dmin) dmin = lf;
-      if (ri<=thresh) continue; if (ri<dmin) dmin = ri;
-      if (ll<=thresh) continue; if (ll<dmin) dmin = ll;
-      if (lm<=thresh) continue; if (lm<dmin) dmin = lm;
-      if (lr<=thresh) continue; if (lr<dmin) dmin = lr;
+      if (lf<=thresh) continue;
+      if (lf<dmin) { dmin = lf; }
+
+      if (ri<=thresh) continue;
+      if (ri<dmin) { dmin = ri; }
+
+      if (ll<=thresh) continue;
+      if (ll<dmin) { dmin = ll; }
+
+      if (lm<=thresh) continue;
+      if (lm<dmin) { dmin = lm; }
+
+      if (lr<=thresh) continue;
+      if (lr<dmin) { dmin = lr; }
       if (dmin>thresh) {
         minima[0][c] = dmin;
         minima_found = true;
@@ -131,11 +158,16 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
       lf = in[nr-1][c-1] - in[nr-1][c];
       ri = in[nr-1][c+1] - in[nr-1][c];
       dmin = mval;
-      if (ul<=thresh) continue; if (ul<dmin) dmin = ul;
-      if (um<=thresh) continue; if (um<dmin) dmin = um;
-      if (ur<=thresh) continue; if (ur<dmin) dmin = ur;
-      if (lf<=thresh) continue; if (lf<dmin) dmin = lf;
-      if (ri<=thresh) continue; if (ri<dmin) dmin = ri;
+      if (ul<=thresh) continue;
+      if (ul<dmin) { dmin = ul; }
+      if (um<=thresh) continue;
+      if (um<dmin) { dmin = um; }
+      if (ur<=thresh) continue;
+      if (ur<dmin) { dmin = ur; }
+      if (lf<=thresh) continue;
+      if (lf<dmin) { dmin = lf; }
+      if (ri<=thresh) continue;
+      if (ri<dmin) { dmin = ri; }
       if (dmin>thresh) {
         minima[nr-1][c] = dmin;
         minima_found = true;
@@ -154,11 +186,21 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
       lm = in[r+1][0] - in[r][0];
       lr = in[r+1][1] - in[r][0];
       dmin = mval;
-      if (um<=thresh) continue; if (um<dmin) dmin = um;
-      if (ur<=thresh) continue; if (ur<dmin) dmin = ur;
-      if (ri<=thresh) continue; if (ri<dmin) dmin = ri;
-      if (lm<=thresh) continue; if (lm<dmin) dmin = lm;
-      if (lr<=thresh) continue; if (lr<dmin) dmin = lr;
+      if (um<=thresh) continue;
+      if (um<dmin) { dmin = um; }
+
+      if (ur<=thresh) continue;
+      if (ur<dmin) { dmin = ur; }
+
+      if (ri<=thresh) continue;
+      if (ri<dmin) { dmin = ri; }
+
+      if (lm<=thresh) continue;
+      if (lm<dmin) { dmin = lm; }
+
+      if (lr<=thresh) continue;
+      if (lr<dmin) { dmin = lr; }
+
       if (dmin>thresh) {
         minima[r][0] = dmin;
         minima_found = true;
@@ -175,11 +217,21 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
       ll = in[r+1][nc-2] - in[r][nc-1];
       lm = in[r+1][nc-1] - in[r][nc-1];
       dmin = mval;
-      if (ul<=thresh) continue; if (ul<dmin) dmin = ul;
-      if (um<=thresh) continue; if (um<dmin) dmin = um;
-      if (lf<=thresh) continue; if (lf<dmin) dmin = lf;
-      if (ll<=thresh) continue; if (ll<dmin) dmin = ll;
-      if (lm<=thresh) continue; if (lm<dmin) dmin = lm;
+      if (ul<=thresh) continue;
+      if (ul<dmin) { dmin = ul; }
+    
+      if (um<=thresh) continue;
+      if (um<dmin) { dmin = um; }
+    
+      if (lf<=thresh) continue;
+      if (lf<dmin) { dmin = lf; }
+    
+      if (ll<=thresh) continue;
+      if (ll<dmin) { dmin = ll; }
+    
+      if (lm<=thresh) continue;
+      if (lm<dmin) { dmin = lm; }
+    
       if (dmin>thresh) {
         minima[r][nc-1] = dmin;
         minima_found = true;
@@ -195,9 +247,15 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
   lm = in[1][0] - in[0][0];
   lr = in[1][1] - in[0][0];
   dmin = mval;
-  if (ri<=thresh) fail = true; if (ri<dmin) dmin = ri;
-  if (lm<=thresh) fail = true; if (lm<dmin) dmin = lm;
-  if (lr<=thresh) fail = true; if (lr<dmin) dmin = lr;
+  if (ri<=thresh) fail = true;
+  if (ri<dmin) { dmin = ri; }
+
+  if (lm<=thresh) fail = true;
+  if (lm<dmin) { dmin = lm; }
+
+  if (lr<=thresh) fail = true;
+  if (lr<dmin) { dmin = lr; }
+
   if (!fail) {
     minima[0][0] = dmin;
     minima_found = true;
@@ -210,9 +268,15 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
   lm = in[1][nc-1] - in[0][nc-1];
   ll = in[1][nc-2] - in[0][nc-1];
   dmin = mval;
-  if (lf<=thresh) fail = true; if (lf<dmin) dmin = lf;
-  if (lm<=thresh) fail = true; if (lm<dmin) dmin = lm;
-  if (ll<=thresh) fail = true; if (ll<dmin) dmin = ll;
+  if (lf<=thresh) { fail = true; }
+  if (lf<dmin) { dmin = lf; }
+
+  if (lm<=thresh) { fail = true; }
+  if (lm<dmin) { dmin = lm; }
+
+  if (ll<=thresh) { fail = true; }
+  if (ll<dmin) { dmin = ll; }
+
   if (!fail) {
     minima[0][nc-1] = dmin;
     minima_found = true;
@@ -225,9 +289,15 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
   um = in[nr-2][nc-1] - in[nr-1][nc-1];
   lf = in[nr-1][nc-2] - in[nr-1][nc-1];
   dmin = mval;
-  if (ul<=thresh) fail = true; if (ul<dmin) dmin = ul;
-  if (um<=thresh) fail = true; if (um<dmin) dmin = um;
-  if (lf<=thresh) fail = true; if (lf<dmin) dmin = lf;
+  if (ul<=thresh) { fail = true; }
+  if (ul<dmin) { dmin = ul; }
+
+  if (um<=thresh) { fail = true; }
+  if (um<dmin) { dmin = um; }
+
+  if (lf<=thresh) { fail = true; }
+  if (lf<dmin) { dmin = lf; }
+
   if (!fail) {
     minima[nr-1][nc-1] = dmin;
     minima_found = true;
@@ -240,9 +310,15 @@ bool local_minima(vbl_array_2d<T> const& in, vbl_array_2d<T>& minima, T thresh)
   um = in[nr-2][0] - in[nr-1][0];
   ri = in[nr-1][1] - in[nr-1][0];
   dmin = mval;
-  if (ur<=thresh) fail = true; if (ur<dmin) dmin = ur;
-  if (um<=thresh) fail = true; if (um<dmin) dmin = um;
-  if (ri<=thresh) fail = true; if (ri<dmin) dmin = ri;
+  if (ur<=thresh) { fail = true; }
+  if (ur<dmin) { dmin = ur; }
+
+  if (um<=thresh) { fail = true; }
+  if (um<dmin) { dmin = um; }
+
+  if (ri<=thresh) { fail = true; }
+  if (ri<dmin) { dmin = ri; }
+
   if (!fail) {
     minima[nr-1][0] = dmin;
     minima_found = true;

--- a/core/vnl/vnl_diag_matrix.h
+++ b/core/vnl/vnl_diag_matrix.h
@@ -42,7 +42,12 @@ class VNL_EXPORT vnl_diag_matrix
   vnl_vector<T> diagonal_;
 
  public:
-  vnl_diag_matrix() : diagonal_() {}
+  vnl_diag_matrix() = default;
+  vnl_diag_matrix(const vnl_diag_matrix<T> & that)  = default;
+  vnl_diag_matrix(vnl_diag_matrix<T> && that)  = default;
+  vnl_diag_matrix& operator=(const vnl_diag_matrix<T> & that)  = default;
+  vnl_diag_matrix& operator=(vnl_diag_matrix<T> && that)  = default;
+  ~vnl_diag_matrix() = default;
 
   //: Construct an empty diagonal matrix.
   vnl_diag_matrix(unsigned nn) : diagonal_(nn) {}
@@ -53,12 +58,6 @@ class VNL_EXPORT vnl_diag_matrix
   //: Construct a diagonal matrix from a vnl_vector.
   //  The vector elements become the diagonal elements.
   vnl_diag_matrix(vnl_vector<T> const& that): diagonal_(that) {}
- ~vnl_diag_matrix() = default;
-
-  inline vnl_diag_matrix& operator=(vnl_diag_matrix<T> const& that) {
-    this->diagonal_ = that.diagonal_;
-    return *this;
-  }
 
   // Operations----------------------------------------------------------------
 

--- a/core/vnl/vnl_diag_matrix_fixed.h
+++ b/core/vnl/vnl_diag_matrix_fixed.h
@@ -42,7 +42,12 @@ class VNL_EXPORT vnl_diag_matrix_fixed
   vnl_vector_fixed<T,N> diagonal_;
 
  public:
-  vnl_diag_matrix_fixed() : diagonal_() {}
+  vnl_diag_matrix_fixed() = default;
+  vnl_diag_matrix_fixed(const vnl_diag_matrix_fixed<T,N> & that) = default;
+  vnl_diag_matrix_fixed(vnl_diag_matrix_fixed<T,N> && that) = default;
+  vnl_diag_matrix_fixed& operator=(const vnl_diag_matrix_fixed<T,N> & that) = default;
+  vnl_diag_matrix_fixed& operator=(vnl_diag_matrix_fixed<T,N> && that) = default;
+  ~vnl_diag_matrix_fixed() = default;
 
 
   //: Construct a diagonal matrix with diagonal elements equal to value.
@@ -51,12 +56,6 @@ class VNL_EXPORT vnl_diag_matrix_fixed
   //: Construct a diagonal matrix from a vnl_vector_fixed.
   //  The vector elements become the diagonal elements.
   explicit vnl_diag_matrix_fixed(vnl_vector_fixed<T,N> const& that): diagonal_(that) {}
- ~vnl_diag_matrix_fixed() = default;
-
-  inline vnl_diag_matrix_fixed& operator=(vnl_diag_matrix_fixed<T,N> const& that) {
-    this->diagonal_ = that.diagonal_;
-    return *this;
-  }
 
   // Operations----------------------------------------------------------------
 

--- a/core/vnl/vnl_fastops.cxx
+++ b/core/vnl/vnl_fastops.cxx
@@ -36,6 +36,7 @@ void vnl_fastops::AtA(vnl_matrix<double>& out, const vnl_matrix<double>& A)
 */
     std::memset(ata[0], 0, n * n * sizeof ata[0][0]);
     for (unsigned int k = 0; k < m; ++k)
+    {
       for (unsigned int i = 0; i < n; ++i) {
         const double aki = a[k][i];
         double const* arow = a[k] + i;
@@ -44,6 +45,7 @@ void vnl_fastops::AtA(vnl_matrix<double>& out, const vnl_matrix<double>& A)
         while (arow != arowend)
           *atarow++ += aki * *arow++;
       }
+    }
       for (unsigned int i = 0; i < n; ++i)
         for (unsigned int j = i+1; j < n; ++j)
           ata[j][i] = ata[i][j];

--- a/v3p/geotiff/geotiff_proj4.c
+++ b/v3p/geotiff/geotiff_proj4.c
@@ -549,7 +549,9 @@ char * GTIFGetProj4Defn( GTIFDefn * psDefn )
 
     strcat( szProjection, szUnits );
 
-    return( strdup( szProjection ) );
+    char * return_string=malloc( strlen(szProjection) + 1  );
+    strcpy( return_string, szProjection );
+    return( return_string );
 }
 
 #if !defined(HAVE_LIBPROJ) || !defined(HAVE_PROJECTS_H)


### PR DESCRIPTION
Compiling vxl with gcc 9.1 identifies new sources of potential weak coding.

Update to address the new warnings.
