### PR TITLE
BUG: remove failing test (contrib/mul/vimt/tests/test_v2i)

### DIFF
--- a/contrib/mul/vimt/tests/CMakeLists.txt
+++ b/contrib/mul/vimt/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ add_test( NAME vimt_test_find_troughs COMMAND $<TARGET_FILE:vimt_test_all> test_
 add_test( NAME vimt_test_correlate_2d COMMAND $<TARGET_FILE:vimt_test_all> test_correlate_2d )
 add_test( NAME vimt_test_resample_bilin COMMAND $<TARGET_FILE:vimt_test_all> test_resample_bilin )
 add_test( NAME vimt_test_image_bounds_and_centre_2d COMMAND $<TARGET_FILE:vimt_test_all> test_image_bounds_and_centre_2d )
-add_test( NAME vimt_test_v2i COMMAND $<TARGET_FILE:vimt_test_all> test_v2i )
+# add_test( NAME vimt_test_v2i COMMAND $<TARGET_FILE:vimt_test_all> test_v2i )
 add_test( NAME vimt_test_reflect COMMAND $<TARGET_FILE:vimt_test_all> test_reflect )
 
 add_executable( vimt_test_include test_include.cxx )


### PR DESCRIPTION
Commit 84bd0b87 (pushed directly to master) by @TimCootes removed functionality from the contrib/mul/vimt library, but did not remove the associated test (which now fails).  This PR removes the failing test.  Note this failing test is not caught by CI, as travis doesn't build/test contrib.

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
