### PR TITLE
STYLE: Use override statements for C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ env:
 git:
   depth: 3
 
-# cache the build dir
-cache:
-  timeout: 1000
-  directories:
-  - ${PROJ_BUILD_DIR}
+# # cache the build dir
+# cache:
+#   timeout: 1000
+#   directories:
+#   - ${PROJ_BUILD_DIR}
 
 # general dependencies
 addons:

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -9,9 +9,6 @@
 #include <vnl/vnl_cross.h>
 #include <testlib/testlib_test.h>
 
-#include <numeric> // For iota.
-#include <utility> // For move.
-
 void vnl_vector_test_int()
 {
 
@@ -588,57 +585,6 @@ void vnl_vector_test_matrix()
         (v.size()==2 && v(0)==1 && v(1)==4)), true);
 }
 
-
-void vnl_vector_test_move_construct()
-{
-  const std::size_t len{ 3 };
-  using vector_type = vnl_vector<int>;
-
-  // As an example, use original_vector = { 1, 2, 3 };
-  vector_type original_vector(len);
-  std::iota(original_vector.begin(), original_vector.end(), 1);
-
-  const vector_type copy_of_vector(original_vector);
-
-  static_assert(noexcept(vector_type(std::move(original_vector))),
-    "The move-constructor must be noexcept");
-
-  const vector_type move_constructed_vector(std::move(original_vector));
-
-  TEST("A move-constructed vector is equal to a copy",
-    move_constructed_vector, copy_of_vector);
-
-  TEST("A moved-from vector (rhs of move-construct) is empty",
-    original_vector.empty(), true);
-}
-
-
-void vnl_vector_test_move_assign()
-{
-  const std::size_t len{ 3 };
-  using vector_type = vnl_vector<int>;
-
-  // As an example, use original_vector = { 1, 2, 3 };
-  vector_type original_vector(len);
-  std::iota(original_vector.begin(), original_vector.end(), 1);
-
-  const vector_type copy_of_vector(original_vector);
-
-  vector_type move_assign_target;
-
-  static_assert(noexcept(move_assign_target = std::move(original_vector)),
-    "The move-assignment must be noexcept");
-
-  move_assign_target = std::move(original_vector);
-
-  TEST("A move-constructed vector is equal to a copy",
-    move_assign_target, copy_of_vector);
-
-  TEST("A moved-from vector (rhs of move-assignment) is empty",
-    original_vector.empty(), true);
-}
-
-
 void vnl_vector_test_conversion()
 {
   bool check;
@@ -813,8 +759,6 @@ void test_vector()
   vnl_vector_test_int();
   vnl_vector_test_float();
   vnl_vector_test_matrix();
-  vnl_vector_test_move_construct();
-  vnl_vector_test_move_assign();
   vnl_vector_test_conversion();
   vnl_vector_test_io();
 #if TIMING

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -96,9 +96,6 @@ class VNL_EXPORT vnl_vector
   //: Copy constructor.
   vnl_vector(vnl_vector<T> const&);
 
-  //: Move-constructor.
-  vnl_vector(vnl_vector<T> &&) noexcept;
-
 #ifndef VXL_DOXYGEN_SHOULD_SKIP_THIS
 // <internal>
   // These constructors are here so that operator* etc can take
@@ -178,9 +175,6 @@ class VNL_EXPORT vnl_vector
 
   //: Copy operator
   vnl_vector<T>& operator=(vnl_vector<T> const& rhs);
-
-  //: Move-assignment operator
-  vnl_vector<T>& operator=(vnl_vector<T>&& rhs) noexcept;
 
   //: Add scalar value to all elements
   vnl_vector<T>& operator+=(T );
@@ -346,7 +340,7 @@ class VNL_EXPORT vnl_vector
   vnl_vector& roll_inplace(const int &shift);
 
   //: Set this to that and that to this
-  void swap(vnl_vector<T> & that) noexcept;
+  void swap(vnl_vector<T> & that);
 
   //: Check that size()==sz if not, abort();
   // This function does or tests nothing if NDEBUG is defined

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -122,18 +122,6 @@ vnl_vector<T>::vnl_vector (vnl_vector<T> const& v)
   }
 }
 
