### PR TITLE
Fix failing build

### DIFF
--- a/contrib/gel/gevd/gevd_edgel_regions.cxx
+++ b/contrib/gel/gevd/gevd_edgel_regions.cxx
@@ -1528,7 +1528,9 @@ void gevd_edgel_regions::repair_failed_insertions(std::vector<vtol_edge_2d_sptr>
 {
   std::vector<vtol_vertex_sptr> temp1, temp2;
   for (auto & bad_vert : bad_verts)
+  {
     for (auto & failed_insertion : *failed_insertions_)
+    {
       if (bad_vert==failed_insertion->v1())
       {
         edges.push_back(failed_insertion);
@@ -1541,6 +1543,8 @@ void gevd_edgel_regions::repair_failed_insertions(std::vector<vtol_edge_2d_sptr>
         temp1.push_back(bad_vert);
         temp2.push_back(failed_insertion->v1());
       }
+    }
+  }
   for (auto wit = temp1.begin();
        wit != temp1.end(); wit++)
     bad_verts.erase(wit);

--- a/contrib/mul/msm/msm_subset_aligner.cxx
+++ b/contrib/mul/msm/msm_subset_aligner.cxx
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <cstddef>
 #include <sstream>
+#include <iterator>
 #include "msm_subset_aligner.h"
 #include <vnl/vnl_vector.h>
 #include <vsl/vsl_binary_loader.h>

--- a/contrib/mul/msm/tools/msm_compare_markup_curves.cxx
+++ b/contrib/mul/msm/tools/msm_compare_markup_curves.cxx
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_int_list.h>

--- a/contrib/mul/msm/tools/msm_compare_markups.cxx
+++ b/contrib/mul/msm/tools/msm_compare_markups.cxx
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_int_list.h>

--- a/contrib/mul/msm/tools/msm_estimate_residuals.cxx
+++ b/contrib/mul/msm/tools/msm_estimate_residuals.cxx
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_colon_pairs_list.h>

--- a/contrib/mul/msm/tools/msm_get_shape_params.cxx
+++ b/contrib/mul/msm/tools/msm_get_shape_params.cxx
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_colon_pairs_list.h>

--- a/contrib/mul/msm/tools/msm_points_to_matrix.cxx
+++ b/contrib/mul/msm/tools/msm_points_to_matrix.cxx
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_colon_pairs_list.h>

--- a/contrib/mul/msm/tools/msm_robust_mean.cxx
+++ b/contrib/mul/msm/tools/msm_robust_mean.cxx
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <iterator>
 #include <mbl/mbl_read_props.h>
 #include <mbl/mbl_exception.h>
 #include <mbl/mbl_parse_int_list.h>


### PR DESCRIPTION
* COMP: Many compiler errors like this:

error C2039: 'back_inserter': is not a member of 'std'

Solution:
Add the <iterator> header to solve.

