### PR TITLE
COMP: Use lighter weight std::array<> with rigid size of 2

### DIFF
--- a/core/vpgl/vpgl_rational_camera.cxx
+++ b/core/vpgl/vpgl_rational_camera.cxx
@@ -91,5 +91,4 @@ vpgl_rational_order_func::from_string(std::string const& buf)
 }
 
 // define vpgl_rational_order_func static initializer_list in namespace
-constexpr std::initializer_list<vpgl_rational_order>
-vpgl_rational_order_func::initializer_list;
+constexpr std::array<vpgl_rational_order,2> vpgl_rational_order_func::initializer_list;

--- a/core/vpgl/vpgl_rational_camera.h
+++ b/core/vpgl/vpgl_rational_camera.h
@@ -83,7 +83,8 @@
 #include <utility>
 #include <vector>
 #include <stdexcept>
-#include <initializer_list>
+#include <array>
+
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
@@ -91,6 +92,7 @@
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_vector_fixed.h>
 #include <vpgl/vpgl_camera.h>
+
 
 // ----------------------------------------
 // rational camera order for input/output operations
@@ -108,14 +110,16 @@ class vpgl_rational_order_func {
 
   // initializer_list for iteration
   // e.g. "for (auto item : vpgl_rational_order_func::initializer_list) {...}"
-  static constexpr std::initializer_list<vpgl_rational_order> initializer_list = {
-    vpgl_rational_order::VXL,
-    vpgl_rational_order::RPC00B
+  static constexpr std::array<vpgl_rational_order,2> initializer_list{
+      vpgl_rational_order::VXL,
+      vpgl_rational_order::RPC00B
   };
 
  private:
   vpgl_rational_order_func() = delete;
 };
+
+
 
 
 // ----------------------------------------


### PR DESCRIPTION
Avoid compiler warning for gcc 5.3.1 by using std::array instead of std::initializer_list.
