### PR TITLE
BUG: fixed signed integer overflow by casting to unsigned long

### DIFF
--- a/core/vnl/vnl_drand48.cpp
+++ b/core/vnl/vnl_drand48.cpp
@@ -153,7 +153,9 @@ _dorand48(unsigned short xseed[3])
 					(unsigned long) _rand48_mult[1] * (unsigned long) xseed[0];
 	temp[1] = (unsigned short) accu;        /* middle 16 bits */
 	accu >>= sizeof(unsigned short) * 8;
-	accu += _rand48_mult[0] * xseed[2] + _rand48_mult[1] * xseed[1] + _rand48_mult[2] * xseed[0];
+	accu += (unsigned long)_rand48_mult[0] * (unsigned long)xseed[2] +
+					(unsigned long)_rand48_mult[1] * (unsigned long)xseed[1] +
+					(unsigned long)_rand48_mult[2] * (unsigned long)xseed[0];
 	xseed[0] = temp[0];
 	xseed[1] = temp[1];
 	xseed[2] = (unsigned short) accu;


### PR DESCRIPTION
UBSan found a signed integer overflow. Arithmetic with 6 unsigned shorts gets promoted to signed int, which can then overflow with big numbers. Cast to unsigned long, as in lines preceding, to force unsigned arithmetic, where overflow is well-defined.