### PR TITLE
BUG: vnl_matrix move-assignment segfault

### DIFF
--- a/core/vnl/tests/test_container_interface.cxx
+++ b/core/vnl/tests/test_container_interface.cxx
@@ -121,15 +121,21 @@ void test_common_interface()
     TContainer l(2, 2);
     l.copy_in(data1);
     TContainer l_swap(l);
+    TContainer l_std_swap(l);
 
     const typename TContainer::element_type data2[4] = {4, 5, 6, 7};
     TContainer r(2, 2);
     r.copy_in(data2);
     TContainer r_swap(r);
+    TContainer r_std_swap(r);
 
     l_swap.swap(r_swap);
     TEST("swap left-right", l.is_equal(r_swap, 10e-6), true);
     TEST("swap right-left", r.is_equal(l_swap, 10e-6), true);
+
+    std::swap(l_std_swap, r_std_swap);
+    TEST("std::swap left-right", l.is_equal(r_std_swap, 10e-6), true);
+    TEST("std::swap right-left", r.is_equal(l_std_swap, 10e-6), true);
     }
   m.array_one_norm();
   m.array_two_norm();

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -9,6 +9,33 @@
 #include <vnl/vnl_cross.h>
 #include <testlib/testlib_test.h>
 
+
+template< class TContainer >
+void test_common_interface()
+{
+  std::cout << "Testing swap" << std::endl;
+
+  const typename TContainer::element_type l_values[4] = {0, 1, 2, 3};
+  TContainer l(4,4,l_values);
+  TContainer l_swap(l);
+  TContainer l_std_swap(l);
+
+  const typename TContainer::element_type r_values[4] = {4, 5, 6, 7};
+  TContainer r(4,4,r_values);
+  TContainer r_swap(r);
+  TContainer r_std_swap(r);
+
+  l_swap.swap(r_swap);
+  TEST("swap left-right", l.is_equal(r_swap, 10e-6), true);
+  TEST("swap right-left", r.is_equal(l_swap, 10e-6), true);
+
+  std::swap(l_std_swap, r_std_swap);
+  TEST("std::swap left-right", l.is_equal(r_std_swap, 10e-6), true);
+  TEST("std::swap right-left", r.is_equal(l_std_swap, 10e-6), true);
+
+}
+
+
 void vnl_vector_test_int()
 {
 
@@ -634,6 +661,8 @@ void vnl_vector_test_conversion()
   }
 }
 
+
+
 static void vnl_vector_test_io()
 {
   double expected_data[] = {1.0, 2.0, 3.0};
@@ -760,7 +789,9 @@ static void vnl_vector_test_leak()           // use top4.1 to watch for memory.
 static void test_vector()
 {
   vnl_vector_test_int();
+  test_common_interface< vnl_vector<int> >();
   vnl_vector_test_float();
+  test_common_interface< vnl_vector<float> >();
   vnl_vector_test_matrix();
   vnl_vector_test_conversion();
   vnl_vector_test_io();

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -277,7 +277,7 @@ vnl_matrix<T>& vnl_matrix<T>::operator=(vnl_matrix<T>&& rhs)
       rhs.data = nullptr;
       rhs.num_rows = 0;
       rhs.num_cols = 0;
-      rhs.m_LetArrayManageMemory = false;
+      rhs.m_LetArrayManageMemory = true;
     }
   }
   return *this;

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -164,6 +164,7 @@ vnl_vector<T>& vnl_vector<T>::operator=(vnl_vector<T>&& rhs)
       m_LetArrayManageMemory = rhs.m_LetArrayManageMemory;
       rhs.data = nullptr;
       rhs.num_elmts = 0;
+      rhs.m_LetArrayManageMemory = true;
     }
   }
   return *this;


### PR DESCRIPTION
In the move-assignment `operator=` for `vnl_matrix` (see PR #694) when both left-hand side and right-hand side objects manage their own memory, the right-hand side object should finally be invalidated with null data, zero size, and  `m_LetArrayManageMemory` set to a default value of true (not false).  The system segfaults should a user attempt to `std::swap` two matrices.

Set `m_LetArrayManageMemory` to true in move-assignment `operator=` for both `vnl_matrix` and `vnl_vector`.  Add more swap tests, including native swap and `std::swap` for both `vnl_matrix` and `vnl_vector`.


## More Details
During move-assignment, `vnl_matrix` wrongly reset `m_LetArrayManageMemory` to false.  This is an issue should a user attempt to `std:swap` two matrices (while users should prefer the native `vnl_matrix::swap` function, `std::swap` should certainly not segfault).  

The C++11 `std::swap` method is implemented as follows
```
template<typename T> void swap(T& t1, T& t2) {
    T temp = std::move(t1); // line (1)
    t1 = std::move(t2);     // line (2)
    t2 = std::move(temp);   // line (3)
}
```

When using `std::swap` on a `vnl_matrix`, matrix t1 would be cleared after line 1 but with `m_LetArrayManageMemory = false`.  Line two would attempt to follow a code path for externally managed memory and the system would segfault.

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
✔️ Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
