### PR TITLE
ENH (contrib): bpgl_gridding

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_gridding.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_gridding.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <numeric>
 #include <bvgl/bvgl_k_nearest_neighbors_2d.h>
 #include <vnl/vnl_numeric_traits.h>
 #include <vnl/algo/vnl_matrix_inverse.h>
@@ -23,27 +24,48 @@
 namespace bpgl_gridding
 {
 
+
+//: Inverse distance interpolation class
+// invalid_val: Value to return when interpolation is not appropriate
+// dist_eps: The smallest meaningful distance of input points. Must be > 0.
 template<class T, class DATA_T>
 class inverse_distance_interp
 {
-public:
-  inverse_distance_interp( T max_dist=vnl_numeric_traits<T>::maxval,
-                           DATA_T invalid_val=DATA_T(NAN) )
-    : max_dist_(max_dist), invalid_val_(invalid_val)
+ public:
+
+  // constructors
+  inverse_distance_interp() = default;
+
+  inverse_distance_interp(
+      DATA_T invalid_val,
+      T dist_eps) :
+    invalid_val_(invalid_val),
+    dist_eps_(dist_eps)
   {}
-  DATA_T operator() ( vgl_point_2d<T> loc,
-                      std::vector<vgl_point_2d<T>> const& neighbor_locs,
-                      std::vector<DATA_T> const& neighbor_vals ) const
+
+  // accessors
+  DATA_T invalid_val() const { return invalid_val_; }
+  void invalid_val(DATA_T x) { invalid_val_ = x; }
+
+  T dist_eps() const { return dist_eps_; }
+  void dist_eps(T x) { dist_eps_ = x; }
+
+  // interpolation operator
+  DATA_T operator() (
+      vgl_point_2d<T> interp_loc,
+      std::vector<vgl_point_2d<T> > const& neighbor_locs,
+      std::vector<DATA_T> const& neighbor_vals,
+      T max_dist = vnl_numeric_traits<T>::maxval
+      ) const
   {
     T weight_sum(0);
     T val_sum(0);
-    const T eps(1e-6);
     const unsigned num_neighbors = neighbor_locs.size();
     for (unsigned i=0; i<num_neighbors; ++i) {
-      T dist = (neighbor_locs[i] - loc).length();
-      if (dist <= max_dist_) {
-        if (dist < eps) {
-          dist = eps;
+      T dist = (neighbor_locs[i] - interp_loc).length();
+      if (dist <= max_dist) {
+        if (dist < this->dist_eps_) {
+          dist = this->dist_eps_;
         }
         T weight = 1.0 / dist;
         weight_sum += weight;
@@ -51,86 +73,209 @@ public:
       }
     }
     if (weight_sum == T(0)) {
-      return invalid_val_;
+      return this->invalid_val_;
     }
     return val_sum / weight_sum;
   }
-private:
-  T max_dist_;
-  DATA_T invalid_val_;
+
+ private:
+
+  // parameters with defaults
+  DATA_T invalid_val_ = DATA_T(NAN);
+  T dist_eps_ = 1e-5;
+
 };
 
 
+//: Linear interpolation class
+// invalid_val: Value to return when interpolation is not appropriate
+// dist_eps: The smallest meaningful distance of input points. Must be > 0.
+// dist_iexp: neighbor weight is proportional to (1/dist)^dist_iexp
+// regularization_lambda: Larger regularization values will bias the solution
+//    towards "flatter" functions.  Very large values will result in weighted
+//    averages of neighbor values.
+// rcond_thresh: Threshold for inverse matrix conditioning. Must be > 0
+// relative_interp: interpolation relative to neighbor centroids
+//
+// Note: internals are represented at double precision to ensure
+// accuracy of the final result.  Only on output is the resulting
+// interpolated value cast back to DATA_T
 template<class T, class DATA_T>
 class linear_interp
 {
-public:
-  linear_interp( T max_dist=vnl_numeric_traits<T>::maxval,
-                 DATA_T invalid_val=DATA_T(NAN) )
-    : max_dist_(max_dist), invalid_val_(invalid_val)
+ public:
+
+  // constructors
+  linear_interp() = default;
+
+  linear_interp(
+      DATA_T invalid_val,
+      T dist_eps) :
+    invalid_val_(invalid_val),
+    dist_eps_(dist_eps)
   {}
-  DATA_T operator() ( vgl_point_2d<T> loc,
-                      std::vector<vgl_point_2d<T>> const& neighbor_locs,
-                      std::vector<DATA_T> const& neighbor_vals ) const
+
+  // accessors
+  DATA_T invalid_val() const { return invalid_val_; }
+  void invalid_val(DATA_T x) { invalid_val_ = x; }
+
+  T dist_eps() const { return dist_eps_; }
+  void dist_eps(T x) { dist_eps_ = x; }
+
+  int dist_iexp() const { return dist_iexp_; }
+  void dist_iexp(int x) { dist_iexp_ = x; }
+
+  double regularization_lambda() const { return regularization_lambda_; }
+  void regularization_lambda(double x) { regularization_lambda_ = x; }
+
+  double rcond_thresh() const { return rcond_thresh_; }
+  void rcond_thresh(double x) { rcond_thresh_ = x; }
+
+  bool relative_interp() const { return relative_interp_; }
+  void relative_interp(bool x) { relative_interp_ = x; }
+
+  // interpolation operator
+  DATA_T operator() (
+      vgl_point_2d<T> interp_loc,
+      std::vector<vgl_point_2d<T> > const& neighbor_locs,
+      std::vector<DATA_T> const& neighbor_vals,
+      T max_dist = vnl_numeric_traits<T>::maxval
+      ) const
   {
-    T weight_sum(0);
-    T val_sum(0);
-    const T eps(1e-6);
     const unsigned num_neighbors = neighbor_locs.size();
-    vnl_matrix<T> A(num_neighbors,3);
-    vnl_vector<T> b(num_neighbors);
+
+    // vectors of valid neighbor data
+    std::vector<double> X,Y,V,W;
     int num_valid_neighbors = 0;
+
     for (unsigned i=0; i<num_neighbors; ++i) {
-      vgl_point_2d<T> const& neighbor_loc(neighbor_locs[i]);
-      T dist = (neighbor_locs[i] - loc).length();
-      T weight = 0;
-      if (dist <= max_dist_) {
-        if (dist < eps) {
-          dist = eps;
+      T dist = (neighbor_locs[i] - interp_loc).length();
+      if (dist <= max_dist) {
+        if (dist < this->dist_eps_) {
+          dist = this->dist_eps_;
         }
-        weight = 1.0 / dist;
-        ++num_valid_neighbors;
+
+        // neighbor weight
+        double dist_d = static_cast<double>(dist);
+        double weight = 1.0 / std::pow(dist_d, dist_iexp_);
+
+        // save to internal storage
+        X.emplace_back(static_cast<double>(neighbor_locs[i].x()));
+        Y.emplace_back(static_cast<double>(neighbor_locs[i].y()));
+        V.emplace_back(static_cast<double>(neighbor_vals[i]));
+        W.emplace_back(weight);
+        num_valid_neighbors++;
       }
-      A[i][0] = weight * neighbor_loc.x();
-      A[i][1] = weight * neighbor_loc.y();
-      A[i][2] = weight;
-      b[i] = weight * neighbor_vals[i];
     }
+
+    // check for sufficent neighbors
     if (num_valid_neighbors < 3) {
-      return invalid_val_;
+      // std::cerr << "insufficent neighbors" << std::endl;
+      return this->invalid_val_;
     }
+
+    // weight normalization
+    double weight_norm = std::accumulate(W.begin(), W.end(), 0.0);
+    for (auto& w : W) {
+      w /= weight_norm;
+    }
+
+    // absolute interpolation: origin at 0
+    // relative interpolation: origin at neighbor loc/val centroid
+    double x_origin = 0, y_origin = 0, v_origin = 0;
+    if (relative_interp_) {
+      double N = static_cast<double>(num_valid_neighbors);
+      x_origin = std::accumulate(X.begin(), X.end(), 0.0) / N;
+      y_origin = std::accumulate(Y.begin(), Y.end(), 0.0) / N;
+      v_origin = std::accumulate(V.begin(), V.end(), 0.0) / N;
+    }
+
+    // system matrices
+    vnl_matrix<double> A(num_valid_neighbors,3);
+    vnl_vector<double> b(num_valid_neighbors);
+    for (unsigned i=0; i<num_valid_neighbors; ++i) {
+      A[i][0] = W[i] * (X[i] - x_origin);
+      A[i][1] = W[i] * (Y[i] - y_origin);
+      A[i][2] = W[i];
+      b[i] = W[i] * (V[i] - v_origin);
+    }
+
     // employ Tikhonov Regularization to cope with degenerate point configurations
-    vnl_matrix<T> R(3, 3, 0);
-    const T reg_const = 1e-3;
+    // f = inv(AT * A + lambda * I) * AT * b
+    vnl_matrix<double> lambdaI(3, 3, 0);
     for (int d=0; d<3; ++d) {
-      R[d][d] = reg_const;
+      lambdaI[d][d] = regularization_lambda_;
     }
-    vnl_matrix<T> A_transpose = A.transpose();
-    vnl_vector<T> f = vnl_matrix_inverse<T>(A_transpose*A + R.transpose()*R)*A_transpose * b;
-    DATA_T value = f[0]*loc.x() + f[1]*loc.y() + f[2];
-    return value;
+
+    // matrix processing
+    vnl_matrix<double> At = A.transpose();
+    vnl_matrix<double> AtA_reg = At*A + lambdaI;
+    vnl_matrix_inverse<double> inv_AtA_reg(AtA_reg.as_ref());
+
+    // check reciprocal condition number
+    auto rcond = inv_AtA_reg.well_condition();
+    if (rcond < rcond_thresh_) {
+      std::cerr << "matrix has poor condition (" << rcond << ")\n" << std::endl;
+      return this->invalid_val_;
+    }
+
+    // final solution
+    vnl_vector<double> f = inv_AtA_reg.as_matrix() * At * b;
+    double x = static_cast<double>(interp_loc.x());
+    double y = static_cast<double>(interp_loc.y());
+    double value = f[0]*(x - x_origin) + f[1]*(y - y_origin) + f[2] + v_origin;
+
+    // cast as data type
+    DATA_T value_return = static_cast<DATA_T>(value);
+    return value_return;
   }
-private:
-  T max_dist_;
-  DATA_T invalid_val_;
+
+ private:
+
+  // parameters with defaults
+  DATA_T invalid_val_ = DATA_T(NAN);
+  T dist_eps_ = 1e-5;
+  int dist_iexp_ = 2;
+  double regularization_lambda_ = 1e-3;
+  double rcond_thresh_ = 1e-8;
+  bool relative_interp_ = true;
+
 };
 
 
 
 template<class T, class DATA_T, class INTERP_T>
 vil_image_view<DATA_T>
-grid_data_2d(std::vector<vgl_point_2d<T>> const& data_in_loc,
-             std::vector<DATA_T> const& data_in,
-             vgl_point_2d<T> out_upper_left,
-             size_t out_ni, size_t out_nj,
-             T step_size,
-             INTERP_T &interp_fun,
-             unsigned num_nearest_neighbors,
-             double out_theta_radians=0.0)
+grid_data_2d(
+    INTERP_T const& interp_fun,
+    std::vector<vgl_point_2d<T>> const& data_in_loc,
+    std::vector<DATA_T> const& data_in,
+    vgl_point_2d<T> out_upper_left,
+    size_t out_ni,
+    size_t out_nj,
+    T step_size,
+    unsigned min_neighbors = 3,
+    unsigned max_neighbors = 5,
+    T max_dist = vnl_numeric_traits<T>::maxval,
+    double out_theta_radians = 0.0)
 {
+  // total number of points
+  size_t npts = data_in_loc.size();
+
   // validate input
-  if (data_in_loc.size() != data_in.size()) {
+  if (npts != data_in.size()) {
     throw std::runtime_error("Input location and data arrays not equal size");
+  }
+
+  // validate min/max neighbor range
+  if (size_t(min_neighbors) > npts) {
+    throw std::runtime_error("Fewer points than minimum number of neighbors");
+  }
+  if (size_t(max_neighbors) > npts) {
+    max_neighbors = unsigned(npts);
+  }
+  if (min_neighbors > max_neighbors) {
+    throw std::runtime_error("Invalid neighbor range");
   }
 
   // create knn instance
@@ -148,42 +293,52 @@ grid_data_2d(std::vector<vgl_point_2d<T>> const& data_in_loc,
     for (unsigned i=0; i<out_ni; ++i) {
 
       // interpolation point
-      vgl_point_2d<T> loc = out_upper_left +
+      vgl_point_2d<T> loc = out_upper_left
                           + i*step_size*i_vec
                           + j*step_size*j_vec;
 
-      // nearest neighbors
+      // retrieve at most max_neighbors within max_dist of interpolation point
       std::vector<vgl_point_2d<T> > neighbor_locs;
       std::vector<unsigned> neighbor_indices;
-      if (!knn.knn(loc, num_nearest_neighbors, neighbor_locs, neighbor_indices)) {
+      if (!knn.knn(loc, max_neighbors, neighbor_locs, neighbor_indices, max_dist)) {
         throw std::runtime_error("KNN failed to return neighbors");
+      }
+
+      // check for at least min_neighbors
+      if (neighbor_indices.size() < min_neighbors) {
+        gridded(i,j) = interp_fun.invalid_val();
         continue;
       }
 
       // neighbor values for interpolation
       std::vector<DATA_T> neighbor_vals;
-      for (auto index : neighbor_indices) {
-        neighbor_vals.push_back(data_in[index]);
+      for (auto nidx : neighbor_indices) {
+        neighbor_vals.push_back(data_in[nidx]);
       }
 
-      // interpolate
-      T val = interp_fun(loc, neighbor_locs, neighbor_vals);
+      // interpolate via non-virtual method
+      T val = interp_fun(loc, neighbor_locs, neighbor_vals, max_dist);
       gridded(i,j) = val;
     }
   }
   return gridded;
 }
 
- template<class pointT, class pixelT>
-void  pointset_from_grid(vil_image_view<pixelT> const& grid, vgl_point_2d<pointT> const& upper_left, pointT step_size,
-                         std::vector<vgl_point_3d<pointT> >& ptset, double out_theta_radians = 0.0){
+
+template<class pointT, class pixelT>
+void pointset_from_grid(vil_image_view<pixelT> const& grid,
+                        vgl_point_2d<pointT> const& upper_left,
+                        pointT step_size,
+                        std::vector<vgl_point_3d<pointT> >& ptset,
+                        double out_theta_radians = 0.0)
+{
   ptset.clear();
   vgl_vector_2d<pointT> i_vec(std::cos(out_theta_radians), std::sin(out_theta_radians));
   vgl_vector_2d<pointT> j_vec(std::sin(out_theta_radians), -std::cos(out_theta_radians));
   pointT xul = upper_left.x(), yul = upper_left.y();
   size_t ni = grid.ni(), nj = grid.nj();
-  for(size_t j = 0; j<nj; ++j)
-    for(size_t i = 0; i<ni; ++i){
+  for (size_t j = 0; j<nj; ++j) {
+    for (size_t i = 0; i<ni; ++i) {
       vgl_point_2d<pixelT> loc = upper_left +
         i*step_size*i_vec + j*step_size*j_vec;
       pointT z = grid(i,j);
@@ -191,6 +346,7 @@ void  pointset_from_grid(vil_image_view<pixelT> const& grid, vgl_point_2d<pointT
         continue;
       ptset.emplace_back(loc.x(), loc.y(), z);
     }
+  }
 }
 
 

--- a/contrib/brl/bbas/bpgl/algo/bpgl_heightmap_from_disparity.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_heightmap_from_disparity.h
@@ -12,7 +12,6 @@
 #include <vgl/vgl_pointset_3d.h>
 #include <vil/vil_image_view.h>
 
-
 /**
  * Main convenience function
  * Given cameras for a stereo pair and a disparity map, return a 3-plane (x,y,z)
@@ -46,33 +45,28 @@ class bpgl_heightmap
     bpgl_heightmap(
         vgl_box_3d<T> heightmap_bounds,
         T ground_sample_distance) :
-      _heightmap_bounds(heightmap_bounds),
-      _ground_sample_distance(ground_sample_distance)
+      heightmap_bounds_(heightmap_bounds),
+      ground_sample_distance_(ground_sample_distance)
     {}
 
     //: destructor
     ~bpgl_heightmap() = default;
 
     // Accessors
-    T ground_sample_distance() const { return _ground_sample_distance; }
-    void set_ground_sample_distance(T ground_sample_distance) {
-      _ground_sample_distance = ground_sample_distance;
-    }
+    T ground_sample_distance() const { return ground_sample_distance_; }
+    void ground_sample_distance(T x) { ground_sample_distance_ = x; }
 
-    vgl_box_3d<T> heightmap_bounds() const { return _heightmap_bounds; }
-    void set_heightmap_bounds(vgl_box_3d<T> heightmap_bounds) {
-      _heightmap_bounds = heightmap_bounds;
-    }
+    vgl_box_3d<T> heightmap_bounds() const { return heightmap_bounds_; }
+    void heightmap_bounds(vgl_box_3d<T> x) { heightmap_bounds_ = x; }
 
-    T neighbor_dist_factor() const { return _neighbor_dist_factor; }
-    void set_neighbor_dist_factor(T neighbor_dist_factor) {
-      _neighbor_dist_factor = neighbor_dist_factor;
-    }
+    T neighbor_dist_factor() const { return neighbor_dist_factor_; }
+    void neighbor_dist_factor(T x) { neighbor_dist_factor_ = x; }
 
-    unsigned num_neighbors() const { return _num_neighbors; }
-    void set_num_neighbors(unsigned num_neighbors) {
-      _num_neighbors = num_neighbors;
-    }
+    unsigned min_neighbors() const { return min_neighbors_; }
+    void min_neighbors(unsigned x) { min_neighbors_ = x; }
+
+    unsigned max_neighbors() const { return max_neighbors_; }
+    void max_neighbors(unsigned x) { max_neighbors_ = x; }
 
     //: compute pointset from triangulated image
     void pointset_from_tri(
@@ -127,13 +121,15 @@ class bpgl_heightmap
         bool ignore_scalar);
 
     // parameters
-    vgl_box_3d<T> _heightmap_bounds;
-    T _ground_sample_distance;
+    vgl_box_3d<T> heightmap_bounds_;
+    T ground_sample_distance_;
 
-    // gridding parameters
-    T _neighbor_dist_factor = 3.0;
-    unsigned _num_neighbors = 3;
-
+    // pointset->heightmap gridding paramters:
+    // expected number of neighbors (between min/max neighbors) within some distance
+    // (neighbor_dist_factor_ * ground_sample_distance_) of each heightmap pixel
+    unsigned min_neighbors_ = 3;
+    unsigned max_neighbors_ = 5;
+    T neighbor_dist_factor_ = 3.0;
 };
 
 #endif

--- a/contrib/brl/bbas/bpgl/algo/tests/test_gridding.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_gridding.cxx
@@ -34,30 +34,24 @@ void test_simple()
   vgl_point_2d<T> upper_left(0.0f, 0.0f);
   size_t ni = 8, nj = 8;
   T step_size = 1.0;
-  unsigned num_neighbors = 4;
-  T maxdist = 15.0f;
+  unsigned min_neighbors = 3;
+  unsigned max_neighbors = 5;
+  T max_dist = 15.0f;
 
-  bpgl_gridding::linear_interp<T, float> interp_fun(maxdist, NAN);
+  bpgl_gridding::linear_interp<T, float> interp_fun;
 
   vil_image_view<float> gridded =
-    bpgl_gridding::grid_data_2d(sample_locs, sample_vals,
+    bpgl_gridding::grid_data_2d(interp_fun, sample_locs, sample_vals,
                                 upper_left, ni, nj, step_size,
-                                interp_fun,
-                                num_neighbors);
-  bool print_grid = false;
-  if (print_grid) {
-    for (int j=0; j<nj; ++j) {
-      for (int i=0; i<ni; ++i) {
-        std::cout << std::fixed << std::setprecision(3) << gridded(i,j) << " ";
-      }
-      std::cout << std::endl;
-    }
-  }
+                                min_neighbors, max_neighbors, max_dist);
 
   bool all_good = true;
   for (int j=0; j<nj; ++j) {
     for (int i=0; i<ni; ++i) {
       // "truth" is f(x,y) = x
+      std::cout << "i,j: " << i << "," << j << "  "
+                << "expected: " << i << "  "
+                << "f(i,j): " << gridded(i,j) << "\n";
       double err = gridded(i,j) - i;
       all_good &= std::fabs(err) < 0.25;
     }
@@ -87,30 +81,24 @@ void test_degenerate()
   vgl_point_2d<T> upper_left(0.0f, 0.0f);
   size_t ni = 6, nj = 6;
   T step_size = 1.0;
-  unsigned num_neighbors = 3;
-  T maxdist = 15.0f;
+  unsigned min_neighbors = 3;
+  unsigned max_neighbors = 5;
+  T max_dist = 15.0f;
 
-  bpgl_gridding::linear_interp<T, float> interp_fun(maxdist, NAN);
+  bpgl_gridding::linear_interp<T, float> interp_fun;
 
   vil_image_view<float> gridded =
-    bpgl_gridding::grid_data_2d(sample_locs, sample_vals,
+    bpgl_gridding::grid_data_2d(interp_fun, sample_locs, sample_vals,
                                 upper_left, ni, nj, step_size,
-                                interp_fun,
-                                num_neighbors);
-  bool print_grid = false;
-  if (print_grid) {
-    for (int j=0; j<nj; ++j) {
-      for (int i=0; i<ni; ++i) {
-        std::cout << std::fixed << std::setprecision(3) << gridded(i,j) << " ";
-      }
-      std::cout << std::endl;
-    }
-  }
+                                min_neighbors, max_neighbors, max_dist);
 
   bool all_good = true;
   for (int j=0; j<nj; ++j) {
     for (int i=0; i<ni; ++i) {
       // "truth" is f(x,y) = x
+      std::cout << "i,j: " << i << "," << j << "  "
+                << "expected: " << i << "  "
+                << "f(i,j): " << gridded(i,j) << "\n";
       double err = gridded(i,j) - i;
       all_good &= std::fabs(err) < 0.25;
     }
@@ -118,8 +106,9 @@ void test_degenerate()
   TEST("gridded values correct", all_good, true);
 }
 
+
 void test_interp_real()
-{ 
+{
   // A test case derived from a real example giving unexpected results
   std::vector<vgl_point_2d<double>> ctrl_pts;
   ctrl_pts.emplace_back(9.35039, 151.517);
@@ -128,19 +117,82 @@ void test_interp_real()
 
   std::vector<double> values = { 47.7940, 46.3976, 47.7940 };
 
- bpgl_gridding::linear_interp<double, double> interp;
+  bpgl_gridding::linear_interp<double, double> interp_fun;
 
   vgl_point_2d<double> test_point(9, 151.999);
-  double value = interp(test_point, ctrl_pts, values);
-
+  double value = interp_fun(test_point, ctrl_pts, values);
   TEST_NEAR("interpolated value in correct range", value, 47.0, 1.0);
 }
+
+
+void test_interp_real_origin()
+{
+  // A test case derived from a real example giving unexpected results
+  // interpolation points centered near origin
+  std::vector<vgl_point_2d<double>> ctrl_pts;
+  ctrl_pts.emplace_back(1.35039, 0.517);
+  ctrl_pts.emplace_back(0.93042, 0.390);
+  ctrl_pts.emplace_back(0.57767, 0.285);
+
+  std::vector<double> values = { 47.7940, 46.3976, 47.7940 };
+
+  bpgl_gridding::linear_interp<double, double> interp_fun;
+
+  vgl_point_2d<double> test_point(1, 0.999);
+  double value = interp_fun(test_point, ctrl_pts, values);
+  TEST_NEAR("interpolated value in correct range", value, 47.0, 1.0);
+}
+
+
+#ifndef BPGL_TIMING
+#define BPGL_TIMING 0
+#endif
+
+#if BPGL_TIMING
+#include <vul/vul_timer.h>
+
+void test_interp_timing(unsigned long num_iter)
+{
+  double value = 0.0;
+  vul_timer timer;
+
+  std::vector<vgl_point_2d<double>> ctrl_pts;
+  ctrl_pts.emplace_back(9.35039, 151.517);
+  ctrl_pts.emplace_back(8.93042, 151.390);
+  ctrl_pts.emplace_back(8.57767, 151.285);
+
+  std::vector<double> values = { 47.7940, 46.3976, 47.7940 };
+
+  bpgl_gridding::linear_interp<double, double> interp_fun;
+
+  vgl_point_2d<double> test_point(9, 151.999);
+
+  timer.mark();
+  for (unsigned i = 0; i < num_iter; i++)
+    value = interp_fun(test_point, ctrl_pts, values);
+  double operator_sec = timer.real() / 1000.0;
+
+  std::cout << "---Timing report---\n"
+            << "Interpolate " << ctrl_pts.size() << " points for " << num_iter << " iterations\n"
+            << "operator()\n"
+            << "  total time = " << operator_sec << " sec.\n"
+            << "  per-operation time = " << operator_sec / double(num_iter) << " sec.\n"
+            ;
+}
+#endif
+
 
 static void test_gridding()
 {
   test_simple();
   test_degenerate();
   test_interp_real();
+  test_interp_real_origin();
+
+  // timing report
+#if BPGL_TIMING
+  test_interp_timing(1000000);
+#endif
 }
 
 TESTMAIN(test_gridding);

--- a/contrib/brl/bbas/bpgl/algo/tests/test_heightmap_from_disparity.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_heightmap_from_disparity.cxx
@@ -71,7 +71,7 @@ static void test_heightmap_from_disparity_affine()
     for (int i=0; i<2; ++i) {
       std::cout << "i,j: " << i << "," << j << "  truth: " << hmap_truth(i,j) << "   pred: " << hmap_pred(i,j) << std::endl;
       double diff = hmap_pred(i,j) - hmap_truth(i,j);
-      all_good &= std::fabs(diff) < 1e-4;
+      all_good &= std::fabs(diff) < 1e-2; // i.e., accurate to a cm (0.01 meters)
     }
   }
   TEST("predicted heights match truth", all_good, true);


### PR DESCRIPTION
Refactor `bpgl_gridding` functionality for improved flexibility & test coverage.  This includes
- expected neighbor range (between min/max number of neighbors)
- max neighbor distance as gridding input (not as member of interp. class)
- linear_interp with double internals
- improve linear_interp against new test cases

Update `bpgl_heightmap_from_disparity` and `bsgm_prob_pairwise_dsm` accordingly

## PR Checklist
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
🚫 Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.

