### PR TITLE
BUG/STYLE: contrib bvgl update

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -17,7 +17,7 @@
 // movable pointset coordinate system to the fixed pointset is determined. Two methods are currently implmented:
 // exhausitve search over a space of translations and a simple form of RANSAC. The fixed pointset is stored in a
 // k-d tree to efficiently retrieve the nearest neighbor to a given point from the movable pointset.
-// 
+//
 #include <iostream>
 #include <ostream>
 #ifdef _MSC_VER
@@ -35,22 +35,15 @@ class bvgl_register_ptsets_3d_rigid
 
 public:
   //: Constructor - default
- bvgl_register_ptsets_3d_rigid():
-  t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
-    t_inc_(vgl_vector_3d<T>(0.5, 0.5, 0.5)),
-    outlier_thresh_(5.0), transform_fraction_(0.25),
-    min_n_pts_(1000), n_hypos_(100), min_exhaustive_error_(std::numeric_limits<T>::max()),
-    min_ransac_error_(std::numeric_limits<T>::max()), exhaustive_t_(vgl_vector_3d<T>(T(0),T(0),T(0))) {}
+  bvgl_register_ptsets_3d_rigid() = default;
+
   //: constructor with pointsets
- bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable):
-  t_range_(vgl_vector_3d<T>(2.5, 2.5, 2.5)),
-    t_inc_(vgl_vector_3d<T>(0.5, 0.5, 0.5)),
-    outlier_thresh_(5.0), transform_fraction_(0.25),
-    min_n_pts_(1000), n_hypos_(100), min_exhaustive_error_(std::numeric_limits<T>::max()),
-    min_ransac_error_(std::numeric_limits<T>::max()),exhaustive_t_(vgl_vector_3d<T>(T(0),T(0),T(0)))
+  bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable) :
+    fixed_(fixed),
+    movable_(movable)
   {
     // initialize knn index with fixed pointset
-    fixed_ = fixed; movable_ = movable; knn_fixed_ = bvgl_k_nearest_neighbors_3d<T>(fixed);
+    knn_fixed_ = bvgl_k_nearest_neighbors_3d<T>(fixed);
 
     // reduce the size of the movable pointset to reduce computation
     unsigned n = movable_.npts();
@@ -66,6 +59,7 @@ public:
       frac_trans_.add_point(p);
     }
   }
+
   //: load the fixed pointset (use with default constructor)
   bool read_fixed_ptset(std::string const& fixed_path);
 
@@ -123,21 +117,24 @@ public:
 
   //: does this instance have valid pointsets
   bool valid_instance() const {return (fixed_.size()>0 && movable_.size()>0);}
+
  private:
-  T outlier_thresh_;
+  vgl_vector_3d<T> t_range_ = vgl_vector_3d<T>(T(2.5), T(2.5), T(2.5));
+  vgl_vector_3d<T> t_inc_ = vgl_vector_3d<T>(T(0.5), T(0.5), T(0.5));
+  T outlier_thresh_ = T(5.0);
+  double transform_fraction_ = 0.25;
+  size_t min_n_pts_ = 1000;
+  size_t n_hypos_ = 100;
+  T min_exhaustive_error_ = std::numeric_limits<T>::max();
+  T min_ransac_error_ = std::numeric_limits<T>::max();
+  vgl_vector_3d<T> exhaustive_t_ = vgl_vector_3d<T>(T(0),T(0),T(0));
+
   vgl_pointset_3d<T> fixed_;
   bvgl_k_nearest_neighbors_3d<T> knn_fixed_;
   vgl_pointset_3d<T> movable_;
-  double transform_fraction_;
-  size_t min_n_pts_;
-  size_t n_hypos_;
   vgl_pointset_3d<T> frac_trans_;
   vgl_vector_3d<T> best_ransac_t_;
-  vgl_vector_3d<T> exhaustive_t_;
-  vgl_vector_3d<T> t_range_;
-  vgl_vector_3d<T> t_inc_;
-  T min_exhaustive_error_;
-  T min_ransac_error_;
+
 };
 
 

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -40,11 +40,9 @@ public:
   //: constructor with pointsets
   bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable) :
     fixed_(fixed),
-    movable_(movable)
+    movable_(movable),
+    knn_fixed_(fixed)
   {
-    // initialize knn index with fixed pointset
-    knn_fixed_ = bvgl_k_nearest_neighbors_3d<T>(fixed);
-
     // reduce the size of the movable pointset to reduce computation
     unsigned n = movable_.npts();
     size_t nf = static_cast<size_t>(transform_fraction_ * n);

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
@@ -32,7 +32,8 @@ T bvgl_register_ptsets_3d_rigid<T>::error(vgl_vector_3d<T> const& t)
   error /= cnt;
   return sqrt(error);
 }
-// distr_error is defined as below. Ideally the distance distribution reaches 100% of the population 
+
+// distr_error is defined as below. Ideally the distance distribution reaches 100% of the population
 // in zero distance to the nearest points in the fixed population
 //     |
 //     |             /--------------
@@ -66,7 +67,6 @@ T bvgl_register_ptsets_3d_rigid<T>::distr_error(vgl_vector_3d<T> const& t){
   return (dists[nd/2] + dists[nd/4] + dists[(3*nd)/4])/T(3);
 }
 
-
 template <class T>
 bool bvgl_register_ptsets_3d_rigid<T>::minimize_exhaustive()
 {
@@ -99,6 +99,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_exhaustive()
   exhaustive_t_ = vgl_vector_3d<T>(x_at_min, y_at_min, z_at_min);
   return true;
 }
