### PR TITLE
ENH (contrib/brl): operator & input argument

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.cxx
@@ -16,6 +16,20 @@
 #include "bpgl_rectify_affine_image_pair.h"
 
 
+// print rectification parameters
+std::ostream& operator<<(std::ostream &os, const rectify_params& p)
+{
+  os << "BPGL affine rectification parameters:\n"
+     << "  min_disparity_z ......... " << p.min_disparity_z_ << '\n'
+     << "  n_points ................ " << p.n_points_ << '\n'
+     << "  upsample_scale .......... " << p.upsample_scale_ << '\n'
+     << "  invalid_pixel_val ....... " << p.invalid_pixel_val_ << '\n'
+     << "  min_overlap_fraction .... " << p.min_overlap_fraction_ << std::endl
+     ;
+  return os;
+}
+
+
 bool bpgl_rectify_affine_image_pair::
 set_images_and_cams(vil_image_view_base_sptr const& view0, vpgl_affine_camera<double> const& acam0,
                     vil_image_view_base_sptr const& view1, vpgl_affine_camera<double> const& acam1)

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_affine_image_pair.h
@@ -26,6 +26,8 @@ struct rectify_params{
   double min_overlap_fraction_;  // minimum fraction of points in overlap with tile in both images
 };
 
+std::ostream& operator<<(std::ostream &os, const rectify_params& p);
+
 //
 // requires two images and associated affine cameras. Class can load the data from files if needed.
 // the output is a pair of images that have common epipolar lines along image rows. The difference in

--- a/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
+++ b/contrib/brl/bpro/core/pyscripts/bbas_adaptor.py
@@ -401,7 +401,7 @@ def heightmap_from_disparity(camera1, camera2, disparity,
 
 def rectify_affine_image_pair(image0, affine_camera0, image1, affine_camera1,
                               min_x, min_y, min_z, max_x, max_y, max_z,
-                              n_points = 1000,
+                              rectify_z = None, n_points = 1000,
                               file_H0=None, file_H1=None):
 
     batch.init_process("bpglRectifyAffineImagePairProcess")
@@ -417,12 +417,14 @@ def rectify_affine_image_pair(image0, affine_camera0, image1, affine_camera1,
     batch.set_input_double(8, max_y)
     batch.set_input_double(9, max_z)
 
-    batch.set_input_unsigned(10, n_points)
+    if rectify_z is None: rectify_z = min_z - 1.0
+    batch.set_input_double(10, rectify_z)
+    batch.set_input_unsigned(11, n_points)
 
     if not file_H0: file_H0 = ""
     if not file_H1: file_H1 = ""
-    batch.set_input_string(11, file_H0)
-    batch.set_input_string(12, file_H1)
+    batch.set_input_string(12, file_H0)
+    batch.set_input_string(13, file_H1)
 
     if batch.run_process():
         (id, type) = batch.commit_output(0)


### PR DESCRIPTION
Two minor contrib/brl enhancements
- bpgl rectification parameter operator<<
- 'rectify_z' input argument to rectify_affine_image_pair in bbas python adaptor

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
