### PR TITLE
BUG: regularize solution to improve stability of linear interpolation

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/tests/test_gridding.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_gridding.cxx
@@ -10,8 +10,9 @@
 #include <vnl/vnl_math.h>
 #include <vnl/vnl_random.h>
 
-static void test_gridding()
+void test_simple()
 {
+  // test a simple surface
   typedef double T;
 
   // sample a simple surface z=x
@@ -47,7 +48,7 @@ static void test_gridding()
   if (print_grid) {
     for (int j=0; j<nj; ++j) {
       for (int i=0; i<ni; ++i) {
-        std::cout << std::fixed << std::setprecision(6) << gridded(i,j) << " ";
+        std::cout << std::fixed << std::setprecision(3) << gridded(i,j) << " ";
       }
       std::cout << std::endl;
     }
@@ -62,6 +63,84 @@ static void test_gridding()
     }
   }
   TEST("gridded values correct", all_good, true);
+}
+
+void test_degenerate()
+{
+  // test a degenerate (linear) set of control points
+  typedef double T;
+
+  // sample a simple surface z=x
+  std::vector<vgl_point_2d<T> > sample_locs;
+  sample_locs.emplace_back(0.0f, 0.0f);
+  sample_locs.emplace_back(1.0f, 0.0f);
+  sample_locs.emplace_back(2.0f, 0.0f);
+
+  vnl_random randgen(1234);  // fixed seed for repeatability
+  std::vector<float> sample_vals;
+  for (auto loc : sample_locs) {
+    double noise = randgen.normal()*0.01;
+    // f(x,y) = x
+    sample_vals.push_back(loc.x() + noise);
+  }
+
+  vgl_point_2d<T> upper_left(0.0f, 0.0f);
+  size_t ni = 6, nj = 6;
+  T step_size = 1.0;
+  unsigned num_neighbors = 3;
+  T maxdist = 15.0f;
+
+  bpgl_gridding::linear_interp<T, float> interp_fun(maxdist, NAN);
+
+  vil_image_view<float> gridded =
+    bpgl_gridding::grid_data_2d(sample_locs, sample_vals,
+                                upper_left, ni, nj, step_size,
+                                interp_fun,
+                                num_neighbors);
+  bool print_grid = false;
+  if (print_grid) {
+    for (int j=0; j<nj; ++j) {
+      for (int i=0; i<ni; ++i) {
+        std::cout << std::fixed << std::setprecision(3) << gridded(i,j) << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
+
+  bool all_good = true;
+  for (int j=0; j<nj; ++j) {
+    for (int i=0; i<ni; ++i) {
+      // "truth" is f(x,y) = x
+      double err = gridded(i,j) - i;
+      all_good &= std::fabs(err) < 0.25;
+    }
+  }
+  TEST("gridded values correct", all_good, true);
+}
+
+void test_interp_real()
+{ 
+  // A test case derived from a real example giving unexpected results
+  std::vector<vgl_point_2d<double>> ctrl_pts;
+  ctrl_pts.emplace_back(9.35039, 151.517);
+  ctrl_pts.emplace_back(8.93042, 151.390);
+  ctrl_pts.emplace_back(8.57767, 151.285);
+
+  std::vector<double> values = { 47.7940, 46.3976, 47.7940 };
+
+ bpgl_gridding::linear_interp<double, double> interp;
+
+  vgl_point_2d<double> test_point(9, 151.999);
+  double value = interp(test_point, ctrl_pts, values);
+
+  TEST_NEAR("interpolated value in correct range", value, 47.0, 1.0);
+}
+
+static void test_gridding()
+{
+  test_simple();
+  test_degenerate();
+  test_interp_real();
 }
 
 TESTMAIN(test_gridding);


### PR DESCRIPTION
This commit fixes interpolation instability problems in bpgl_gridding.
This commit includes new test cases that fail without this change.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
-  :no_entry_sign:  Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign:  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
-  [X] Adds tests and baseline comparison (quantitative).
-  :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
