### PR TITLE
ENH: Fix issue #664: vnl_rational numerator, denominator both int64_t

### DIFF
--- a/core/vnl/tests/test_rational.cxx
+++ b/core/vnl/tests/test_rational.cxx
@@ -1,6 +1,9 @@
 #include <iostream>
 #include <iomanip>
 #include <complex>
+#include <string>
+#include <utility>
+#include <typeinfo>
 #include <vnl/vnl_rational.h>
 #include <testlib/testlib_test.h>
 #include <vnl/vnl_math.h>
@@ -9,6 +12,84 @@
 #include <vnl/vnl_det.h>
 
 inline vnl_rational vnl_sqrt(vnl_rational x) { return vnl_rational(std::sqrt(double(x))); }
+
+namespace
+{
+  template <typename T>
+  void test_converting_whole_number_to_rational(const T num)
+  {
+    // Convert whole number to vnl_rational:
+    const vnl_rational rat = num;
+
+    const auto message = "test_converting_value_to_rational<" +
+      std::string(typeid(T).name()) + ">(" + std::to_string(num) + ')';
+
+    using pair_type = std::pair<vnl_rational::int_type, vnl_rational::int_type>;
+
+    TEST(message.c_str(),
+      std::make_pair(rat.numerator(), rat.denominator()),
+      pair_type(num, 1));
+  }
+
+  template <typename T>
+  void test_converting_floating_point_number_to_rational(T num)
+  {
+    // Convert floating point number to vnl_rational:
+    const vnl_rational rat = num;
+
+    const auto message = "test_converting_floating_point_number_to_rational<" +
+      std::string(typeid(T).name()) + ">(" + std::to_string(num) + ')';
+
+    using pair_type = std::pair<vnl_rational::int_type, vnl_rational::int_type>;
+
+    TEST(message.c_str(),
+      static_cast<T>(rat.numerator()) / static_cast<T>(rat.denominator()),
+      num);
+  }
+
+  template <typename T>
+  void test_converting_decimal_digits()
+  {
+    for (int i{}; i < 10; ++i)
+    {
+      test_converting_whole_number_to_rational( static_cast<T>(i) );
+    }
+  }
+
+  template <typename T>
+  void test_converting_decimal_digits_and_min_and_max()
+  {
+    test_converting_decimal_digits<T>();
+
+    test_converting_whole_number_to_rational(std::numeric_limits<T>::min());
+    test_converting_whole_number_to_rational(std::numeric_limits<T>::max());
+  }
+
+}
+
+static void test_converting_constructors()
+{
+  test_converting_decimal_digits_and_min_and_max<unsigned char>();
+  test_converting_decimal_digits_and_min_and_max<signed char>();
+  test_converting_decimal_digits_and_min_and_max<unsigned char>();
+  test_converting_decimal_digits_and_min_and_max<short>();
+  test_converting_decimal_digits_and_min_and_max<unsigned short>();
+  test_converting_decimal_digits_and_min_and_max<int>();
+  test_converting_decimal_digits_and_min_and_max<unsigned int>();
+  test_converting_decimal_digits_and_min_and_max<long>();
+  test_converting_decimal_digits_and_min_and_max<unsigned long>();
+  test_converting_decimal_digits_and_min_and_max<long long>();
+  test_converting_decimal_digits_and_min_and_max<unsigned long long>();
+
+  test_converting_decimal_digits<float>();
+  test_converting_decimal_digits<double>();
+
+  for (float f{}; f <= 1.0f; f += 0.25f)
+  {
+    test_converting_floating_point_number_to_rational<float>(f);
+    test_converting_floating_point_number_to_rational<double>(f);
+  }
+}
 
 static void test_operators()
 {
@@ -233,6 +314,7 @@ static void test_zero_one()
 
 void test_rational()
 {
+  test_converting_constructors();
   test_operators();
   test_infinite();
   test_frac();

--- a/core/vnl/vnl_rational.cxx
+++ b/core/vnl/vnl_rational.cxx
@@ -6,19 +6,21 @@
 
 #include <vnl/vnl_numeric_traits.h> // for vnl_numeric_traits<long>::maxval
 
+using int_type = vnl_rational::int_type;
+
 template<typename FloatingType>
-inline void makeNumDen( FloatingType d, long &num_, long &den_)
+inline void makeNumDen( FloatingType d, int_type &num_, int_type &den_)
 {
   bool sign = d<0;
   if (sign) d = -d;
 
   // Continued fraction approximation of abs(d): recursively determined
-  long den=0L, num=1L, prev_den=1L, prev_num=0L;
+  int_type den=0L, num=1L, prev_den=1L, prev_num=0L;
 
   while (d*num < 1e9 && d*den < 1e9) {
-    long a = (long)d; // integral part of d
+    int_type a = static_cast<int_type>(d); // integral part of d
     d -= a; // certainly >= 0
-    long temp = num; num = a*num + prev_num; prev_num = temp;
+    int_type temp = num; num = a*num + prev_num; prev_num = temp;
          temp = den; den = a*den + prev_den; prev_den = temp;
     if (d < 1e-6) break;
     d = 1/d;
@@ -49,14 +51,14 @@ vnl_rational::vnl_rational(float f)
 vnl_rational& vnl_rational::operator*=(vnl_rational const& r)
 {
   assert(num_!=0 || den_ != 0); // 0 * Inf is undefined
-  long a = vnl_rational::gcd(r.numerator(),den_),
+  int_type a = vnl_rational::gcd(r.numerator(),den_),
        b = vnl_rational::gcd(r.denominator(),num_);
   num_ /= b; den_ /= a;
   a = r.numerator()/a; b = r.denominator()/b;
   // find out whether overflow would occur; in that case, return approximate result
   double n = double(a) * double(num_),
          d = double(b) * double(den_);
-  if (n < vnl_numeric_traits<long>::maxval && d < vnl_numeric_traits<long>::maxval)
+  if (n < vnl_numeric_traits<int_type>::maxval && d < vnl_numeric_traits<int_type>::maxval)
   { num_ *= a; den_ *= b; normalize(); return *this; }
   else
     return *this = vnl_rational(n/d);
@@ -65,13 +67,13 @@ vnl_rational& vnl_rational::operator*=(vnl_rational const& r)
 //: Multiply/assign: replace lhs by lhs * rhs
 //  Note that there could be integer overflow during this calculation!
 //  In that case, an approximate result will be returned.
-vnl_rational& vnl_rational::operator*=(long r)
+vnl_rational& vnl_rational::operator*=(int_type r)
 {
-  long a = vnl_rational::gcd(r,den_);
+  int_type a = vnl_rational::gcd(r,den_);
   den_ /= a; r /= a;
   // find out whether overflow would occur; in that case, return approximate result
   double n = double(r) * double(num_);
-  if (n < vnl_numeric_traits<long>::maxval)
+  if (n < vnl_numeric_traits<int_type>::maxval)
   { num_ *= r; normalize(); return *this; }
   else
     return *this = vnl_rational(n/double(den_));
@@ -84,14 +86,14 @@ vnl_rational& vnl_rational::operator*=(long r)
 vnl_rational& vnl_rational::operator/=(vnl_rational const& r)
 {
   assert(num_!=0 || den_ != 0); // 0/0, Inf/Inf undefined
-  long a = vnl_rational::gcd(r.numerator(),num_),
+  int_type a = vnl_rational::gcd(r.numerator(),num_),
        b = vnl_rational::gcd(r.denominator(),den_);
   num_ /= a; den_ /= b;
   a = r.numerator()/a; b = r.denominator()/b;
   // find out whether overflow would occur; in that case, return approximate result
   double n = double(b) * double(num_),
          d = double(a) * double(den_);
-  if (n < vnl_numeric_traits<long>::maxval && d < vnl_numeric_traits<long>::maxval)
+  if (n < vnl_numeric_traits<int_type>::maxval && d < vnl_numeric_traits<int_type>::maxval)
   { num_ *= b; den_ *= a; normalize(); return *this; }
   else
     return *this = vnl_rational(n/d);
@@ -101,14 +103,14 @@ vnl_rational& vnl_rational::operator/=(vnl_rational const& r)
 //  Note that 0 / 0 is undefined.
 //  Also note that there could be integer overflow during this calculation!
 //  In that case, an approximate result will be returned.
-vnl_rational& vnl_rational::operator/=(long r)
+vnl_rational& vnl_rational::operator/=(int_type r)
 {
   assert(num_!=0 || r != 0); // 0/0 undefined
-  long a = vnl_rational::gcd(r,num_);
+  int_type a = vnl_rational::gcd(r,num_);
   num_ /= a; r /= a;
   // find out whether overflow would occur; in that case, return approximate result
   double d = double(r) * double(den_);
-  if (d < vnl_numeric_traits<long>::maxval)
+  if (d < vnl_numeric_traits<int_type>::maxval)
   { den_ *= r; normalize(); return *this; }
   else
     return *this = vnl_rational(double(num_)/d);

--- a/core/vnl/vnl_rational.h
+++ b/core/vnl/vnl_rational.h
@@ -7,7 +7,7 @@
 //
 // The  vnl_rational  class  provides  high-precision rational numbers and
 // arithmetic, using the built-in type long, for the numerator and denominator.
-// Implicit conversion to the system defined types short, int, long, float, and
+// Implicit conversion to the system defined signed integral types, float, and
 // double is supported by  overloaded  operator member functions.  Although the
 // rational class makes judicious use of inline  functions and  deals only with
 // integral values, the user  is warned that  the rational  integer  arithmetic
@@ -46,17 +46,19 @@
 // \endverbatim
 
 #include <iostream>
+#include <type_traits> // For enable_if, is_signed, and is_integral.
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cassert>
+#include <cstdint>
 #include "vnl/vnl_export.h"
 
 //: High-precision rational numbers
 //
 // The  vnl_rational  class  provides  high-precision rational numbers and
 // arithmetic, using the built-in type long, for the numerator and denominator.
-// Implicit conversion to the system defined types short, int, long, float, and
+// Implicit conversion to the system defined signed integral types, float, and
 // double is supported by  overloaded  operator member functions.  Although the
 // rational class makes judicious use of inline  functions and  deals only with
 // integral values, the user  is warned that  the rational  integer  arithmetic
@@ -72,49 +74,39 @@
 //
 class VNL_EXPORT vnl_rational
 {
+ public:
+  //! The integer type of the numerator and the denominator.
+  using int_type = std::int64_t;
+
  private:
-  long num_; //!< Numerator portion
-  long den_; //!< Denominator portion
+  int_type num_; //!< Numerator portion
+  int_type den_; //!< Denominator portion
 
  public:
+   // Helper type alias to be used for SFINAE.
+   template <typename T>
+   using enable_if_signed_integral_type = typename std::enable_if<
+     std::is_signed<T>::value && std::is_integral<T>::value>::type;
+
   //: Creates a rational with given numerator and denominator.
   //  Default constructor gives 0.
-  //  Also serves as automatic cast from long to vnl_rational.
+  //  Also serves as automatic cast from int_type to vnl_rational.
   //  The only input which is not allowed is (0,0);
   //  the denominator is allowed to be 0, to represent +Inf or -Inf.
 
   inline vnl_rational()
     : num_(0L), den_(1L) { normalize(); }
 
-  inline vnl_rational(long num)
+  inline vnl_rational(int_type num)
     : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(long num, long den)
+  inline vnl_rational(int_type num, int_type den)
     : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
 
-  inline vnl_rational(unsigned long num)
-    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(unsigned long num, unsigned long den)
-    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
-
-  inline vnl_rational(int num)
-    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(int num, int den)
-    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
-
-  inline vnl_rational(unsigned int num)
-    : num_((long)num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(unsigned int num, unsigned int den)
-    : num_((long)num), den_((long)den) { assert(num!=0||den!=0); normalize(); }
-
-  inline vnl_rational(short num)
-    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(short num, short den)
-    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
-
-  inline vnl_rational(unsigned short num)
-    : num_(num), den_(1L) { assert(num!=0||den_!=0); normalize(); }
-  inline vnl_rational(unsigned short num, unsigned short den)
-    : num_(num), den_(den) { assert(num!=0||den!=0); normalize(); }
+  //: Implicitly converts a signed or unsigned integer to a rational.
+  template <typename T, typename SFINAE =
+    typename std::enable_if<std::is_integral<T>::value>::type>
+  inline vnl_rational(const T num)
+    : num_{ static_cast<int_type>(num) }, den_{1} {}
 
   //: Creates a rational from a double.
   //  This is done by computing the continued fraction approximation for d.
@@ -127,12 +119,12 @@ class VNL_EXPORT vnl_rational
   //  Destructor
   inline ~vnl_rational() = default;
   //  Assignment: overwrite an existing vnl_rational
-  inline void set(long num, long den) { assert(num!=0||den!=0); num_=num; den_=den; normalize(); }
+  inline void set(int_type num, int_type den) { assert(num!=0||den!=0); num_=num; den_=den; normalize(); }
 
   //: Return the numerator of the (simplified) rational number representation
-  inline long numerator() const { return num_; }
+  inline int_type numerator() const { return num_; }
   //: Return the denominator of the (simplified) rational number representation
-  inline long denominator() const { return den_; }
+  inline int_type denominator() const { return den_; }
 
   //: Copies the contents and state of rhs rational over to the lhs
   inline vnl_rational& operator=(vnl_rational const& rhs) {
@@ -142,10 +134,12 @@ class VNL_EXPORT vnl_rational
   inline bool operator==(vnl_rational const& rhs) const {
     return num_ == rhs.numerator() && den_ == rhs.denominator(); }
   inline bool operator!=(vnl_rational const& rhs) const { return !operator==(rhs); }
-  inline bool operator==(long rhs) const { return num_ == rhs && den_ == 1; }
-  inline bool operator!=(long rhs) const { return !operator==(rhs); }
-  inline bool operator==(int rhs) const { return num_ == rhs && den_ == 1; }
-  inline bool operator!=(int rhs) const { return !operator==(rhs); }
+  inline bool operator==(int_type rhs) const { return num_ == rhs && den_ == 1; }
+  inline bool operator!=(int_type rhs) const { return !operator==(rhs); }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator==(const T rhs) const { return num_ == rhs && den_ == 1; }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator!=(const T rhs) const { return !operator==(rhs); }
 
   //: Unary minus - returns the negation of the current rational.
   inline vnl_rational operator-() const { return vnl_rational(-num_, den_); }
@@ -158,30 +152,30 @@ class VNL_EXPORT vnl_rational
   //: Replaces rational with 1/rational and returns it.
   //  Inverting 0 gives +Inf, inverting +-Inf gives 0.
   vnl_rational& invert() {
-    long t = num_; num_ = den_; den_ = t; normalize(); return *this; }
+    int_type t = num_; num_ = den_; den_ = t; normalize(); return *this; }
 
   //: Plus/assign: replace lhs by lhs + rhs
   //  Note that +Inf + -Inf and -Inf + +Inf are undefined.
   inline vnl_rational& operator+=(vnl_rational const& r) {
     if (den_ == r.denominator()) num_ += r.numerator();
-    else { long c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
+    else { int_type c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
            num_ = num_*(r.denominator()/c) + (den_/c)*r.numerator();
            den_ *= r.denominator()/c; }
     assert(num_!=0 || den_ != 0); // +Inf + -Inf is undefined
     normalize(); return *this;
   }
-  inline vnl_rational& operator+=(long r) { num_ += den_*r; return *this; }
+  inline vnl_rational& operator+=(int_type r) { num_ += den_*r; return *this; }
   //: Minus/assign: replace lhs by lhs - rhs
   //  Note that +Inf - +Inf and -Inf - -Inf are undefined.
   inline vnl_rational& operator-=(vnl_rational const& r) {
     if (den_ == r.denominator()) num_ -= r.num_;
-    else { long c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
+    else { int_type c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
            num_ = num_*(r.denominator()/c) - (den_/c)*r.numerator();
            den_ *= r.denominator()/c; }
     assert(num_!=0 || den_ != 0); // +Inf - +Inf is undefined
     normalize(); return *this;
   }
-  inline vnl_rational& operator-=(long r) { num_ -= den_*r; return *this; }
+  inline vnl_rational& operator-=(int_type r) { num_ -= den_*r; return *this; }
   //: Multiply/assign: replace lhs by lhs * rhs
   //  Note that 0 * Inf and Inf * 0 are undefined.
   //  Also note that there could be integer overflow during this calculation!
@@ -190,7 +184,7 @@ class VNL_EXPORT vnl_rational
   //: Multiply/assign: replace lhs by lhs * rhs
   //  Note that there could be integer overflow during this calculation!
   //  In that case, an approximate result will be returned.
-  vnl_rational& operator*=(long r);
+  vnl_rational& operator*=(int_type r);
   //: Divide/assign: replace lhs by lhs / rhs
   //  Note that 0 / 0 and Inf / Inf are undefined.
   //  Also note that there could be integer overflow during this calculation!
@@ -200,19 +194,19 @@ class VNL_EXPORT vnl_rational
   //  Note that 0 / 0 is undefined.
   //  Also note that there could be integer overflow during this calculation!
   //  In that case, an approximate result will be returned.
-  vnl_rational& operator/=(long r);
+  vnl_rational& operator/=(int_type r);
   //: Modulus/assign: replace lhs by lhs % rhs
   //  Note that r % Inf is r, and that r % 0 and Inf % r are undefined.
   inline vnl_rational& operator%=(vnl_rational const& r) {
     assert(r.numerator() != 0);
     if (den_ == r.denominator()) num_ %= r.numerator();
-    else { long c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
+    else { int_type c = vnl_rational::gcd(den_,r.denominator()); if (c==0) c=1;
            num_ *= r.denominator()/c;
            num_ %= (den_/c)*r.numerator();
            den_ *= r.denominator()/c; }
     normalize(); return *this;
   }
-  inline vnl_rational& operator%=(long r) {assert(r);num_%=den_*r;normalize();return *this;}
+  inline vnl_rational& operator%=(int_type r) {assert(r);num_%=den_*r;normalize();return *this;}
 
   //: Pre-increment (++r).  No-op when +-Inf.
   inline vnl_rational& operator++() { num_ += den_; return *this; }
@@ -233,46 +227,47 @@ class VNL_EXPORT vnl_rational
   inline bool operator>(vnl_rational const& r) const { return r < *this; }
   inline bool operator<=(vnl_rational const& r) const { return !operator>(r); }
   inline bool operator>=(vnl_rational const& r) const { return !operator<(r); }
-  inline bool operator<(long r) const { return num_ < den_ * r; }
-  inline bool operator>(long r) const { return num_ > den_ * r; }
-  inline bool operator<=(long r) const { return !operator>(r); }
-  inline bool operator>=(long r) const { return !operator<(r); }
-  inline bool operator<(int r) const { return num_ < den_ * r; }
-  inline bool operator>(int r) const { return num_ > den_ * r; }
-  inline bool operator<=(int r) const { return !operator>(r); }
-  inline bool operator>=(int r) const { return !operator<(r); }
+  inline bool operator<(int_type r) const { return num_ < den_ * r; }
+  inline bool operator>(int_type r) const { return num_ > den_ * r; }
+  inline bool operator<=(int_type r) const { return !operator>(r); }
+  inline bool operator>=(int_type r) const { return !operator<(r); }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator<(const T r) const { return num_ < den_ * r; }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator>(const T r) const { return num_ > den_ * r; }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator<=(const T r) const { return !operator>(r); }
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline bool operator>=(const T r) const { return !operator<(r); }
+
   inline bool operator<(double r) const { return num_ < den_ * r; }
   inline bool operator>(double r) const { return num_ > den_ * r; }
   inline bool operator<=(double r) const { return !operator>(r); }
   inline bool operator>=(double r) const { return !operator<(r); }
 
   //: Converts rational value to integer by truncating towards zero.
-  inline long truncate() const { assert(den_ != 0);  return num_/den_; }
+  inline int_type truncate() const { assert(den_ != 0);  return num_/den_; }
   //: Converts rational value to integer by truncating towards negative infinity.
-  inline long floor() const { long t = truncate();
+  inline int_type floor() const { int_type t = truncate();
     return num_<0L && (num_%den_) != 0 ? t-1 : t; }
   //: Converts rational value to integer by truncating towards positive infinity.
-  inline long ceil() const { long t = truncate();
+  inline int_type ceil() const { int_type t = truncate();
     return num_>0L && (num_%den_) != 0 ? t+1 : t; }
   //: Rounds rational to nearest integer.
-  inline long round() const { long t = truncate();
+  inline int_type round() const { int_type t = truncate();
     if (num_ < 0) return ((-num_)%den_) >= 0.5*den_ ? t-1 : t;
     else          return   (num_ %den_) >= 0.5*den_ ? t+1 : t;
   }
 
   // Implicit conversions
-  inline operator short() {
-    long t = truncate(); short r = (short)t;
+  template <typename T, typename SFINAE = enable_if_signed_integral_type<T>>
+  inline operator T() const {
+    int_type t = truncate(); auto r = static_cast<T>(t);
     assert(r == t); // abort on underflow or overflow
     return r;
   }
-  inline operator int() {
-    long t = truncate(); int r = (int)t;
-    assert(r == t); // abort on underflow or overflow
-    return r;
-  }
-  inline operator long() const { return truncate(); }
-  inline operator long() { return truncate(); }
+  inline operator int_type() const { return truncate(); }
+  inline operator int_type() { return truncate(); }
   inline operator float() const { return ((float)num_)/((float)den_); }
   inline operator float() { return ((float)num_)/((float)den_); }
   inline operator double() const { return ((double)num_)/((double)den_); }
@@ -280,8 +275,8 @@ class VNL_EXPORT vnl_rational
 
   //: Calculate greatest common divisor of two integers.
   //  Used to simplify rational number.
-  static inline long gcd (long l1, long l2) {
-    while (l2!=0) { long t = l2; l2 = l1 % l2; l1 = t; }
+  static inline int_type gcd (int_type l1, int_type l2) {
+    while (l2!=0) { int_type t = l2; l2 = l1 % l2; l1 = t; }
     return l1<0 ? (-l1) : l1;
   }
 
@@ -293,7 +288,7 @@ class VNL_EXPORT vnl_rational
     if (num_ == 0) { den_ = 1; return; } // zero
     if (den_ == 0) { num_ = (num_>0) ? 1 : -1; return; } // +-Inf
     if (num_ != 1 && num_ != -1 && den_ != 1) {
-      long common = vnl_rational::gcd(num_, den_);
+      int_type common = vnl_rational::gcd(num_, den_);
       if (common != 1) { num_ /= common; den_ /= common; }
     }
     // if negative, put sign in numerator:
@@ -312,7 +307,7 @@ inline std::ostream& operator<<(std::ostream& s, vnl_rational const& r)
 // \relatesalso vnl_rational
 inline std::istream& operator>>(std::istream& s, vnl_rational& r)
 {
-  long n, d; s >> n >> d;
+  vnl_rational::int_type n, d; s >> n >> d;
   r.set(n,d); return s;
 }
 
@@ -323,24 +318,26 @@ inline vnl_rational operator+(vnl_rational const& r1, vnl_rational const& r2)
   vnl_rational result(r1); return result += r2;
 }
 
-inline vnl_rational operator+(vnl_rational const& r1, long r2)
+inline vnl_rational operator+(vnl_rational const& r1, vnl_rational::int_type r2)
 {
   vnl_rational result(r1); return result += r2;
 }
 
-inline vnl_rational operator+(vnl_rational const& r1, int r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator+(vnl_rational const& r1, const T r2)
 {
-  vnl_rational result(r1); return result += (long)r2;
+  vnl_rational result(r1); return result += vnl_rational::int_type{r2};
 }
 
-inline vnl_rational operator+(long r2, vnl_rational const& r1)
+inline vnl_rational operator+(vnl_rational::int_type r2, vnl_rational const& r1)
 {
   vnl_rational result(r1); return result += r2;
 }
 
-inline vnl_rational operator+(int r2, vnl_rational const& r1)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator+(const T r2, vnl_rational const& r1)
 {
-  vnl_rational result(r1); return result += (long)r2;
+  vnl_rational result(r1); return result += vnl_rational::int_type{r2};
 }
 
 //: Returns the difference of two rational numbers.
@@ -350,24 +347,26 @@ inline vnl_rational operator-(vnl_rational const& r1, vnl_rational const& r2)
   vnl_rational result(r1); return result -= r2;
 }
 
-inline vnl_rational operator-(vnl_rational const& r1, long r2)
+inline vnl_rational operator-(vnl_rational const& r1, vnl_rational::int_type r2)
 {
   vnl_rational result(r1); return result -= r2;
 }
 
-inline vnl_rational operator-(vnl_rational const& r1, int r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator-(vnl_rational const& r1, const T r2)
 {
-  vnl_rational result(r1); return result -= (long)r2;
+  vnl_rational result(r1); return result -= vnl_rational::int_type{r2};
 }
 
-inline vnl_rational operator-(long r2, vnl_rational const& r1)
+inline vnl_rational operator-(vnl_rational::int_type r2, vnl_rational const& r1)
 {
   vnl_rational result(-r1); return result += r2;
 }
 
-inline vnl_rational operator-(int r2, vnl_rational const& r1)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator-(const T r2, vnl_rational const& r1)
 {
-  vnl_rational result(-r1); return result += (long)r2;
+  vnl_rational result(-r1); return result += vnl_rational::int_type{r2};
 }
 
 //: Returns the product of two rational numbers.
@@ -377,24 +376,26 @@ inline vnl_rational operator*(vnl_rational const& r1, vnl_rational const& r2)
   vnl_rational result(r1); return result *= r2;
 }
 
-inline vnl_rational operator*(vnl_rational const& r1, long r2)
+inline vnl_rational operator*(vnl_rational const& r1, vnl_rational::int_type r2)
 {
   vnl_rational result(r1); return result *= r2;
 }
 
-inline vnl_rational operator*(vnl_rational const& r1, int r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator*(vnl_rational const& r1, const T r2)
 {
-  vnl_rational result(r1); return result *= (long)r2;
+  vnl_rational result(r1); return result *= vnl_rational::int_type{r2};
 }
 
-inline vnl_rational operator*(long r2, vnl_rational const& r1)
+inline vnl_rational operator*(vnl_rational::int_type r2, vnl_rational const& r1)
 {
   vnl_rational result(r1); return result *= r2;
 }
 
-inline vnl_rational operator*(int r2, vnl_rational const& r1)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator*(const T r2, vnl_rational const& r1)
 {
-  vnl_rational result(r1); return result *= (long)r2;
+  vnl_rational result(r1); return result *= vnl_rational::int_type{r2};
 }
 
 //: Returns the quotient of two rational numbers.
@@ -404,24 +405,26 @@ inline vnl_rational operator/(vnl_rational const& r1, vnl_rational const& r2)
   vnl_rational result(r1); return result /= r2;
 }
 
-inline vnl_rational operator/(vnl_rational const& r1, long r2)
+inline vnl_rational operator/(vnl_rational const& r1, vnl_rational::int_type r2)
 {
   vnl_rational result(r1); return result /= r2;
 }
 
-inline vnl_rational operator/(vnl_rational const& r1, int r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator/(vnl_rational const& r1, const T r2)
 {
-  vnl_rational result(r1); return result /= (long)r2;
+  vnl_rational result(r1); return result /= vnl_rational::int_type{r2};
 }
 
-inline vnl_rational operator/(long r1, vnl_rational const& r2)
+inline vnl_rational operator/(vnl_rational::int_type r1, vnl_rational const& r2)
 {
   vnl_rational result(r1); return result /= r2;
 }
 
-inline vnl_rational operator/(int r1, vnl_rational const& r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator/(const T r1, vnl_rational const& r2)
 {
-  vnl_rational result((long)r1); return result /= r2;
+  vnl_rational result(vnl_rational::int_type{r1}); return result /= r2;
 }
 
 //: Returns the remainder of r1 divided by r2.
@@ -431,43 +434,51 @@ inline vnl_rational operator%(vnl_rational const& r1, vnl_rational const& r2)
   vnl_rational result(r1); return result %= r2;
 }
 
-inline vnl_rational operator%(vnl_rational const& r1, long r2)
+inline vnl_rational operator%(vnl_rational const& r1, vnl_rational::int_type r2)
 {
   vnl_rational result(r1); return result %= r2;
 }
 
-inline vnl_rational operator%(vnl_rational const& r1, int r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator%(vnl_rational const& r1, const T r2)
 {
-  vnl_rational result(r1); return result %= (long)r2;
+  vnl_rational result(r1); return result %= vnl_rational::int_type{r2};
 }
 
-inline vnl_rational operator%(long r1, vnl_rational const& r2)
+inline vnl_rational operator%(vnl_rational::int_type r1, vnl_rational const& r2)
 {
   vnl_rational result(r1); return result %= r2;
 }
 
-inline vnl_rational operator%(int r1, vnl_rational const& r2)
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline vnl_rational operator%(const T r1, vnl_rational const& r2)
 {
-  vnl_rational result((long)r1); return result %= r2;
+  vnl_rational result(vnl_rational::int_type{r1}); return result %= r2;
 }
 
-inline bool operator==(int  r1, vnl_rational const& r2) { return r2==r1; }
-inline bool operator==(long r1, vnl_rational const& r2) { return r2==r1; }
-inline bool operator!=(int  r1, vnl_rational const& r2) { return r2!=r1; }
-inline bool operator!=(long r1, vnl_rational const& r2) { return r2!=r1; }
-inline bool operator< (int  r1, vnl_rational const& r2) { return r2> r1; }
-inline bool operator< (long r1, vnl_rational const& r2) { return r2> r1; }
-inline bool operator> (int  r1, vnl_rational const& r2) { return r2< r1; }
-inline bool operator> (long r1, vnl_rational const& r2) { return r2< r1; }
-inline bool operator<=(int  r1, vnl_rational const& r2) { return r2>=r1; }
-inline bool operator<=(long r1, vnl_rational const& r2) { return r2>=r1; }
-inline bool operator>=(int  r1, vnl_rational const& r2) { return r2<=r1; }
-inline bool operator>=(long r1, vnl_rational const& r2) { return r2<=r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator==(const T r1, vnl_rational const& r2) { return r2==r1; }
+inline bool operator==(vnl_rational::int_type r1, vnl_rational const& r2) { return r2==r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator!=(const T r1, vnl_rational const& r2) { return r2 != r1; }
+inline bool operator!=(vnl_rational::int_type r1, vnl_rational const& r2) { return r2!=r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator< (const T r1, vnl_rational const& r2) { return r2 > r1; }
+inline bool operator< (vnl_rational::int_type r1, vnl_rational const& r2) { return r2> r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator> (const T r1, vnl_rational const& r2) { return r2 < r1; }
+inline bool operator> (vnl_rational::int_type r1, vnl_rational const& r2) { return r2< r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator<=(const T r1, vnl_rational const& r2) { return r2>=r1; }
+inline bool operator<=(vnl_rational::int_type r1, vnl_rational const& r2) { return r2>=r1; }
+template <typename T, typename SFINAE = vnl_rational::enable_if_signed_integral_type<T>>
+inline bool operator>=(const T r1, vnl_rational const& r2) { return r2 <= r1; }
+inline bool operator>=(vnl_rational::int_type r1, vnl_rational const& r2) { return r2<=r1; }
 
-inline long truncate(vnl_rational const& r) { return r.truncate(); }
-inline long floor(vnl_rational const& r) { return r.floor(); }
-inline long ceil(vnl_rational const& r) { return r.ceil(); }
-inline long round(vnl_rational const& r) { return r.round(); }
+inline vnl_rational::int_type truncate(vnl_rational const& r) { return r.truncate(); }
+inline vnl_rational::int_type floor(vnl_rational const& r) { return r.floor(); }
+inline vnl_rational::int_type ceil(vnl_rational const& r) { return r.ceil(); }
+inline vnl_rational::int_type round(vnl_rational const& r) { return r.round(); }
 
 namespace vnl_math
 {


### PR DESCRIPTION
Fixed issue #664, "vnl_rational should have same size on all platforms":

Added `vnl_rational::int_type`, the integer type of both the numerator
and the denominator, and defined this type as `std::int64_t` to ensure
64-bit integers on all supported platforms. Note that `boost::rational`
also has an `int_type`: www.boost.org/doc/libs/1_71_0/boost/rational.hpp

Extensively used C++ SFINAE (Substitution Failure Is Not An Error) to
avoid redundant code.

Added missing `const` keyword to converting operator for signed
integral types.

Added `test_converting_constructors()` to test_rational.