### PR TITLE
ENH: travis ctest --output-on-failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ script:
   - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalStart
   - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalConfigure
   - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalBuild -j2
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalTest --schedule-random -j2
+  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalTest --schedule-random -j2 --output-on-failure
   - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalSubmit
   - make install


### PR DESCRIPTION
Add ctest `--output-on-failure` flag to `.travis.yml` to print test output for any failing test.  Without such information, developers may have difficulty fixing a test failure for travis-specific build environments.

## PR Checklist
:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
:no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
:no_entry_sign: Adds tests and baseline comparison (quantitative).
:no_entry_sign: Adds Documentation.
