### PR TITLE
BUG: fix failing vpgl/algo test

### DIFF
--- a/core/vpgl/algo/tests/test_fit_rational_cubic.cxx
+++ b/core/vpgl/algo/tests/test_fit_rational_cubic.cxx
@@ -84,7 +84,8 @@ static void project(const double x, const double y, const double z, double& u, d
 
 static void test_fit_rational_cubic()
 {
-  vnl_random rng;
+  // deterministic random generator
+  vnl_random rng(9667566);
 
   // Rational polynomial coefficients (RPCs)
   vnl_vector_fixed<double,20> neu_u, den_u, neu_v, den_v;


### PR DESCRIPTION
vpgl/algo fix failing `test_fit_rational_cubic` - use a fixed seed for deterministic random numbers and repeatable results.  

This should stop failures like travisci linked below due to randomness in the test.
https://travis-ci.org/vxl/vxl/jobs/607604654#L1060

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
🚫 Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
🚫 Makes design changes to existing vxl/core\* API that requires semantic versioning increase
🚫 Makes changes to the contributed directory API DOES NOT require semantic versioning increase
✔️ Adds tests and baseline comparison (quantitative).
🚫 Adds Documentation.