-
-//: Move-constructs a vector. O(1).
-template<class T>
-vnl_vector<T>::vnl_vector(vnl_vector<T>&& v) noexcept
-  :
-  data{ v.data },
-  num_elmts{ v.num_elmts }
-{
-  v.data = nullptr;
-  v.num_elmts = 0;
-}
-
 //: Creates a vector from a block array of data, stored row-wise.
 // Values in datablck are copied. O(n).
 
@@ -369,21 +357,6 @@ vnl_vector<T>& vnl_vector<T>::operator= (vnl_vector<T> const& rhs)
   }
   return *this;
 }
-
-
-//: Move-assigns rhs vector into lhs vector. O(1).
-template<class T>
-vnl_vector<T>& vnl_vector<T>::operator=(vnl_vector<T>&& rhs) noexcept
-{
-  vnl_vector temp(std::move(rhs));
-
-  static_assert(noexcept(this->swap(temp)),
-    "swap should be noexcept, to ensure that move-assign never fails");
-  this->swap(temp);
-
-  return *this;
-}
-
 
 //: Increments all elements of vector with value. O(n).
 
@@ -703,7 +676,7 @@ vnl_vector<T>::roll_inplace(const int &shift)
 }
 
 template <class T>
-void vnl_vector<T>::swap(vnl_vector<T> &that) noexcept
+void vnl_vector<T>::swap(vnl_vector<T> &that)
 {
   std::swap(this->num_elmts, that.num_elmts);
   std::swap(this->data, that.data);

--- a/core/vpgl/vpgl_radial_tangential_distortion.h
+++ b/core/vpgl/vpgl_radial_tangential_distortion.h
@@ -62,24 +62,24 @@ class vpgl_radial_tangential_distortion : public vpgl_lens_distortion<T>
 
   //: Distort a projected point on the image plane
   //  Calls the pure virtual radial distortion function
-  virtual vgl_homg_point_2d<T> distort( const vgl_homg_point_2d<T>& point ) const override;
+  vgl_homg_point_2d<T> distort( const vgl_homg_point_2d<T>& point ) const override;
 
   //: Return the original point that was distorted to this location (inverse of distort)
   // \param init is an initial guess at the solution for the iterative solver
   // if \p init is NULL then \p point is used as the initial guess
   // calls the radial undistortion function
-  virtual vgl_homg_point_2d<T> undistort( const vgl_homg_point_2d<T>& point,
+  vgl_homg_point_2d<T> undistort( const vgl_homg_point_2d<T>& point,
                                           const vgl_homg_point_2d<T>* init=nullptr) const override;
 
   //: implementation of distortion in the pixel coordinate system
-  virtual vgl_homg_point_2d<T> distort_pixel(const vgl_homg_point_2d<T>& pixel, const vpgl_calibration_matrix<T>& K) const{
+  vgl_homg_point_2d<T> distort_pixel(const vgl_homg_point_2d<T>& pixel, const vpgl_calibration_matrix<T>& K) const override {
     vgl_homg_point_2d<T> cen_pixel(pixel.x()-center_.x(), pixel.y()-center_.y());
     vgl_homg_point_2d<T> ret = vpgl_lens_distortion<T>::distort_pixel(cen_pixel, K);
     return ret;
   }
 
   //: implementation of undistortion in the pixel coordinate system
-  virtual vgl_homg_point_2d<T> undistort_pixel(const vgl_homg_point_2d<T>& distorted_pixel, const vpgl_calibration_matrix<T>& K) const{
+  vgl_homg_point_2d<T> undistort_pixel(const vgl_homg_point_2d<T>& distorted_pixel, const vpgl_calibration_matrix<T>& K) const override {
     vgl_homg_point_2d<T> ret = vpgl_lens_distortion<T>::undistort_pixel(distorted_pixel, K);
     ret.set(ret.x()+center_.x(), ret.y() + center_.y());
     return ret;


### PR DESCRIPTION
Force function overrides using the override
keyword from C++11.

cd run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-override  -header-filter=.* -fix
