### PR TITLE
COMP: Improve default building of VXL with MSVC 1920-2929 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ foreach(p
     ##----- Policies Introduced by CMake 3.10
     CMP0071  #: Let AUTOMOC and AUTOUIC process GENERATED files.
     CMP0070  #: Define file(GENERATE) behavior for relative paths.
+    CMP0083  #: Add PIE options when linking executable.
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)
@@ -83,6 +84,10 @@ include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-Wno-undefined-var-template HAS_NO_UNDEFINED_VAR_TEMPLATE)
 if( HAS_NO_UNDEFINED_VAR_TEMPLATE )
   add_definitions( -Wno-undefined-var-template )
+endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14.0)
+  include(CheckPIESupported)
+  check_pie_supported()
 endif()
 
 find_program( MEMORYCHECK_COMMAND valgrind )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,11 @@ set( CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_EXE_
 set( CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_MODULE_LINKER_FLAGS}" )
 set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${VXL_EXTRA_CMAKE_SHARED_LINKER_FLAGS}" )
 
-
+if(MSVC_VERSION GREATER_EQUAL 1920)
+# Force synchronous writes of .pdb files for building VXL on MSVC 1920-1929
+# https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-201
+  add_compile_options( "/FS" )
+endif()
 #-------------------------------------------------------------------
 #-- BUILD CONFIG OPTIONS
 

--- a/core/vnl/examples/vnl_polynomial_factoring.cxx
+++ b/core/vnl/examples/vnl_polynomial_factoring.cxx
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 #include <vnl/vnl_polynomial.h>
+#include <string>
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019

and discussions:

https://discourse.itk.org/t/has-anyone-tried-to-build-visual-studio-c-2019/1561
