### PR TITLE
BUG: bpgl & acal fixes

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_f_utils.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_f_utils.cxx
@@ -412,27 +412,54 @@ bool acal_f_utils::read_affine_cameras(
     std::string affine_cam_path,
     std::map<size_t, vpgl_affine_camera<double> >& acams)
 {
+  // Open affine_cam_path for reading
   std::ifstream istr(affine_cam_path.c_str());
-  if(!istr){
-    std::cout << "Can't open " << affine_cam_path << " to read affine cameras" << std::endl;
+  if(!istr) {
+    std::cerr << "Can't open " << affine_cam_path << " to read affine cameras" << std::endl;
     return false;
   }
+
+  // Read the first line, which should be the number of cameras
   size_t ncams, cam_idx;
   istr >> ncams;
-  if(ncams == 0){
-    std::cout << "no cameras to read" << std::endl;
+  if(ncams == 0) {
+    std::cerr << "no cameras to read" << std::endl;
     return false;
   }
-  for(size_t i = 0; i<ncams; ++i){
+
+  // For each camera
+  for(size_t i = 0; i<ncams; ++i) {
+
+    // Read in the camera ID
     istr >> cam_idx;
+
+    // Read in the viewing distance
+    double vd;
+    istr >> vd;
+
+    // Create an affine camera
     vpgl_affine_camera<double> acam;
-	double vd;
-	istr >> vd;
+
+    // Read in the 3x4 affine camera matrix
     istr >> acam;
+
+    // Store the viewing distance in the camera
     acam.set_viewing_distance(vd);
-    acams[cam_idx]=acam;
+
+    // Save camera into input map
+    acams[cam_idx] = acam;
+
+    if (!istr.good()) {
+      // An error state flag was set for the input stream, so something went wrong
+      std::cerr << "Can't open " << affine_cam_path << " to read affine cameras" << std::endl;
+      return false;
+    }
   }
+
+  // Close affine_cam_path
   istr.close();
+
+  // Return success
   return true;
 }
 

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
@@ -189,14 +189,14 @@ compute_rectification(vgl_box_3d<double>const& scene_box)
     double y = rng.drand64()*height + min_y;
     double u, v;
     acam0_.project(x,y,z0,u,v);
-  if(u>=0 || u<ni0||v>=0||v<nj0)
+    if(u>=0 && u<ni0 && v>=0 && v<nj0)
      img_pts0.emplace_back(u,v,1);
-  acam1_.project(x, y, z0, u, v);
-  if (u >= 0 || u<ni1 || v >= 0 || v<nj1)
+    acam1_.project(x, y, z0, u, v);
+    if (u >= 0 && u<ni1 && v >= 0 && v<nj1)
      img_pts1.emplace_back(u,v,1);
   }
 
-  // santity check
+  // sanity check
   bool epi_constraint = true;
   for (size_t k = 0; k < img_pts0.size(); ++k) {
     vnl_vector_fixed<double, 3> pr = img_pts0[0], line_l, pl = img_pts1[0];


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
## PR Description
- BPGL rectification was incorrectly checking the bounds of points projected into the images. The bounds are now checked correctly.
- Acal was silently erroring when the affine camera text format it expected was violated. It will now properly return false if the format is invalid.