+
 template <class T>
 bool bvgl_register_ptsets_3d_rigid<T>::minimize_ransac(vgl_vector_3d<T> const& initial_t){
   // select a random point from the test set
@@ -113,7 +114,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_ransac(vgl_vector_3d<T> const& i
     if (!knn_fixed_.closest_point(tp, cp)) {
       std::cout << "KNN index failed to find neighbors" << std::endl;
       return false;
-    }    
+    }
     vgl_vector_3d<T> t = cp-tp;
     vgl_vector_3d<T> tt = t+initial_t;
     T er = distr_error(tt);

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
@@ -138,7 +138,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::read_fixed_ptset(std::string const& fixed
     return false;
   }
   istr >> fixed_;
-  knn_fixed_ = bvgl_k_nearest_neighbors_3d<T>(fixed_);
+  knn_fixed_.set_pointset(fixed_);
   return true;
 }
 

--- a/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_3d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_3d.h
@@ -23,24 +23,33 @@ class bvgl_k_nearest_neighbors_3d
 {
  public:
   //: default constructor
- bvgl_k_nearest_neighbors_3d():tolerance_(Type(0)), search_tree_(nullptr){}
+  bvgl_k_nearest_neighbors_3d() = default;
+
   //: Construct from a vgl_pointset
-  bvgl_k_nearest_neighbors_3d(vgl_pointset_3d<Type>  const &ptset, Type tolerance = Type(0));
+  bvgl_k_nearest_neighbors_3d(vgl_pointset_3d<Type> const &ptset, Type tolerance = Type(0)) :
+    tolerance_(tolerance),
+    ptset_(std::move(ptset))
+  {
+    create();
+  }
+
   //: destructor
   ~bvgl_k_nearest_neighbors_3d(){
     if(search_tree_)
       delete search_tree_;
     search_tree_ = nullptr;
   }
+
   //: copy constructor
   bvgl_k_nearest_neighbors_3d(bvgl_k_nearest_neighbors_3d const& other) :
-    tolerance_(other.tolerance_), ptset_(other.ptset_),
-    search_tree_(nullptr)
+    tolerance_(other.tolerance_),
+    ptset_(other.ptset_)
   {
     // create handles init of M_ and search_tree_, and flags_
     create();
   }
-  //: assignment operator
+
+  //: assignment operator (copy-and-swap idiom)
   bvgl_k_nearest_neighbors_3d& operator = (bvgl_k_nearest_neighbors_3d rhs)
   {
     this->swap(rhs);
@@ -86,15 +95,15 @@ class bvgl_k_nearest_neighbors_3d
     swap(this->search_tree_, other.search_tree_);
   }
 
-  protected:
+ protected:
   //: util function for finding the k closest neighbors and indices
   inline bool knn_util(vgl_point_3d<Type> const& p, unsigned k, vgl_pointset_3d<Type>& neighbors, vnl_vector<int> &indices) const;
 
-  Type tolerance_;
-  Nabo::NearestNeighbourSearch<Type>* search_tree_;
+  Type tolerance_ = Type(0);
+  Nabo::NearestNeighbourSearch<Type>* search_tree_ = nullptr;
   vnl_matrix<Type> M_;//a matrix form(3 x n) of the pointset used by nabo
   vgl_pointset_3d<Type> ptset_;
-  unsigned flags_;//control various actions during queries
+  unsigned flags_ = 0;//control various actions during queries
 };
 
 template<class Type>
@@ -124,13 +133,6 @@ bool bvgl_k_nearest_neighbors_3d<Type>::create(){
   }
   search_tree_ = Nabo::NearestNeighbourSearch<Type>::createKDTreeLinearHeap(M_, dim);
   return true;
-}
-template <class Type>
-bvgl_k_nearest_neighbors_3d<Type>::bvgl_k_nearest_neighbors_3d(vgl_pointset_3d<Type> const& ptset, Type tolerance):
-tolerance_(tolerance),
-search_tree_(nullptr),
-ptset_(std::move(ptset)){
-  create();
 }
 
 template <class Type>

--- a/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_3d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_3d.h
@@ -78,11 +78,12 @@ class bvgl_k_nearest_neighbors_3d
   //: swap the two objects (used as part of "copy and swap" idiom)
   void swap(bvgl_k_nearest_neighbors_3d<Type>& other)
   {
-    std::swap(this->tolerance_, other.tolerance_);
-    std::swap(this->M_, other.M_);
-    std::swap(this->ptset_, other.ptset_);
-    std::swap(this->flags_, other.flags_);
-    std::swap(this->search_tree_, other.search_tree_);
+    using std::swap;
+    swap(this->tolerance_, other.tolerance_);
+    swap(this->M_, other.M_);
+    swap(this->ptset_, other.ptset_);
+    swap(this->flags_, other.flags_);
+    swap(this->search_tree_, other.search_tree_);
   }
 
   protected:


### PR DESCRIPTION
Minor update for `contrib/brl/bbas/bvgl`:
- BUG: let compiler choose appropriate swap method for `bvgl_k_nearest_neighbors_3d` (e.g., prefer `vnl_matrix::swap` over explict `std::swap`)
- STYLE: improve member variable initialization for constructors in `bvgl_k_nearest_neighbors_3d` and `bvgl_register_ptsets_3d_rigid`
- STYLE: code cleanup for `bvgl_k_nearest_neighbors_3d` and `bvgl_register_ptsets_3d_rigid`

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core/\* API that requires semantic versioning increase
✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
