### PR TITLE
ENH: RANSAC methods in bvgl_register_ptsets_3d_rigid

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -5,7 +5,7 @@
 
 //:
 // \file
-// \brief register two 3-d poinsets with 2-d rotation and 3-d translation
+// \brief register two 3-d pointsets 3-d translation
 //
 // \author J.L. Mundy
 // \date Sept. 7, 2019
@@ -13,8 +13,11 @@
 // \verbatim
 //  Modifications:None
 // \endverbatim
-
-
+// Two pointsets are used: 1) a movable pointset and 2) a fixed pointset. The transformation from initial
+// movable pointset coordinate system to the fixed pointset is determined. Two methods are currently implmented:
+// exhausitve search over a space of translations and a simple form of RANSAC. The fixed pointset is stored in a
+// k-d tree to efficiently retrieve the nearest neighbor to a given point from the movable pointset.
+// 
 #include <iostream>
 #include <ostream>
 #ifdef _MSC_VER
@@ -32,19 +35,24 @@ class bvgl_register_ptsets_3d_rigid
 
 public:
   //: Constructor - default
-  bvgl_register_ptsets_3d_rigid():
-    t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
+ bvgl_register_ptsets_3d_rigid():
+  t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
     t_inc_(vgl_vector_3d<T>(0.5, 0.5, 0.5)),
-    outlier_thresh_(5.0), transform_fraction_(0.05),
-    min_n_pts_(1000), min_error_(std::numeric_limits<T>::max()) {}
-
-  bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable):
-    t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
+    outlier_thresh_(5.0), transform_fraction_(0.25),
+    min_n_pts_(1000), n_hypos_(100), min_exhaustive_error_(std::numeric_limits<T>::max()),
+    min_ransac_error_(std::numeric_limits<T>::max()), exhaustive_t_(vgl_vector_3d<T>(T(0),T(0),T(0))) {}
+  //: constructor with pointsets
+ bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable):
+  t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
     t_inc_(vgl_vector_3d<T>(0.5, 0.5, 0.5)),
-    outlier_thresh_(5.0), transform_fraction_(0.05),
-    min_n_pts_(1000), min_error_(std::numeric_limits<T>::max())
+    outlier_thresh_(5.0), transform_fraction_(0.25),
+    min_n_pts_(1000), n_hypos_(100), min_exhaustive_error_(std::numeric_limits<T>::max()),
+    min_ransac_error_(std::numeric_limits<T>::max()),exhaustive_t_(vgl_vector_3d<T>(T(0),T(0),T(0)))
   {
+    // initialize knn index with fixed pointset
     fixed_ = fixed; movable_ = movable; knn_fixed_ = bvgl_k_nearest_neighbors_3d<T>(fixed);
+
+    // reduce the size of the movable pointset to reduce computation
     unsigned n = movable_.npts();
     size_t nf = static_cast<size_t>(transform_fraction_ * n);
     if (nf < min_n_pts_)
@@ -58,25 +66,62 @@ public:
       frac_trans_.add_point(p);
     }
   }
+  //: load the fixed pointset (use with default constructor)
   bool read_fixed_ptset(std::string const& fixed_path);
+
+  //: load the movable pointset (use with default constructor)
   bool read_movable_ptset(std::string const& movable_path);
+
+  //: save the transformed pointset
   bool save_transformed_ptset(std::string const& path);
+
+  // ======  Parameters ========
+  //: define the bounds for the exhaustive search
   void set_search_range( vgl_vector_3d<T> const& t_range){ t_range_ = t_range;}
+
+  //: define the increment for the exhaustive search
   void set_search_increment( vgl_vector_3d<T> const& t_inc){ t_inc_ = t_inc;}
+
+  //: define a distance threshold for outliers (used in exhaustive search)
   void set_outlier_thresh(T outlier_thresh){outlier_thresh_ = outlier_thresh;}
+
+  //: define the fraction of the movable pointset to be used in computing the transformation
+  //  enables reduced computation
   void set_transform_fraction(T fraction){transform_fraction_ = fraction;}
