### PR TITLE
BUG: The vnl_vector & vnl_matrix destructor should be virtual

### DIFF
--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -1,9 +1,6 @@
 // This is core/vnl/vnl_matrix.h
 #ifndef vnl_matrix_h_
 #define vnl_matrix_h_
-#ifdef __INTEL_COMPILER
-#pragma warning disable 444
-#endif
 //:
 // \file
 // \brief An ordinary mathematical matrix
@@ -153,7 +150,7 @@ class VNL_EXPORT vnl_matrix
   vnl_matrix<T>& operator=(vnl_matrix<T>&& rhs);
 
   //: Matrix destructor
-  ~vnl_matrix();
+  virtual ~vnl_matrix();
 
 // Basic 2D-Array functionality-------------------------------------------
 

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -108,12 +108,9 @@ class VNL_EXPORT vnl_vector
   vnl_vector<T>& operator=(vnl_vector<T>&& rhs);
 
   //: Destructor
-#ifdef __INTEL_COMPILER
-#pragma warning disable 444 //destructor for base class "itk::Array<>" is not virtual
-#endif
-  /** This destructor is not virtual for performance reasons. However, this
-   * means that subclasses cannot allocate memory. */
-  ~vnl_vector();
+  /** This destructor *must* be virtual to ensure that the vnl_vector_ref subclass destructor
+   * is called and memory is not accidently de-allocated. */
+  virtual ~vnl_vector();
 
   //: Return the length, number of elements, dimension of this vector.
   size_t size() const { return this->num_elmts; }

--- a/core/vnl/vnl_vector_ref.h
+++ b/core/vnl/vnl_vector_ref.h
@@ -42,7 +42,7 @@ class VNL_EXPORT vnl_vector_ref : public vnl_vector<T>
 
   //: Destructor
   // Prevents base destructor from releasing memory we don't own
-  ~vnl_vector_ref() = default;
+  virtual ~vnl_vector_ref() = default;
 
   //: Reference to self to make non-const temporaries.
   // This is intended for passing vnl_vector_fixed objects to


### PR DESCRIPTION
The derived class of vnl_vector_ref has a specialized destructor that
must be called in order to avoid incorrect memory deallocation.  The
polymorphic behaviors that are depended upon require virtual destructors.

Non-virtual destructors were rationalized as a potential performance gain,
but experimentation in the tests showed no measurable performance difference
after these changes (i.e. the tests took the same amount of time to run
before and after the changes).
