### PR TITLE
BUG: Acal Intertile Solver

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.cxx
@@ -244,10 +244,10 @@ bool acal_intertile_graph_solver::solve_least_squares_problem() {
   if (gc_lsq.track_intersect_failed())
     return false;
 
-  vnl_levenberg_marquardt levmarq_ = construct_levmarq(gc_lsq);
+  vnl_levenberg_marquardt levmarq = construct_levmarq(gc_lsq);
   // Minimize the error and get the best intersection point
-  levmarq_.minimize(translations);
-  levmarq_.diagnose_outcome();
+  levmarq.minimize(translations);
+  levmarq.diagnose_outcome();
   gc_lsq.f(translations, residuals);// final set of residuals and translations
 
   size_t n_non_seed = trans_indx_to_cam_id_.size();
@@ -292,9 +292,9 @@ bool acal_intertile_graph_solver::solve_least_squares_problem() {
   if (gc_lsq2.track_intersect_failed())
     return false;
   // Minimize the projection errors
-  construct_levmarq(gc_lsq2);
-  levmarq_.minimize(translations);
-  levmarq_.diagnose_outcome();
+  vnl_levenberg_marquardt levmarq2 = construct_levmarq(gc_lsq2);
+  levmarq2.minimize(translations);
+  levmarq2.diagnose_outcome();
   gc_lsq2.f(translations, residuals);// final set of residuals and translations
   residual_cams = cam_residuals(residuals);
   unique_res_cams = find_minimum_residual_set(residual_cams, tile_indices);


### PR DESCRIPTION
We were re-using the same vnl_levenberg_marquardt object in the second pass of the solver. If cameras were filtered out from the first pass, this led to a different number of unknowns, and the solver would fail, leaving the translations to default to (0,0). Fixed this by properly constructing the new vnl_levenberg_marquardt object in the second pass.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
