### PR TITLE
fixed warnings type cast pointer truncation in brl

### DIFF
--- a/contrib/brl/bbas/bocl/bocl_device.cxx
+++ b/contrib/brl/bbas/bocl/bocl_device.cxx
@@ -29,7 +29,7 @@ bocl_device::bocl_device(cl_device_id& device) : device_(device)
 std::string bocl_device::device_identifier()
 {
     std::stringstream outstr;
-    outstr<<(long)(device_);
+    outstr<<(size_t)(device_);
     return info_.device_vendor_+info_.device_name_+outstr.str();
 }
 //destructor

--- a/contrib/brl/bbas/bocl/bocl_device_info.cxx
+++ b/contrib/brl/bbas/bocl/bocl_device_info.cxx
@@ -220,7 +220,7 @@ std::ostream& operator <<(std::ostream &s, bocl_device_info& info)
 {
   unsigned size = sizeof(std::size_t);
   s  << " Device Description: \n"
-     << " Device ID : " << (long) (*info.device_) << '\n'
+     << " Device ID : " << (size_t) (*info.device_) << '\n'
      << " Device Name : " << info.device_name_ << '\n'
      << " Device Vendor: " << info.device_vendor_ << '\n'
      << " Device Platform: " << info.platform_name_ << '\n'


### PR DESCRIPTION
COMP: fixed compiler warnings C4311: 'type cast': pointer truncation in brl/bbas/bocl