### PR TITLE
ENH: vpgl_rational_order initializer list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 2.0.2.1 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 2.0.2.2 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vpgl/tests/test_rational_camera.cxx
+++ b/core/vpgl/tests/test_rational_camera.cxx
@@ -199,6 +199,43 @@ static void test_rational_camera()
   good = good && sv == rcam.scale(vpgl_rational_camera<double>::V_INDX);
   good = good && ov == rcam.offset(vpgl_rational_camera<double>::V_INDX);
   TEST("test getting scale and offset values", good, true);
+
+  // test vpgl_rational_order
+  // iterate through vpgl_rational_order enumeration checking related functionality
+  // try/catch for general failure (e.g., invalid std::initializer_list)
+  try {
+    std::cout << "testing vpgl_rational_order" << std::endl;
+
+    for (auto choice : vpgl_rational_order_func::initializer_list) {
+      std::string choice_str;
+
+      switch (choice) {
+        case vpgl_rational_order::VXL : {
+          choice_str = "VXL";
+          break;
+        }
+        case vpgl_rational_order::RPC00B : {
+          choice_str = "RPC00B";
+          break;
+        }
+        default: {
+          throw std::invalid_argument("vpgl_rational_order not recognized");
+        }
+      }
+
+      TEST(("vpgl_rational_order::" + choice_str + " to_string").c_str(),
+           vpgl_rational_order_func::to_string(choice),
+           choice_str);
+      TEST(("vpgl_rational_order::" + choice_str + " from_string").c_str(),
+           vpgl_rational_order_func::from_string(choice_str),
+           choice);
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "vpgl_rational_order general failure: " << e.what();
+    TEST("vpgl_rational_order general", false, true);
+  }
+
 }
 
 TESTMAIN(test_rational_camera);

--- a/core/vpgl/vpgl_rational_camera.cxx
+++ b/core/vpgl/vpgl_rational_camera.cxx
@@ -1,7 +1,6 @@
 // This is core/vpgl/vpgl_rational_camera.cxx
 #include "vpgl_rational_camera.h"
 
-
 // std::vector from vpgl_rational_order
 std::vector<unsigned>
 vpgl_rational_order_func::to_vector(vpgl_rational_order choice) {
@@ -90,3 +89,7 @@ vpgl_rational_order_func::from_string(std::string const& buf)
   else
     throw std::invalid_argument("string not recognized as vpgl_rational_order");
 }
+
+// define vpgl_rational_order_func static initializer_list in namespace
+constexpr std::initializer_list<vpgl_rational_order>
+vpgl_rational_order_func::initializer_list;

--- a/core/vpgl/vpgl_rational_camera.h
+++ b/core/vpgl/vpgl_rational_camera.h
@@ -83,6 +83,7 @@
 #include <utility>
 #include <vector>
 #include <stdexcept>
+#include <initializer_list>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
@@ -104,6 +105,14 @@ class vpgl_rational_order_func {
   static std::vector<unsigned> to_vector(vpgl_rational_order choice);
   static std::string to_string(vpgl_rational_order choice);
   static vpgl_rational_order from_string(std::string const& buf);
+
+  // initializer_list for iteration
+  // e.g. "for (auto item : vpgl_rational_order_func::initializer_list) {...}"
+  static constexpr std::initializer_list<vpgl_rational_order> initializer_list = {
+    vpgl_rational_order::VXL,
+    vpgl_rational_order::RPC00B
+  };
+
  private:
   vpgl_rational_order_func() = delete;
 };


### PR DESCRIPTION
small enhancement adding a `std::initializer_list` for the `vpgl_rational_order` enumeration allowing easy iteration through all choices (i.e., `for (auto item:  vpgl_rational_order_func::initializer_list) {...}`)

## PR Checklist
🚫 Makes breaking changes to the `vxl/core/` API that requires semantic versioning increase
✅ Makes design changes to existing `vxl/core/` API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