+
+  //: define the least number of points that can be used to compute the transform
   void set_min_n_pts(size_t n) { min_n_pts_ = n; }
+
+  //: the number of transform hypotheses used by RANSAC
+  void set_n_hypotheses(size_t n) {n_hypos_ = n;}
+
+  // ===========  Accessors =================
   vgl_vector_3d<T> search_range() const {return t_range_;}
   vgl_vector_3d<T> search_increment() const {return t_inc_;}
   T outlier_thresh() const { return outlier_thresh_;}
   T transform_fraction() const {return transform_fraction_;}
   size_t min_n_pts() const {return min_n_pts_;}
-  bool closest_point(vgl_point_3d<T> const& probe, vgl_point_3d<T>& closest){return knn_fixed_.closest_point(probe, closest);}
-  T error(vgl_vector_3d<T> const& t);
-  bool minimize();
-  vgl_vector_3d<T> t()const {return t_;}
-  T min_error() const {return min_error_;}
   const bvgl_k_nearest_neighbors_3d<T>& knn_fixed() const {return knn_fixed_;}
+  vgl_vector_3d<T> exhaustive_t()const {return exhaustive_t_;}
+  vgl_vector_3d<T> best_ransac_t()const {return best_ransac_t_;}
+  T min_exhaustive_error() const {return min_exhaustive_error_;}
+  T min_ransac_error() const {return min_ransac_error_;}
+
+
+  //: the rms error between the movable and fixed closest points
+  T error(vgl_vector_3d<T> const& t);
+
+  //: error defined in terms of distances to population fractions
+  T distr_error(vgl_vector_3d<T> const& t);
+
+  //: Find the transformation that minimizes rms error by exhaustive search
+  bool minimize_exhaustive();
+
+  //: Find the transformation by a fixed number of RANSAC trials. Uses distr_error
+  // by default use as an intial transform the exhaustive result
+  bool minimize_ransac(vgl_vector_3d<T> const& initial_t = exhaustive_t());
+
+  //: does this instance have valid pointsets
   bool valid_instance() const {return (fixed_.size()>0 && movable_.size()>0);}
  private:
   T outlier_thresh_;
@@ -85,11 +130,14 @@ public:
   vgl_pointset_3d<T> movable_;
   double transform_fraction_;
   size_t min_n_pts_;
+  size_t n_hypos_;
   vgl_pointset_3d<T> frac_trans_;
-  vgl_vector_3d<T> t_;
+  vgl_vector_3d<T> best_ransac_t_;
+  vgl_vector_3d<T> exhaustive_t_;
   vgl_vector_3d<T> t_range_;
   vgl_vector_3d<T> t_inc_;
-  T min_error_;
+  T min_exhaustive_error_;
+  T min_ransac_error_;
 };
 
 

--- a/contrib/brl/bbas/bvgl/algo/tests/test_register.cxx
+++ b/contrib/brl/bbas/bvgl/algo/tests/test_register.cxx
@@ -34,10 +34,10 @@ static void test_register()
     test_ptset.add_point(tp);
   }
   bvgl_register_ptsets_3d_rigid<float> reg(gt_ptset, test_ptset);
-  bool good = reg.minimize();
+  bool good = reg.minimize_exhaustive();
   TEST("registration success", good, true);
-  std::cout << "msq_error " << reg.min_error() << " trans at min "<< reg.t() << std::endl;
-  vgl_vector_3d<float> tmin = reg.t();
+  std::cout << "msq_error " << reg.min_exhaustive_error() << " trans at min "<< reg.exhaustive_t() << std::endl;
+  vgl_vector_3d<float> tmin = reg.exhaustive_t();
   vgl_vector_3d<float> dif = t+tmin;
   float er = dif.length();
   TEST_NEAR("solve for translation", er, 0.0f, 0.5f);


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.

Adding RANSAC registration methods to bvgl_register_ptsets_3d_rigid in bvgl/algo.

<!-- **Thanks for contributing to vxl!** -->
