### PR TITLE
BUG: vnl_matrix & vnl_vector swap

### DIFF
--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -1352,6 +1352,7 @@ void vnl_matrix<T>::swap(vnl_matrix<T> &that) noexcept
   std::swap(this->num_rows, that.num_rows);
   std::swap(this->num_cols, that.num_cols);
   std::swap(this->data, that.data);
+  std::swap(this->m_LetArrayManageMemory, that.m_LetArrayManageMemory);
 }
 
 //: Reverse order of rows.  Name is from Matlab, meaning "flip upside down".

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -642,6 +642,7 @@ void vnl_vector<T>::swap(vnl_vector<T> &that) noexcept
 {
   std::swap(this->num_elmts, that.num_elmts);
   std::swap(this->data, that.data);
+  std::swap(this->m_LetArrayManageMemory, that.m_LetArrayManageMemory);
 }
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
PR #694 recently added a `m_LetArrayManageMemory` member variable to `vnl_matrix` and `vnl_vector`.  Add this new member variable to respective `swap` functions.

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core/\* API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
