### PR TITLE
ENH: bpgl_rectify_affine_image_pair sliver check

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
@@ -15,12 +15,15 @@
 #include <vnl/vnl_matrix_fixed.h>
 
 struct rectify_params{
-  rectify_params(): min_disparity_z_(NAN), n_points_(1000), upsample_scale_(1.0), invalid_pixel_val_(0.0f) {}
+  rectify_params():
+    min_disparity_z_(NAN), n_points_(1000), upsample_scale_(1.0),
+    invalid_pixel_val_(0.0f), min_overlap_fraction_(0.25) {}
 
-  double min_disparity_z_; // horizontal plane where disparity at each pixel is minimum
-  size_t n_points_;            // number of points used to create correspondences
-  double upsample_scale_;      // scale factor to upsample rectified images
+  double min_disparity_z_;       // horizontal plane where disparity at each pixel is minimum
+  size_t n_points_;              // number of points used to create correspondences
+  double upsample_scale_;        // scale factor to upsample rectified images
   float invalid_pixel_val_;
+  double min_overlap_fraction_;  // minimum fraction of points in overlap with tile in both images
 };
 
 //


### PR DESCRIPTION
Allow rectification even if points in the zero disparity plane project outside of the scene bounding box. Add a check to ensure the overlap is above a certain percentage.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
