### PR TITLE
ENH/COMP (contrib): bvgl_k_nearest_neighbors_2d/bpgl_3d_from_disparity

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_3d_from_disparity.hxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_3d_from_disparity.hxx
@@ -22,7 +22,7 @@ vil_image_view<T> bpgl_3d_from_disparity(
       A[r+2][c] = P2[r][c];
     }
   }
-  vnl_matrix_inverse<double> invA(A);
+  vnl_matrix_inverse<double> invA(A.as_ref());
 
   const unsigned int ni = disparity.ni();
   const unsigned int nj = disparity.nj();
@@ -69,7 +69,7 @@ vil_image_view<T> bpgl_3d_from_disparity_with_scalar(
       A[r+2][c] = P2[r][c];
     }
   }
-  vnl_matrix_inverse<double> invA(A);
+  vnl_matrix_inverse<double> invA(A.as_ref());
 
   const unsigned int ni = disparity.ni();
   const unsigned int nj = disparity.nj();

--- a/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_2d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_k_nearest_neighbors_2d.h
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <utility>
 #include <memory>
+#include <stdexcept>
 #include <bnabo/bnabo.h>
 #include <vgl/vgl_point_2d.h>
 #ifdef _MSC_VER
@@ -24,7 +25,13 @@ class bvgl_k_nearest_neighbors_2d
 {
 public:
   //: Construct from set of points
-  bvgl_k_nearest_neighbors_2d(std::vector<vgl_point_2d<Type> > const &ptset, Type tolerance = Type(0));
+  bvgl_k_nearest_neighbors_2d(
+      std::vector<vgl_point_2d<Type> > const &ptset,
+      Type tolerance = Type(0)
+      );
+
+  //: check class validity
+  bool is_valid() const;
 
   //: query for the closest point (k = 1) including self
   bool closest_point(vgl_point_2d<Type> const& p, vgl_point_2d<Type>& cp) const;
@@ -32,126 +39,247 @@ public:
   //: query for the index in the pointset with the closest point including self
   bool closest_index(vgl_point_2d<Type> const& p, unsigned& index) const;
 
-  //: find k nearest neighbors.
-  bool knn(vgl_point_2d<Type> const& p, unsigned k, std::vector<vgl_point_2d<Type>>& neighbors) const;
+  //: find the indices of the k closest neighbors (limited by max_dist)
+  bool knn_indices(
+      vgl_point_2d<Type> const& p,
+      unsigned k,
+      std::vector<unsigned> &neighbor_indices,
+      Type max_dist = std::numeric_limits<Type>::infinity()
+      ) const;
+
+  //: find k nearest neighbors
+  bool knn(
+      vgl_point_2d<Type> const& p,
+      unsigned k,
+      std::vector<vgl_point_2d<Type>>& neighbor_locs,
+      Type max_dist = std::numeric_limits<Type>::infinity()
+      ) const;
 
   //: find k nearest neighbors and indices
-  bool knn(vgl_point_2d<Type> const& p, unsigned k, std::vector<vgl_point_2d<Type>>& neighbors, vnl_vector<int> &indices) const;
-
-  //: find the indices of the k closest neighbors.
-  bool knn_indices(vgl_point_2d<Type> const& p, unsigned k, vnl_vector<int> &indices) const;
+  bool knn(
+      vgl_point_2d<Type> const& p,
+      unsigned k,
+      std::vector<vgl_point_2d<Type>>& neighbor_locs,
+      std::vector<unsigned>& neighbor_indices,
+      Type max_dist = std::numeric_limits<Type>::infinity()
+      ) const;
 
 protected:
   //: creates and populates the underlying data structure
   bool create();
 
-  Type tolerance_;
-  std::unique_ptr<Nabo::NearestNeighbourSearch<Type>> search_tree_;
-  vnl_matrix<Type> M_;//a matrix form(2 x n) of the pointset used by nabo
+  //: main utility function - discover "k" nearest neighbors
+  // to point p within max_dist radius; return locations &indices
+  bool knn_util(
+      vgl_point_2d<Type> const& p,
+      unsigned k,
+      std::vector<vgl_point_2d<Type>>& neighbor_locs,
+      std::vector<unsigned>& neighbor_indices,
+      Type max_dist = std::numeric_limits<Type>::infinity()
+      ) const;
+
+  //: "closest" utility function - single nearest neighbor
+  bool closest_util(
+      vgl_point_2d<Type> const& p,
+      vgl_point_2d<Type>& cp,
+      unsigned& ci
+      ) const;
+
+  // private member variables
+  Type tolerance_ = Type(0);
+  std::unique_ptr<Nabo::NearestNeighbourSearch<Type>> search_tree_ = nullptr;
+  vnl_matrix<Type> M_; //a matrix form (2 x n) of the pointset used by nabo
   std::vector<vgl_point_2d<Type>> ptset_;
-  unsigned flags_;//control various actions during queries
+  unsigned flags_ = Type(0); //control various actions during queries
 };
 
 
