### PR TITLE
PERF: Add C++11 move-constructor and move-assignment to vnl_vector

### DIFF
--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -9,6 +9,9 @@
 #include <vnl/vnl_cross.h>
 #include <testlib/testlib_test.h>
 
+#include <numeric> // For iota.
+#include <utility> // For move.
+
 void vnl_vector_test_int()
 {
 
@@ -585,6 +588,57 @@ void vnl_vector_test_matrix()
         (v.size()==2 && v(0)==1 && v(1)==4)), true);
 }
 
+
+void vnl_vector_test_move_construct()
+{
+  const std::size_t len{ 3 };
+  using vector_type = vnl_vector<int>;
+
+  // As an example, use original_vector = { 1, 2, 3 };
+  vector_type original_vector(len);
+  std::iota(original_vector.begin(), original_vector.end(), 1);
+
+  const vector_type copy_of_vector(original_vector);
+
+  static_assert(noexcept(vector_type(std::move(original_vector))),
+    "The move-constructor must be noexcept");
+
+  const vector_type move_constructed_vector(std::move(original_vector));
+
+  TEST("A move-constructed vector is equal to a copy",
+    move_constructed_vector, copy_of_vector);
+
+  TEST("A moved-from vector (rhs of move-construct) is empty",
+    original_vector.empty(), true);
+}
+
+
+void vnl_vector_test_move_assign()
+{
+  const std::size_t len{ 3 };
+  using vector_type = vnl_vector<int>;
+
+  // As an example, use original_vector = { 1, 2, 3 };
+  vector_type original_vector(len);
+  std::iota(original_vector.begin(), original_vector.end(), 1);
+
+  const vector_type copy_of_vector(original_vector);
+
+  vector_type move_assign_target;
+
+  static_assert(noexcept(move_assign_target = std::move(original_vector)),
+    "The move-assignment must be noexcept");
+
+  move_assign_target = std::move(original_vector);
+
+  TEST("A move-constructed vector is equal to a copy",
+    move_assign_target, copy_of_vector);
+
+  TEST("A moved-from vector (rhs of move-assignment) is empty",
+    original_vector.empty(), true);
+}
+
+
 void vnl_vector_test_conversion()
 {
   bool check;
@@ -759,6 +813,8 @@ void test_vector()
   vnl_vector_test_int();
   vnl_vector_test_float();
   vnl_vector_test_matrix();
+  vnl_vector_test_move_construct();
+  vnl_vector_test_move_assign();
   vnl_vector_test_conversion();
   vnl_vector_test_io();
 #if TIMING

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -96,6 +96,9 @@ class VNL_EXPORT vnl_vector
   //: Copy constructor.
   vnl_vector(vnl_vector<T> const&);
 
+  //: Move-constructor.
+  vnl_vector(vnl_vector<T> &&) noexcept;
+
 #ifndef VXL_DOXYGEN_SHOULD_SKIP_THIS
 // <internal>
   // These constructors are here so that operator* etc can take
@@ -175,6 +178,9 @@ class VNL_EXPORT vnl_vector
 
   //: Copy operator
   vnl_vector<T>& operator=(vnl_vector<T> const& rhs);
+
+  //: Move-assignment operator
+  vnl_vector<T>& operator=(vnl_vector<T>&& rhs) noexcept;
 
   //: Add scalar value to all elements
   vnl_vector<T>& operator+=(T );
@@ -340,7 +346,7 @@ class VNL_EXPORT vnl_vector
   vnl_vector& roll_inplace(const int &shift);
 
   //: Set this to that and that to this
-  void swap(vnl_vector<T> & that);
+  void swap(vnl_vector<T> & that) noexcept;
 
   //: Check that size()==sz if not, abort();
   // This function does or tests nothing if NDEBUG is defined

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -122,6 +122,18 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const& v)
   }
 }
 
+
+//: Move-constructs a vector. O(1).
+template<class T>
+vnl_vector<T>::vnl_vector(vnl_vector<T>&& v) noexcept
+  :
+  data{ v.data },
+  num_elmts{ v.num_elmts }
+{
+  v.data = nullptr;
+  v.num_elmts = 0;
+}
+
 //: Creates a vector from a block array of data, stored row-wise.
 // Values in datablck are copied. O(n).
 
@@ -357,6 +369,21 @@ vnl_vector<T>& vnl_vector<T>::operator= (vnl_vector<T> const& rhs)
   }
   return *this;
 }
+
+
+//: Move-assigns rhs vector into lhs vector. O(1).
+template<class T>
+vnl_vector<T>& vnl_vector<T>::operator=(vnl_vector<T>&& rhs) noexcept
+{
+  vnl_vector temp(std::move(rhs));
+
+  static_assert(noexcept(this->swap(temp)),
+    "swap should be noexcept, to ensure that move-assign never fails");
+  this->swap(temp);
+
+  return *this;
+}
+
 
 //: Increments all elements of vector with value. O(n).
 
@@ -676,7 +703,7 @@ vnl_vector<T>::roll_inplace(const int &shift)
 }
 
 template <class T>
-void vnl_vector<T>::swap(vnl_vector<T> &that)
+void vnl_vector<T>::swap(vnl_vector<T> &that) noexcept
 {
   std::swap(this->num_elmts, that.num_elmts);
   std::swap(this->data, that.data);


### PR DESCRIPTION
Added fast (O(1)), `noexcept` move-constructor and move-assignment
operator to `vnl_vector`.

Added `noexcept` specifier to `vnl_vector::swap`, in order to use it
for the move-assignment implementation.

Added `vnl_vector_test_move_construct()` and `vnl_vector_test_move_assign()`.