### PR TITLE
CI: faster travis with build cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,73 @@ compiler:
   - clang
   - gcc
 
+# environment variables
+env:
+  global:
+    - VXL_SOURCE_DIR=$TRAVIS_BUILD_DIR
+    - VXL_BUILD_DIR=${HOME}/build
+    - VXL_INSTALL_DIR=${HOME}/install
+
 # https://docs.travis-ci.com/user/customizing-the-build/
 git:
   depth: 3
-before_install:
-  - TOOLS_DIR=$(pwd)
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then CMAKE_URL="http://www.cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then mkdir -p cmake && travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake ; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then export PATH=${TOOLS_DIR}/cmake/bin:${PATH} ; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "need cmake 3.10.2"; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew install ccache cmake; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/cmake/bin:$PATH"; fi
 
+# cache the build dir
+cache:
+  timeout: 1000
+  directories:
+  - ${VXL_BUILD_DIR}
+
+# general dependencies
+addons:
+  apt:
+    packages:
+      - ninja-build
+  homebrew:
+    packages:
+      - ninja
+
+# additional setup
+install:
+
+  # additional dependencies in ${HOME}/deps/
+  - DEPS_DIR="${HOME}/deps"
+  - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+
+  # install recent cmake
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="http://www.cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"
+      mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+    elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      brew install cmake || brew upgrade cmake
+    fi
+  - cmake --version && ctest --version
+
+# before script runs, we need to resolve timestamps between the git clone
+# and the older build cache. A good discussion is found here:
+# https://blog.esciencecenter.nl/travis-caching-and-incremental-builds-6518b89ee889
+before_script:
+
+  # create build & install directories if they do not exist
+  - mkdir -p ${VXL_BUILD_DIR} ${VXL_INSTALL_DIR}
+
+  # fix times on source
+  - |
+    MD5_FILE=${VXL_BUILD_DIR}/vxl.md5
+    export OLDEST_DATE=$(find ${VXL_BUILD_DIR} -type f -printf '%TD %TT\n' | sort | head -1)
+    if [ -f ${MD5_FILE} ]; then
+      (md5sum -c ${MD5_FILE} 2>/dev/null || :) | awk '{if ($NF == "OK") print substr($0, 1, length($0)-4)}' | xargs touch -d "${OLDEST_DATE}"
+    fi
+    find ${VXL_SOURCE_DIR} \( -type d -name .git \) -prune -o -type f -print0 | xargs -0 md5sum > ${MD5_FILE}
+
+# main script
 script:
-  - export HERE=$(pwd)
-  - ${TOOLS_DIR}/cmake/bin/cmake --version
-  - mkdir -p ${HERE}/build
-  - mkdir -p ${HERE}/install
-  - cd ${HERE}/build
-  - ${TOOLS_DIR}/cmake/bin/cmake
-          -DCMAKE_INSTALL_PREFIX:PATH=${HERE}/install
+  - cd ${VXL_BUILD_DIR}
+  - cmake
+          -G Ninja
+          -DCMAKE_INSTALL_PREFIX:PATH=${VXL_INSTALL_DIR}
           -DCMAKE_CXX_STANDARD:STRING=11
           -DVXL_BUILD_BRL:BOOL=OFF
           -DCMAKE_BUILD_TYPE:STRING=Release
@@ -44,10 +91,10 @@ script:
           -DVXL_FORCE_V3P_PNG:BOOL=ON
           -DVXL_FORCE_V3P_TIFF:BOOL=ON
           -DVXL_FORCE_V3P_ZLIB:BOOL=ON
-          ../
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalStart
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalConfigure
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalBuild -j2
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalTest --schedule-random -j2 --output-on-failure
-  - ${TOOLS_DIR}/cmake/bin/ctest -D ExperimentalSubmit
-  - make install
+          ${VXL_SOURCE_DIR}
+  - ctest -D ExperimentalStart
+  - ctest -D ExperimentalConfigure
+  - ctest -D ExperimentalBuild -j2
+  - ctest -D ExperimentalTest --schedule-random -j2 --output-on-failure
+  - ctest -D ExperimentalSubmit
+  - ninja install


### PR DESCRIPTION
Add build caching to travis - on my fork this change reduced CI time for a manually triggered rebuild from 20 min (setup, full core rebuild, test) to 2 min (setup, incremental core rebuild, test).  

Changes include:
- cache entire build directory
- resolve timestamps between git clone and build cache (see below for more info)
- switch from `make` to `ninja`

To elaborate on the timestamp resolution - cloned code timestamps are newer than the build cache, which would typically result in a complete rebuild.  Timestamps are resolved so that a complete rebuild is unnecessary based on CircleCI code from @andyneff.  A good discussion of the issue is found here:
https://blog.esciencecenter.nl/travis-caching-and-incremental-builds-6518b89ee889

Note that admins can always clear the cache should they require a full rebuild.
https://docs.travis-ci.com/user/caching/#clearing-caches

## PR Checklist

🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
🚫  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
✔️ Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