+// constructor
 template <class Type>
-bool bvgl_k_nearest_neighbors_2d<Type>::create(){
+bvgl_k_nearest_neighbors_2d<Type>::bvgl_k_nearest_neighbors_2d(
+    std::vector<vgl_point_2d<Type>> const& ptset,
+    Type tolerance):
+  tolerance_(tolerance),
+  ptset_(ptset)
+{
+  this->create();
+}
+
+// creates and populates the underlying data structure
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::create()
+{
+  // invalidate underlying data structure
+  if (search_tree_) {
+    search_tree_ = nullptr;
+  }
+
+  // search flags
   flags_ = 0;
   flags_ = flags_ |  Nabo::NearestNeighbourSearch<Type>::ALLOW_SELF_MATCH;
+
+  // check input pointset
   unsigned n = ptset_.size(), dim = 2;
-  if(n==0){
-    search_tree_ = nullptr;
+  if (n==0) {
     return false;
   }
+
+  // populate matrix form(2 x n) of the pointset
   M_.set_size(dim, n);
   for(unsigned i = 0; i<n; ++i){
     vgl_point_2d<Type> pi = ptset_[i];
     M_[0][i]=pi.x();
     M_[1][i]=pi.y();
   }
+
+  // create underlying data structure
   search_tree_.reset(Nabo::NearestNeighbourSearch<Type>::createKDTreeLinearHeap(M_, dim));
   return true;
 }
 
-
+// return validity of underlying data structure
 template <class Type>
-bvgl_k_nearest_neighbors_2d<Type>::bvgl_k_nearest_neighbors_2d(std::vector<vgl_point_2d<Type>> const& ptset, Type tolerance):
-tolerance_(tolerance),
-ptset_(ptset)
+bool bvgl_k_nearest_neighbors_2d<Type>::is_valid() const
 {
-  create();
-}
-
-
-template <class Type>
-bool bvgl_k_nearest_neighbors_2d<Type>::knn_indices(vgl_point_2d<Type> const& p, unsigned k, vnl_vector<int> &indices) const
-{
-  indices.set_size(k);
-  vnl_vector<Type> q(2), dists2(k);
-  q[0]=p.x();
-  q[1]=p.y();
-  if(!search_tree_) {
-    return false;
-  }
-  search_tree_->knn(q, indices, dists2, k, tolerance_, flags_);
-  if(dists2[k-1] == std::numeric_limits<Type>::infinity()||indices[k-1]<0) {
-    return false;
-  }
-  return true;
-}
-
-
-template <class Type>
-bool bvgl_k_nearest_neighbors_2d<Type>::closest_index(vgl_point_2d<Type> const& p, unsigned& index) const{
-  unsigned k = 1;
-  vnl_vector<int> indices(k);
-  vnl_vector<Type> q(2), dists2(k);
-  q[0]=p.x();
-  q[1]=p.y();
   if(!search_tree_)
     return false;
-  search_tree_->knn(q, indices,dists2, k, tolerance_, flags_);
-  if(dists2[0] == std::numeric_limits<Type>::infinity()||indices[0]<0)
+  else
+    return true;
+}
+
+// return single closest index
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::closest_index(
+    vgl_point_2d<Type> const& p,
+    unsigned& ci
+    ) const
+{
+  vgl_point_2d<Type> cp;
+  return this->closest_util(p, cp, ci);
+}
+
+// return single closest point
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::closest_point(
+    vgl_point_2d<Type> const& p,
+    vgl_point_2d<Type>& cp
+    ) const
+{
+  unsigned ci = 0;
+  return this->closest_util(p, cp, ci);
+}
+
+// return neighbor indices only
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::knn_indices(
+    vgl_point_2d<Type> const& p,
+    unsigned k,
+    std::vector<unsigned> &neighbor_indices,
+    Type max_dist
+    ) const
+{
+  std::vector<vgl_point_2d<Type>> neighbor_locs;
+  return this->knn_util(p, k, neighbor_locs, neighbor_indices, max_dist);
+}
+
+// return neighbor locations only
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::knn(
+    vgl_point_2d<Type> const& p,
+    unsigned k,
+    std::vector<vgl_point_2d<Type>>& neighbor_locs,
+    Type max_dist
+    ) const
+{
+  std::vector<unsigned> neighbor_indices;
+  return this->knn_util(p, k, neighbor_locs, neighbor_indices, max_dist);
+}
+
+// return neighbor locations & indices
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::knn(
+    vgl_point_2d<Type> const& p,
+    unsigned k,
+    std::vector<vgl_point_2d<Type>>& neighbor_locs,
+    std::vector<unsigned>& neighbor_indices,
+    Type max_dist
+    ) const
+{
+  return this->knn_util(p, k, neighbor_locs, neighbor_indices, max_dist);
+}
+
+
+// "closest" utility function - discover closest neighbor
+template <class Type>
+bool bvgl_k_nearest_neighbors_2d<Type>::closest_util(
+    vgl_point_2d<Type> const& p,
+    vgl_point_2d<Type>& cp,
+    unsigned& ci
+    ) const
+{
+  std::vector<unsigned> neighbor_indices;
+  std::vector<vgl_point_2d<Type>> neighbor_locs;
+  if (!this->knn_util(p, 1, neighbor_locs, neighbor_indices))
     return false;
-  index = static_cast<unsigned>(indices[0]);
+
+  cp = neighbor_locs[0];
+  ci = neighbor_indices[0];
   return true;
 }
 
 
+// main utility function - discover "k" nearest neighbors
+// to point p within max_dist radius; return locations &indices
 template <class Type>
-bool bvgl_k_nearest_neighbors_2d<Type>::closest_point(vgl_point_2d<Type> const& p, vgl_point_2d<Type>& cp) const{
-  unsigned index=0;
-  if(!this->closest_index(p, index))
+bool bvgl_k_nearest_neighbors_2d<Type>::knn_util(
+    vgl_point_2d<Type> const& p,
+    unsigned k,
+    std::vector<vgl_point_2d<Type>>& neighbor_locs,
+    std::vector<unsigned>& neighbor_indices,
+    Type max_dist
+    ) const
+{
+  // clear output
+  neighbor_indices.clear();
+  neighbor_locs.clear();
+
+  // check search tree validity
+  if(!this->is_valid()) {
     return false;
-  cp = ptset_[index];
-  return true;
-}
+  }
 
-
-template <class Type>
-bool bvgl_k_nearest_neighbors_2d<Type>::knn(vgl_point_2d<Type> const& p, unsigned k, std::vector<vgl_point_2d<Type>>& neighbors) const{
-  vnl_vector<int> indices(k);
-  return knn(p, k, neighbors, indices);
-}
-
-
-template <class Type>
-inline bool bvgl_k_nearest_neighbors_2d<Type>::knn(vgl_point_2d<Type> const& p, unsigned k, std::vector<vgl_point_2d<Type>>& neighbors, vnl_vector<int> &indices) const {
-  neighbors.clear();
+  // variable init
   vnl_vector<Type> q(2), dists2(k);
+  vnl_vector<int> indices(k);
   q[0]=p.x();
   q[1]=p.y();
-  if(!search_tree_) {
-    return false;
-  }
-  search_tree_->knn(q, indices, dists2, k, tolerance_, flags_);
-  for(unsigned i = 0; i<k; ++i){
-    if(dists2[i] == std::numeric_limits<Type>::infinity()||indices[i]<0) {
-      return false;
+
+  // search
+  search_tree_->knn(q, indices, dists2, k, tolerance_, flags_, max_dist);
+
+  // gather output
+  for (unsigned i = 0; i < k; ++i) {
+
+    // infinite distance or invalid index == no more neighbors found
+    // if max_dist is finite, fewer than k neighbors is fine
+    // if max_dist is infinite, fewer than k neighbors is unexpected
+    if(!std::isfinite(dists2[i]) || indices[i]<0) {
+      if (std::isfinite(max_dist)) {
+        break;
+      } else {
+        return false;
+      }
     }
-    unsigned indx = static_cast<unsigned>(indices[i]);
-    neighbors.push_back(ptset_[indx]);
+
+    // add valid index to list
+    auto index = static_cast<unsigned>(indices[i]);
+    neighbor_locs.push_back(ptset_[index]);
+    neighbor_indices.push_back(index);
   }
+
+  // success
   return true;
 }
+
 
 #endif // bvgl_k_nearest_neighbors_2d_h_

--- a/contrib/brl/bbas/bvgl/tests/test_k_nearest_neighbors.cxx
+++ b/contrib/brl/bbas/bvgl/tests/test_k_nearest_neighbors.cxx
@@ -101,6 +101,8 @@ static void test_k_nearest_neighbors_3d()
 
 static void test_k_nearest_neighbors_2d()
 {
+  bool good = true;
+
   vgl_point_2d<double> p0(1.5, 3.0);
   vgl_point_2d<double> p1(4.0, 0.0);
   vgl_point_2d<double> p2(-3.0, -2.0);
@@ -109,10 +111,15 @@ static void test_k_nearest_neighbors_2d()
   std::vector<vgl_point_2d<double>> ptset {p0, p1, p2, p3, p4};
 
   bvgl_k_nearest_neighbors_2d<double> knn2d(ptset);
+  good = knn2d.is_valid();
+  TEST("knn2d valid", good, true);
+  if (!good) {
+    return;
+  }
 
   unsigned index=0;
   vgl_point_2d<double> q1(0.5, 0.5);
-  bool good = knn2d.closest_index(q1, index);
+  good = knn2d.closest_index(q1, index);
   TEST("closest_index success", good, true);
   TEST("closest_index correct index", index, 3);
 


### PR DESCRIPTION
## ENH: `bvgl_k_nearest_neighbors_2d`
Refactor `bvgl_k_nearest_neighbors_2d` to include `max_dist` parameter (in the bnano library, referred to as `max_radius`).  
- If `max_dist` is infinite, functionality is unchanged.
- If `max_dist` is specified as a finite number, the knn function will return at most k nearest neighbors within the specified distance of the interpolation point.

Also includes update where this function is `bvgl_k_nearest_neighbors_2d`, specifically the associated test and `bpgl_gridding`.

## COMP: `bpgl_3d_from_disparity`
avoid depreciation warning regarding implicit cast conversion in `vnl_matrix_inverse`

```
/vxl/contrib/brl/bbas/bpgl/algo/bpgl_3d_from_disparity.hxx: In instantiation of 'vil_image_view<T> bpgl_3d_from_disparity(const vpgl_affine_camera<double>&, const vpgl_affine_camera<double>&, const vil_image_view<T>&) [with T = float]':
/vxl/contrib/brl/bbas/bpgl/algo/Templates/bpgl_3d_from_disparity+float-.cxx:3:1:   required from here
/vxl/contrib/brl/bbas/bpgl/algo/bpgl_3d_from_disparity.hxx:25:36: warning: 'vnl_matrix_fixed<T, num_rows, num_cols>::operator const vnl_matrix_ref<T>() const [with T = double; unsigned int num_rows = 4u; unsigned int num_cols = 3u]' is deprecated: Implicit cast conversion is dangerous.
USE: .as_vector() or .as_ref() member function for clarity. [-Wdeprecated-declarations]
```

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
