### PR TITLE
BUG: sdet_classify

### DIFF
--- a/contrib/brl/bseg/sdet/algo/sdet_classify.cxx
+++ b/contrib/brl/bseg/sdet/algo/sdet_classify.cxx
@@ -129,6 +129,10 @@ sdet_classify(sdet_atmospheric_image_classifier tc,
   int ni_valid = image_grey.ni() - (2 * edge_buffer);
   int nj_valid = image_grey.nj() - (2 * edge_buffer);
 
+  if (ni_valid <= 0 || nj_valid <= 0) {
+    throw std::invalid_argument("Filter radius larger than image dimensions!\n");
+  }
+
   // Crop the inner valid pixels which can be classified
   // i.e. this is the region of the input image which will be classified
   vil_image_view<float> outf = vil_crop(image_grey, edge_buffer, ni_valid, edge_buffer, nj_valid);


### PR DESCRIPTION
Fixed a bug in SDET classify, where the valid image bounds could be negative, causing an invalid allocation

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
