### PR TITLE
BUG: Windows fails with too large array size

### DIFF
--- a/core/vnl/algo/tests/test_symmetric_eigensystem.cxx
+++ b/core/vnl/algo/tests/test_symmetric_eigensystem.cxx
@@ -88,7 +88,7 @@ test_symmetric_eigensystem()
   }
 
   { // compare speed and values of specialised 3x3 version with nxn version
-    constexpr unsigned n = 40000;
+    constexpr unsigned n = 20000;
 
     double fixed_data[n][3];
     unsigned int fixed_time=0;


### PR DESCRIPTION
Segmentation fault caused by array being too large.
Making the array smaller avoids exception or
invalid instruction error on windows.
