### PR TITLE
Revert "COMP: Some compilers need both string.h & strings.h"

### DIFF
--- a/v3p/geotiff/cpl_serv.h
+++ b/v3p/geotiff/cpl_serv.h
@@ -41,9 +41,10 @@
 #ifdef HAVE_STRING_H
 #  include <string.h>
 #endif
-#if defined(HAVE_STRINGS_H)
+#if defined(HAVE_STRINGS_H) && !defined(HAVE_STRING_H)
 #  include <strings.h>
 #endif
+
 #ifdef HAVE_STDLIB_H
 #  include <stdlib.h>
 #endif
@@ -100,8 +101,15 @@
 #  define EQUALN(a,b,n)           (strnicmp(a,b,n)==0)
 #  define EQUAL(a,b)              (stricmp(a,b)==0)
 #else
-#  define EQUALN(a,b,n)           (strncasecmp(a,b,n)==0)
-#  define EQUAL(a,b)              (strcasecmp(a,b)==0)
+/*  https://stackoverflow.com/questions/3694723/error-c3861-strcasecmp-identifier-not-found-in-visual-studio-2008/26359433 */
+/* not #if defined(_WIN32) || defined(_WIN64) because we have strncasecmp in mingw */
+#  ifdef _MSC_VER
+#    define EQUALN(a,b,n)           (_strnicmp(a,b,n)==0)
+#    define EQUAL(a,b)              (_stricmp(a,b)==0)
+#  else
+#    define EQUALN(a,b,n)           (strncasecmp(a,b,n)==0)
+#    define EQUAL(a,b)              (strcasecmp(a,b)==0)
+#  endif
 #endif
 #endif
 


### PR DESCRIPTION
This reverts commit 901b41bb412ec18e12a7801a331a19e877b55ba3.

This resolves issue #734 of compilation failure, but
re-introduces a compiler warning about implicitly defined
function on some compilers.
