### PR TITLE
COMP: Prefer const member functions

### DIFF
--- a/contrib/gel/gevd/gevd_edgel_regions.cxx
+++ b/contrib/gel/gevd/gevd_edgel_regions.cxx
@@ -148,12 +148,12 @@ void gevd_edgel_regions::print_intensity_data()
 //: The region array can be offset from the corner of the ROI.
 //    The following two methods transform from the ROI coordinate
 //    system to the region label array coordinate system
-unsigned int gevd_edgel_regions::X(unsigned int x)
+unsigned int gevd_edgel_regions::X(unsigned int x) const
 {
   return x-xo_;
 }
 
-unsigned int gevd_edgel_regions::Y(unsigned int y)
+unsigned int gevd_edgel_regions::Y(unsigned int y) const
 {
   return y-yo_;
 }
@@ -511,7 +511,7 @@ merge_equivalence(std::map<unsigned int, std::vector<unsigned int>* >& tab,
 //    The set of labels is searched to find a label larger than label, but
 //    not in the set, labels.
 bool gevd_edgel_regions::get_next_label(std::vector<unsigned int>* labels,
-                                        unsigned int& label)
+                                        unsigned int& label) const
 {
   unsigned int tmp = label+1;
   if (!labels)
@@ -890,7 +890,7 @@ bool gevd_edgel_regions::InitRegionArray(std::vector< vtol_edge_2d_sptr>& sg)
 //---------------------------------------------------------------
 //: Get code for a given label.
 //
-unsigned char gevd_edgel_regions::label_code(unsigned int label)
+unsigned char gevd_edgel_regions::label_code(unsigned int label) const
 {
   unsigned char result;
   if (label<min_region_label_)
@@ -1254,7 +1254,7 @@ static bool reg_edges_neq(gevd_region_edge* r1, gevd_region_edge* r2)
 // definition is at pixel granularity.  The edge collision causes a needed
 // edge to be superseded.
 void gevd_edgel_regions::print_edge_colis(unsigned int x, unsigned int y,
-                                          gevd_region_edge* r1, gevd_region_edge* r2)
+                                          gevd_region_edge* r1, gevd_region_edge* r2) const
 {
   if (reg_edges_neq(r1, r2))
     if (verbose_)
@@ -1269,7 +1269,7 @@ void gevd_edgel_regions::print_edge_colis(unsigned int x, unsigned int y,
 //    This routine tests this constraint.
 bool gevd_edgel_regions::
 corrupt_boundary(std::vector<vtol_edge_2d_sptr>& edges,
-                 std::vector<vtol_vertex_sptr>& bad_vertices)
+                 std::vector<vtol_vertex_sptr>& bad_vertices) const
 {
   bool bad = false;
   // Initialize Markers
@@ -1740,7 +1740,7 @@ void gevd_edgel_regions::ApplyRegionEquivalence()
 
 //-------------------------------------------------------------------
 //: Bounds check on region_label_array_
-bool gevd_edgel_regions::out_of_bounds(unsigned int x, unsigned int y)
+bool gevd_edgel_regions::out_of_bounds(unsigned int x, unsigned int y) const
 {
   bool out = x>(xend_-xo_)||y>(yend_-yo_);
   return out;

--- a/contrib/gel/gevd/gevd_edgel_regions.h
+++ b/contrib/gel/gevd/gevd_edgel_regions.h
@@ -105,7 +105,7 @@ class gevd_edgel_regions
   // Utilities
   bool GroupContainsEdges(std::vector<vtol_edge_2d_sptr>& sg);
   bool InitRegionArray(std::vector<vtol_edge_2d_sptr>& sg);
-  unsigned char label_code(unsigned int label);
+  unsigned char label_code(unsigned int label) const;
   bool add_to_forward(unsigned int key, unsigned int value);
   bool add_to_reverse(unsigned int key, unsigned int value);
   unsigned char EncodeNeighborhood(unsigned int ul, unsigned int ur,
@@ -113,7 +113,7 @@ class gevd_edgel_regions
   void UpdateConnectedNeighborhood(unsigned int x, unsigned int y);
   void AssignEdgeLabels(unsigned int x, unsigned int y);
   void ApplyRegionEquivalence();
-  bool out_of_bounds(unsigned int x, unsigned int y);
+  bool out_of_bounds(unsigned int x, unsigned int y) const;
   void insert_adjacency(unsigned int region, const vtol_edge_2d_sptr& e);
   void CollectEdges();
   void CollectFaceEdges();
@@ -121,8 +121,8 @@ class gevd_edgel_regions
   void AccumulateMeans();
   void AccumulateRegionData();
   void InsertFaceData();
-  unsigned int X(unsigned int x);
-  unsigned int Y(unsigned int y);
+  unsigned int X(unsigned int x) const;
+  unsigned int Y(unsigned int y) const;
   unsigned int Xf(float x);
   unsigned int Yf(float y);
   bool insert_edgel(float pre_x, float pre_y, float x, float y,
@@ -132,11 +132,11 @@ class gevd_edgel_regions
                          unsigned int cur_label,
                          unsigned int label);
   bool get_next_label(std::vector<unsigned int>* labels,
-                      unsigned int& label);
+                      unsigned int& label) const;
   void print_edge_colis(unsigned int x, unsigned int y,
-                        gevd_region_edge* r1, gevd_region_edge* r2);
+                        gevd_region_edge* r1, gevd_region_edge* r2) const;
   bool corrupt_boundary(std::vector<vtol_edge_2d_sptr>& edges,
-                        std::vector<vtol_vertex_sptr>& bad_verts);
+                        std::vector<vtol_vertex_sptr>& bad_verts) const;
   bool remove_hairs(std::vector<vtol_edge_2d_sptr>& edges);
   bool connect_ends(std::vector<vtol_edge_2d_sptr>& edges,
                     std::vector<vtol_vertex_sptr>& bad_verts);

--- a/contrib/gel/gevd/gevd_fold.cxx
+++ b/contrib/gel/gevd/gevd_fold.cxx
@@ -275,7 +275,7 @@ int
 gevd_fold::RecoverJunctions(const gevd_bufferxy& image,
                             gevd_bufferxy& contour, gevd_bufferxy& direction,
                             gevd_bufferxy& locationx, gevd_bufferxy& locationy,
-                            int*& junctionx, int*& junctiony)
+                            int*& junctionx, int*& junctiony) const
 {
 #if defined(DEBUG)
   vul_timer t;

--- a/contrib/gel/gevd/gevd_fold.h
+++ b/contrib/gel/gevd/gevd_fold.h
@@ -132,7 +132,7 @@ class gevd_fold
                        gevd_bufferxy& edgels, //!< from end points of contours
                        gevd_bufferxy& direction,
                        gevd_bufferxy& locationx, gevd_bufferxy& locationy,
-                       int*& junctionx, int*& junctiony);
+                       int*& junctionx, int*& junctiony) const;
 
   //: query stored/estimated noise sigma
   // Return the standard deviation of raw noise, in the original image,

--- a/contrib/gel/gevd/gevd_step.cxx
+++ b/contrib/gel/gevd/gevd_step.cxx
@@ -358,7 +358,7 @@ int
 gevd_step::RecoverJunctions(const gevd_bufferxy& image,
                             gevd_bufferxy& contour, gevd_bufferxy& direction,
                             gevd_bufferxy& locationx, gevd_bufferxy& locationy,
-                            int*& junctionx, int*& junctiony)
+                            int*& junctionx, int*& junctiony) const
 {
 #if defined(DEBUG)
   vul_timer t;

--- a/contrib/gel/gevd/gevd_step.h
+++ b/contrib/gel/gevd/gevd_step.h
@@ -85,7 +85,7 @@ class gevd_step
                        gevd_bufferxy& edgels, //!< from end points of contours
                        gevd_bufferxy& direction,
                        gevd_bufferxy& locationx, gevd_bufferxy& locationy,
-                       int*& junctionx, int*& junctiony);
+                       int*& junctionx, int*& junctiony) const;
 
   float NoiseSigma() const;     //!< query stored/estimated noise sigma
   float NoiseResponse() const;  //!< response of noise sigma to filter ddG

--- a/contrib/gel/vdgl/vdgl_digital_region.cxx
+++ b/contrib/gel/vdgl/vdgl_digital_region.cxx
@@ -550,7 +550,7 @@ std::vector<unsigned int> vdgl_digital_region::histogram(int nbins)
 
 std::vector<unsigned int> vdgl_digital_region::residual_histogram(int nbins,
                                                                  float* min,
-                                                                 float* max)
+                                                                 float* max) const
 {
   assert(nbins > 0);
   if (nbins == 1) return std::vector<unsigned int>(1, npts_);

--- a/contrib/gel/vdgl/vdgl_digital_region.h
+++ b/contrib/gel/vdgl/vdgl_digital_region.h
@@ -125,7 +125,7 @@ class vdgl_digital_region : public vsol_region_2d
   std::vector<unsigned int> histogram(int nbins);
   //: Compute the residual intensity histogram
   //  The intensity range is returned as the last two arguments.
-  std::vector<unsigned int> residual_histogram(int nbins, float* min=nullptr, float* max=nullptr);
+  std::vector<unsigned int> residual_histogram(int nbins, float* min=nullptr, float* max=nullptr) const;
 
   //: Return true if this region is convex
   bool is_convex() const override { return false; } // virtual of vsol_region_2d

--- a/contrib/gel/vdgl/vdgl_fit_lines_params.cxx
+++ b/contrib/gel/vdgl/vdgl_fit_lines_params.cxx
@@ -8,7 +8,7 @@
 #  include "vcl_msvc_warnings.h"
 #endif
 
-bool vdgl_fit_lines_params::SanityCheck()
+bool vdgl_fit_lines_params::SanityCheck() const
 {
   bool valid = true;
 

--- a/contrib/gel/vdgl/vdgl_fit_lines_params.h
+++ b/contrib/gel/vdgl/vdgl_fit_lines_params.h
@@ -38,7 +38,7 @@ class vdgl_fit_lines_params : public vbl_ref_count
  ~vdgl_fit_lines_params() override = default;
 
   //: Check that parameters are within acceptable bounds
-  bool SanityCheck();
+  bool SanityCheck() const;
 };
 
 std::ostream& operator<<(std::ostream& os, const vdgl_fit_lines_params& flp);

--- a/contrib/gel/vifa/vifa_coll_lines_params.cxx
+++ b/contrib/gel/vifa/vifa_coll_lines_params.cxx
@@ -32,7 +32,7 @@ vifa_coll_lines_params(const vifa_coll_lines_params& old_params)
 }
 
 void vifa_coll_lines_params::
-print_info(void)
+print_info(void) const
 {
   std::cout << "vifa_coll_lines_params:\n"
            << "  midpoint distance = " << midpt_distance_ << std::endl

--- a/contrib/gel/vifa/vifa_coll_lines_params.h
+++ b/contrib/gel/vifa/vifa_coll_lines_params.h
@@ -57,7 +57,7 @@ class vifa_coll_lines_params : public gevd_param_mixin,
   vifa_coll_lines_params(const vifa_coll_lines_params& old_params);
 
   //: Output contents
-  void  print_info(void);
+  void  print_info(void) const;
 };
 
 

--- a/contrib/gel/vifa/vifa_group_pgram_params.cxx
+++ b/contrib/gel/vifa/vifa_group_pgram_params.cxx
@@ -47,7 +47,7 @@ SanityCheck()
 }
 
 void vifa_group_pgram_params::
-print_info(void)
+print_info(void) const
 {
   std::cout << "vifa_group_pgram_params:\n"
            << "  angle increment     = " << angle_increment_ << std::endl

--- a/contrib/gel/vifa/vifa_group_pgram_params.h
+++ b/contrib/gel/vifa/vifa_group_pgram_params.h
@@ -57,7 +57,7 @@ class vifa_group_pgram_params : public gevd_param_mixin,
   bool  SanityCheck() override;
 
   //: Output contents
-  void  print_info(void);
+  void  print_info(void) const;
 
  protected:
   //: Assign internal parameter blocks.

--- a/contrib/gel/vifa/vifa_histogram.cxx
+++ b/contrib/gel/vifa/vifa_histogram.cxx
@@ -989,7 +989,7 @@ float vifa_histogram::ComputeArea() const
 //----------------------------------------------------------------------
 //: Finds the lower bound value which eliminates a given fraction of histogram area.
 //
-float vifa_histogram::LowClipVal(float clip_fraction)
+float vifa_histogram::LowClipVal(float clip_fraction) const
 {
   if (clip_fraction < 0)
     clip_fraction = 0.0f;
@@ -1023,7 +1023,7 @@ float vifa_histogram::LowClipVal(float clip_fraction)
 //----------------------------------------------------------------------
 //: Finds the lower bound value which eliminates a given fraction of histogram area.
 //
-float vifa_histogram::HighClipVal(float clip_fraction)
+float vifa_histogram::HighClipVal(float clip_fraction) const
 {
   if (clip_fraction < 0)
     clip_fraction = 0.0f;
@@ -1056,7 +1056,7 @@ float vifa_histogram::HighClipVal(float clip_fraction)
 }
 //--------------------------------------------------------------------------
 //: Prints histogram counts onto std::cout
-void vifa_histogram::Print()
+void vifa_histogram::Print() const
 {
   float* vals = this->GetVals();
   float* counts = this->GetCounts();
@@ -1099,7 +1099,7 @@ void vifa_histogram::Dump(char *dumpfile)
 
 //---------------------------------------------------------------------------
 //: Writes histogram in format suitable for plotting tools like Gnuplot.
-int vifa_histogram::WritePlot(const char *fname)
+int vifa_histogram::WritePlot(const char *fname) const
 {
   std::ofstream fp(fname, std::ios::out); // open the file...
 
@@ -1139,7 +1139,7 @@ int vifa_histogram::WritePlot(const char *fname)
 //: Compare 'this' histogram to another (passed in).
 //    Taken from the old TargetJr class HistEntropy.
 //
-float vifa_histogram::CompareToHistogram(vifa_histogram* h)
+float vifa_histogram::CompareToHistogram(vifa_histogram* h) const
 {
   // h1 = 'this'
   float m1 = this->GetMean();

--- a/contrib/gel/vifa/vifa_histogram.h
+++ b/contrib/gel/vifa/vifa_histogram.h
@@ -61,7 +61,7 @@ class vifa_histogram : public vul_timestamp,
 
   // Misc. Methods
   void RemoveFlatPeaks(int nbins, float* cnts, bool cyclic);
-  float CompareToHistogram(vifa_histogram* h);
+  float CompareToHistogram(vifa_histogram* h) const;
 
   // Attribute accessors
   void  UpCount(float newval);
@@ -105,12 +105,12 @@ class vifa_histogram : public vul_timestamp,
   float ComputeArea() const;//total area
 
   //Find bounds that clip off a given percent of the area
-  float LowClipVal(float clip_fraction);
-  float HighClipVal(float clip_fraction);
+  float LowClipVal(float clip_fraction) const;
+  float HighClipVal(float clip_fraction) const;
 
-  void Print();
+  void Print() const;
   void Dump(char *);
-  int  WritePlot(const char* fname);
+  int  WritePlot(const char* fname) const;
 
  private:
   mutable int stats_consistent;  // A 2 bit state flag  Mean = 1 | StandDev = 2

--- a/contrib/gel/vifa/vifa_norm_params.cxx
+++ b/contrib/gel/vifa/vifa_norm_params.cxx
@@ -49,7 +49,7 @@ recompute(void)
 }
 
 float vifa_norm_params::
-normalize(float raw_intensity)
+normalize(float raw_intensity) const
 {
   if (imin_ == imax_)
     return raw_intensity;
@@ -112,7 +112,7 @@ get_norm_bounds(vil_image_view_base*  img,
 }
 
 void vifa_norm_params::
-print_info(void)
+print_info(void) const
 {
   std::cout << "vifa_norm_params:\n"
            << "  low % thresh    = " << plow << std::endl

--- a/contrib/gel/vifa/vifa_norm_params.h
+++ b/contrib/gel/vifa/vifa_norm_params.h
@@ -81,7 +81,7 @@ class vifa_norm_params : public gevd_param_mixin,
   void recompute(void);
 
   //: Compute normalized equivalent of given intensity
-  float  normalize(float  raw_intensity);
+  float  normalize(float  raw_intensity) const;
 
   //: Find an image's low & high intensities for normalization
   static bool  get_norm_bounds(vil_image_view_base*  img,
@@ -92,7 +92,7 @@ class vifa_norm_params : public gevd_param_mixin,
                               );
 
   //: Dump the parameters
-  void  print_info(void);
+  void  print_info(void) const;
 
  private:
   //: Internal method to update clip points & interpolation line

--- a/contrib/gel/vifa/vifa_parallel_params.cxx
+++ b/contrib/gel/vifa/vifa_parallel_params.cxx
@@ -45,7 +45,7 @@ vifa_parallel_params(vifa_parallel_params* np)
 }
 
 void vifa_parallel_params::
-print_info(void)
+print_info(void) const
 {
   std::cout << "vifa_parallel_params:\n"
            << "  min angle    = " << min_angle << std::endl

--- a/contrib/gel/vifa/vifa_parallel_params.h
+++ b/contrib/gel/vifa/vifa_parallel_params.h
@@ -44,7 +44,7 @@ class vifa_parallel_params : public gevd_param_mixin,
   vifa_parallel_params(vifa_parallel_params*  np);
 
   //: Output contents
-  void  print_info(void);
+  void  print_info(void) const;
 };
 
 

--- a/contrib/gel/vmal/vmal_track_lines.cxx
+++ b/contrib/gel/vmal/vmal_track_lines.cxx
@@ -187,7 +187,7 @@ double vmal_track_lines::seg_angle(const vtol_edge_2d_sptr& trans_line,const vto
   return alpha;
 }
 
-bool vmal_track_lines::belong(const vtol_edge_2d_sptr& trans_line,const vtol_edge_2d_sptr& fit_line)
+bool vmal_track_lines::belong(const vtol_edge_2d_sptr& trans_line,const vtol_edge_2d_sptr& fit_line) const
 {
   double tl1x=trans_line->v1()->cast_to_vertex_2d()->x();
   double tl2x=trans_line->v2()->cast_to_vertex_2d()->x();

--- a/contrib/gel/vmal/vmal_track_lines.h
+++ b/contrib/gel/vmal/vmal_track_lines.h
@@ -76,7 +76,7 @@ class vmal_track_lines
  private:
 
   double seg_angle(const vtol_edge_2d_sptr&, const vtol_edge_2d_sptr&);
-  bool belong(const vtol_edge_2d_sptr&, const vtol_edge_2d_sptr&);
+  bool belong(const vtol_edge_2d_sptr&, const vtol_edge_2d_sptr&) const;
   double dist(const vtol_edge_2d_sptr&, const vtol_edge_2d_sptr&);
 //-----------------------------------------------------------------------------
 //: Project the point (x0,y0) on the line ((ax,ay),(bx,by)).

--- a/contrib/gel/vtol/vtol_cycle_processor.cxx
+++ b/contrib/gel/vtol/vtol_cycle_processor.cxx
@@ -397,7 +397,7 @@ bool vtol_cycle_processor::assignable(vtol_edge_2d_sptr edg, const vtol_vertex_s
 //    There is no point in traversing the self loop twice.
 void vtol_cycle_processor::assign_initial_edge(vtol_edge_2d_sptr& e,
                                                vtol_vertex_sptr& first,
-                                               vtol_vertex_sptr& last)
+                                               vtol_vertex_sptr& last) const
 {
   if (debug1_)
       std::cout << "==== entering assign_initial_edge =====\n"
@@ -439,7 +439,7 @@ void vtol_cycle_processor::assign_initial_edge(vtol_edge_2d_sptr& e,
 //:   Link the vtol_edge, "edg" to the vtol_vertex, "last".
 //    Set the appropriate direction flag
 
-void vtol_cycle_processor::assign_ends(vtol_edge_2d_sptr edg, vtol_vertex_sptr& last)
+void vtol_cycle_processor::assign_ends(vtol_edge_2d_sptr edg, vtol_vertex_sptr& last) const
 {
   if (debug1_)
       std::cout << "==== entering assign_ends =====\n"
@@ -614,7 +614,7 @@ void vtol_cycle_processor::add_edge_to_path()
 //    Thus, the winding angle is opposite in sign, which is
 //    accounted for in code.
 bool vtol_cycle_processor::classify_path(std::vector<vtol_edge_2d_sptr>& path_edges,
-                                         vtol_one_chain_sptr& chain)
+                                         vtol_one_chain_sptr& chain) const
 {
   if (debug1_)
         std::cout << "======= In classify_path ========\n";

--- a/contrib/gel/vtol/vtol_cycle_processor.h
+++ b/contrib/gel/vtol/vtol_cycle_processor.h
@@ -69,10 +69,10 @@ class vtol_cycle_processor
   vtol_edge_2d_sptr search_for_next_edge(std::vector<vtol_edge_2d_sptr>& edges_at_last);
   bool assignable(vtol_edge_2d_sptr edg, const vtol_vertex_sptr& last);
   void assign_initial_edge(vtol_edge_2d_sptr& e, vtol_vertex_sptr& first,
-                           vtol_vertex_sptr& last);
-  void assign_ends(vtol_edge_2d_sptr edg, vtol_vertex_sptr& last);
+                           vtol_vertex_sptr& last) const;
+  void assign_ends(vtol_edge_2d_sptr edg, vtol_vertex_sptr& last) const;
   void add_edge_to_path();
-  bool classify_path(std::vector<vtol_edge_2d_sptr>& path_edges, vtol_one_chain_sptr& chain);
+  bool classify_path(std::vector<vtol_edge_2d_sptr>& path_edges, vtol_one_chain_sptr& chain) const;
   void compute_cycles();
   void sort_one_cycles();
   void process();

--- a/contrib/mul/clsfy/clsfy_smo_base.cxx
+++ b/contrib/mul/clsfy/clsfy_smo_base.cxx
@@ -18,7 +18,7 @@
 
 // ----------------------------------------------------------------
 
-double clsfy_smo_base::error()
+double clsfy_smo_base::error() const
 {
   return error_;
 }
@@ -65,7 +65,7 @@ void clsfy_smo_base::set_lagrange_mults(const vnl_vector<double>& lagrange_mults
 
 // ----------------------------------------------------------------
 
-double clsfy_smo_base::bias()
+double clsfy_smo_base::bias() const
 {
   return b_;
 }

--- a/contrib/mul/clsfy/clsfy_smo_base.h
+++ b/contrib/mul/clsfy/clsfy_smo_base.h
@@ -90,7 +90,7 @@ class clsfy_smo_base
   //: Bias term in function evaluation.
   // For SVMs this would be the value to be subtracted from sum of kernel
   // functions to get 0 as class boundary.
-  double bias();
+  double bias() const;
 
   //: Reseeds the internal random number generator.
   // To achieve quasi-random initialisation use;
@@ -128,7 +128,7 @@ class clsfy_smo_base
   virtual int calc()=0;
 
   //: error rate on the training data
-  double error();
+  double error() const;
 };
 
 #endif

--- a/contrib/mul/m23d/m23d_correction_matrix_error.cxx
+++ b/contrib/mul/m23d/m23d_correction_matrix_error.cxx
@@ -30,7 +30,7 @@ m23d_correction_matrix_error::m23d_correction_matrix_error(const vnl_matrix<doub
 //  3*(m+1) x 3 matrices formed from the elements of g1 and g2.
 void m23d_correction_matrix_error::compute_q(const vnl_vector<double>& g1,
                  const vnl_vector<double>& g2,
-                 vnl_vector<double>& q)
+                 vnl_vector<double>& q) const
 {
   unsigned t = 3*(n_modes_+1);
   unsigned k=0;

--- a/contrib/mul/m23d/m23d_correction_matrix_error.h
+++ b/contrib/mul/m23d/m23d_correction_matrix_error.h
@@ -38,7 +38,7 @@ class m23d_correction_matrix_error : public vnl_least_squares_function
   //  g1==g2 for full q, g2 = (0 0 ..1 ...0) when computing derivatives
   void compute_q(const vnl_vector<double>& g1,
                  const vnl_vector<double>& g2,
-                 vnl_vector<double>& q);
+                 vnl_vector<double>& q) const;
 
 public:
   m23d_correction_matrix_error(const vnl_matrix<double>& A,

--- a/contrib/mul/mbl/mbl_table.cxx
+++ b/contrib/mul/mbl/mbl_table.cxx
@@ -462,7 +462,7 @@ bool mbl_table::subtable(mbl_table &new_table,  const std::vector<std::string> &
 bool mbl_table::read_delimited_string(std::istream& is,
                                       std::string& str,
                                       bool& eol,
-                                      bool& eof)
+                                      bool& eof) const
 {
   str = "";
   eol = false;

--- a/contrib/mul/mbl/mbl_table.h
+++ b/contrib/mul/mbl/mbl_table.h
@@ -188,7 +188,7 @@ protected:
   bool read_delimited_string(std::istream& is,
                              std::string& str,
                              bool& eol,
-                             bool& eof);
+                             bool& eof) const;
 
   //: The character delimiting each column.
   char delimiter_;

--- a/contrib/mul/mcal/mcal_pca.cxx
+++ b/contrib/mul/mcal/mcal_pca.cxx
@@ -43,7 +43,7 @@ mcal_pca::~mcal_pca() = default;
 
 
 //: Return the number of modes to retain
-unsigned mcal_pca::choose_n_modes(const vnl_vector<double>& evals)
+unsigned mcal_pca::choose_n_modes(const vnl_vector<double>& evals) const
 {
   if (evals.size()==0) return 0;
   const double* v_data = evals.begin();

--- a/contrib/mul/mcal/mcal_pca.h
+++ b/contrib/mul/mcal/mcal_pca.h
@@ -26,7 +26,7 @@ class mcal_pca : public mcal_component_analyzer
   unsigned int min_modes_,max_modes_;
 
   //: Return the number of modes to retain
-  unsigned choose_n_modes(const vnl_vector<double>& evals);
+  unsigned choose_n_modes(const vnl_vector<double>& evals) const;
 
   //: Utility function
   void fillDDt(vnl_matrix<double>& DDt, const vnl_matrix<double>& A,

--- a/contrib/mul/mfpf/mfpf_point_finder_builder.cxx
+++ b/contrib/mul/mfpf/mfpf_point_finder_builder.cxx
@@ -125,7 +125,7 @@ void mfpf_point_finder_builder::parse_base_props(mbl_read_props_type& props)
 
 
 //: Set base-class parameters of point finder
-void mfpf_point_finder_builder::set_base_parameters(mfpf_point_finder& pf)
+void mfpf_point_finder_builder::set_base_parameters(mfpf_point_finder& pf) const
 {
   pf.set_step_size(step_size_);
   pf.set_search_area(search_ni_,search_nj_);

--- a/contrib/mul/mfpf/mfpf_point_finder_builder.h
+++ b/contrib/mul/mfpf/mfpf_point_finder_builder.h
@@ -52,7 +52,7 @@ class mfpf_point_finder_builder
   void parse_base_props(mbl_read_props_type& props);
 
   //: Set base-class parameters of point finder
-  void set_base_parameters(mfpf_point_finder& pf);
+  void set_base_parameters(mfpf_point_finder& pf) const;
 
  public:
 

--- a/contrib/mul/msm/msm_wt_mat_2d.cxx
+++ b/contrib/mul/msm/msm_wt_mat_2d.cxx
@@ -42,7 +42,7 @@ msm_wt_mat_2d msm_wt_mat_2d::inverse() const
 }
 
 //: Calculate eigenvalues
-void msm_wt_mat_2d::eigen_values(double& EV1, double& EV2)
+void msm_wt_mat_2d::eigen_values(double& EV1, double& EV2) const
 {
   double dac=m11_-m22_;
   double d=0.5*std::sqrt(dac*dac+4*m12_*m12_);
@@ -53,7 +53,7 @@ void msm_wt_mat_2d::eigen_values(double& EV1, double& EV2)
 
 //: Calculate eigenvector associated with largest eigenvalue.
 //  Other evec given by (-evec1.y(),evec1.x())
-void msm_wt_mat_2d::eigen_vector(vgl_vector_2d<double>& evec1, double& eval1, double& eval2)
+void msm_wt_mat_2d::eigen_vector(vgl_vector_2d<double>& evec1, double& eval1, double& eval2) const
 {
   double dac=m11_-m22_;
   double d=0.5*std::sqrt(dac*dac+4*m12_*m12_);
@@ -104,7 +104,7 @@ msm_wt_mat_2d& msm_wt_mat_2d::operator+=(const msm_wt_mat_2d& W)
 }
 
 //: Equality test
-bool msm_wt_mat_2d::operator==(const msm_wt_mat_2d& W)
+bool msm_wt_mat_2d::operator==(const msm_wt_mat_2d& W) const
 {
   return (std::fabs(m11_-W.m11_)<1e-8) &&
          (std::fabs(m12_-W.m12_)<1e-8) &&

--- a/contrib/mul/msm/msm_wt_mat_2d.h
+++ b/contrib/mul/msm/msm_wt_mat_2d.h
@@ -52,11 +52,11 @@ class msm_wt_mat_2d
   double det() const { return m11_*m22_ - m12_*m12_; }
 
   //: Calculate eigenvalues
-  void eigen_values(double& EV1, double& EV2);
+  void eigen_values(double& EV1, double& EV2) const;
 
   //: Calculate eigenvector associated with largest eigenvalue.
   //  Other evec given by (-evec1.y(),evec1.x())
-  void eigen_vector(vgl_vector_2d<double>& evec1, double& eval1, double& eval2);
+  void eigen_vector(vgl_vector_2d<double>& evec1, double& eval1, double& eval2) const;
 
   //: Calculates effect of applying rotation/scale to space
   // W2=TWT'/(a*a+b*b) where T is 2x2 matrix (a,-b;b,a)
@@ -91,7 +91,7 @@ class msm_wt_mat_2d
   void b_read(vsl_b_istream& bfs);
 
   //: Equality test
-  bool operator==(const msm_wt_mat_2d& wt_mat);
+  bool operator==(const msm_wt_mat_2d& wt_mat) const;
 };
 
 

--- a/contrib/mul/vil3d/algo/vil3d_overlap.cxx
+++ b/contrib/mul/vil3d/algo/vil3d_overlap.cxx
@@ -33,8 +33,8 @@ public:
       if (voxB) nBnotA++;
   }
 
-  unsigned n_union() { return nAnotB+ nBnotA + nAandB; }
-  unsigned n_intersection() { return nAandB; }
+  unsigned n_union() const { return nAnotB+ nBnotA + nAandB; }
+  unsigned n_intersection() const { return nAandB; }
 };
 
 

--- a/contrib/mul/vil3d/file_formats/vil3d_analyze_format.cxx
+++ b/contrib/mul/vil3d/file_formats/vil3d_analyze_format.cxx
@@ -385,7 +385,7 @@ void vil3d_analyze_header::set_voxel_size(float si, float sj, float sk)
   dim.pixdim[3]=sk;
 }
 
-void vil3d_analyze_header::swapBytes(char *data, int size)
+void vil3d_analyze_header::swapBytes(char *data, int size) const
 {
   if (needSwap())
   {

--- a/contrib/mul/vil3d/file_formats/vil3d_analyze_format.h
+++ b/contrib/mul/vil3d/file_formats/vil3d_analyze_format.h
@@ -140,7 +140,7 @@ class vil3d_analyze_header
   //: Write header to given file
   bool write_file(const std::string& path) const;
 
-  void swapBytes(char *data, int size);
+  void swapBytes(char *data, int size) const;
   bool needSwap() const { return swap_bytes_; }
 
   //: Print out some parts of header

--- a/contrib/oxl/mvl/FMatrixCompute7Point.cxx
+++ b/contrib/oxl/mvl/FMatrixCompute7Point.cxx
@@ -116,7 +116,7 @@ bool FMatrixCompute7Point::compute(std::vector<HomgPoint2D>& points1,
 //-----------------------------------------------------------------------------
 bool FMatrixCompute7Point::compute_preconditioned(std::vector<vgl_homg_point_2d<double> >& points1,
                                                   std::vector<vgl_homg_point_2d<double> >& points2,
-                                                  std::vector<FMatrix*>& F)
+                                                  std::vector<FMatrix*>& F) const
 {
   // Create design matrix from conditioned points
   FDesignMatrix design(points1, points2);
@@ -160,7 +160,7 @@ bool FMatrixCompute7Point::compute_preconditioned(std::vector<vgl_homg_point_2d<
 //-----------------------------------------------------------------------------
 bool FMatrixCompute7Point::compute_preconditioned(std::vector<HomgPoint2D>& points1,
                                                   std::vector<HomgPoint2D>& points2,
-                                                  std::vector<FMatrix*>& F)
+                                                  std::vector<FMatrix*>& F) const
 {
   // Create design matrix from conditioned points
   FDesignMatrix design(points1, points2);

--- a/contrib/oxl/mvl/FMatrixCompute7Point.h
+++ b/contrib/oxl/mvl/FMatrixCompute7Point.h
@@ -64,12 +64,12 @@ class FMatrixCompute7Point
                std::vector<FMatrix*>&);
 
   //: Interface to above using preconditioned points
-  bool compute_preconditioned(std::vector<HomgPoint2D>&, std::vector<HomgPoint2D>&, std::vector<FMatrix*>&);
+  bool compute_preconditioned(std::vector<HomgPoint2D>&, std::vector<HomgPoint2D>&, std::vector<FMatrix*>&) const;
 
   //: Interface to above using preconditioned points
   bool compute_preconditioned(std::vector<vgl_homg_point_2d<double> >& points1,
                               std::vector<vgl_homg_point_2d<double> >& points2,
-                              std::vector<FMatrix*>&);
+                              std::vector<FMatrix*>&) const;
  protected:
   static std::vector<double> GetCoef(FMatrix const& F1, FMatrix const& F2);
   static std::vector<double> solve_quadratic(std::vector<double> v);

--- a/contrib/oxl/mvl/FMatrixComputeLinear.cxx
+++ b/contrib/oxl/mvl/FMatrixComputeLinear.cxx
@@ -106,7 +106,7 @@ bool FMatrixComputeLinear::compute (std::vector<HomgPoint2D>& points1,
 //-----------------------------------------------------------------------------
 bool FMatrixComputeLinear::compute_preconditioned (std::vector<vgl_homg_point_2d<double> >& points1,
                                                    std::vector<vgl_homg_point_2d<double> >& points2,
-                                                   FMatrix& F)
+                                                   FMatrix& F) const
 {
   // Create design matrix from conditioned points.
   FDesignMatrix design(points1, points2);
@@ -130,7 +130,7 @@ bool FMatrixComputeLinear::compute_preconditioned (std::vector<vgl_homg_point_2d
 //-----------------------------------------------------------------------------
 bool FMatrixComputeLinear::compute_preconditioned (std::vector<HomgPoint2D>& points1,
                                                    std::vector<HomgPoint2D>& points2,
-                                                   FMatrix *F)
+                                                   FMatrix *F) const
 {
   // Create design matrix from conditioned points.
   FDesignMatrix design(points1, points2);

--- a/contrib/oxl/mvl/FMatrixComputeLinear.h
+++ b/contrib/oxl/mvl/FMatrixComputeLinear.h
@@ -64,12 +64,12 @@ class FMatrixComputeLinear : public FMatrixCompute
                FMatrix& F) override;
 
   //: Interface to above using preconditioned points
-  bool compute_preconditioned(std::vector<HomgPoint2D>&, std::vector<HomgPoint2D>&, FMatrix* F);
+  bool compute_preconditioned(std::vector<HomgPoint2D>&, std::vector<HomgPoint2D>&, FMatrix* F) const;
 
   //: Interface to above using preconditioned points
   bool compute_preconditioned(std::vector<vgl_homg_point_2d<double> >&,
                               std::vector<vgl_homg_point_2d<double> >&,
-                              FMatrix& F);
+                              FMatrix& F) const;
 
   inline FMatrix compute(PairMatchSetCorner& p) { return FMatrixCompute::compute(p); }
   inline FMatrix compute(std::vector<HomgPoint2D>& p1, std::vector<HomgPoint2D>& p2)

--- a/contrib/oxl/mvl/FMatrixComputeNonLinear.cxx
+++ b/contrib/oxl/mvl/FMatrixComputeNonLinear.cxx
@@ -388,7 +388,7 @@ FMatrix FMatrixComputeNonLinear::params_to_fmatrix(const vnl_vector<double>& par
 }
 
 // Forms a map of the different rank-2 structures for the F Matrix
-void FMatrixComputeNonLinear::get_plan(int &r1, int &c1, int &r2, int &c2)
+void FMatrixComputeNonLinear::get_plan(int &r1, int &c1, int &r2, int &c2) const
 {
   switch (p_) {
     case 0 :

--- a/contrib/oxl/mvl/FMatrixComputeNonLinear.h
+++ b/contrib/oxl/mvl/FMatrixComputeNonLinear.h
@@ -56,7 +56,7 @@ class FMatrixComputeNonLinear : public vnl_least_squares_function
   // Helpers-------------------------------------------------------------------
   void fmatrix_to_params(const FMatrix& F, vnl_vector<double>& params);
   FMatrix params_to_fmatrix(const vnl_vector<double>& params);
-  void get_plan(int &r1, int &c1, int &r2, int &c2);
+  void get_plan(int &r1, int &c1, int &r2, int &c2) const;
   vnl_vector<double> calculate_residuals(FMatrix* F);
 };
 

--- a/contrib/oxl/mvl/FMatrixComputeRobust.cxx
+++ b/contrib/oxl/mvl/FMatrixComputeRobust.cxx
@@ -172,7 +172,7 @@ std::vector<double> FMatrixComputeRobust::calculate_residuals(std::vector<HomgPo
 }
 
 //: Find the standard deviation of the residuals
-double FMatrixComputeRobust::stdev(std::vector<double>& residuals)
+double FMatrixComputeRobust::stdev(std::vector<double>& residuals) const
 {
   double ret = 0.0;
   for (int i = 0; i < data_size_; i++)

--- a/contrib/oxl/mvl/FMatrixComputeRobust.h
+++ b/contrib/oxl/mvl/FMatrixComputeRobust.h
@@ -69,7 +69,7 @@ class FMatrixComputeRobust : public FMatrixCompute
   std::vector<double> calculate_residuals(std::vector<vgl_homg_point_2d<double> >& one,
                                          std::vector<vgl_homg_point_2d<double> >& two,
                                          FMatrix* F);
-  double stdev(std::vector<double>& residuals);
+  double stdev(std::vector<double>& residuals) const;
  protected:
   bool rank2_truncate_;
   double inthresh_;

--- a/contrib/oxl/mvl/HMatrix2DComputeRobust.cxx
+++ b/contrib/oxl/mvl/HMatrix2DComputeRobust.cxx
@@ -175,7 +175,7 @@ bool HMatrix2DComputeRobust::compute(PairMatchSetCorner& matches, HMatrix2D *H)
   return true;
 }
 
-double HMatrix2DComputeRobust::stdev(std::vector<double>& residuals)
+double HMatrix2DComputeRobust::stdev(std::vector<double>& residuals) const
 {
   double ret = 0.0;
   for (int i = 0; i < data_size_; i++)

--- a/contrib/oxl/mvl/HMatrix2DComputeRobust.h
+++ b/contrib/oxl/mvl/HMatrix2DComputeRobust.h
@@ -48,7 +48,7 @@ class HMatrix2DComputeRobust
   std::vector<double> calculate_residuals(std::vector<vgl_homg_point_2d<double> >& one,
                                          std::vector<vgl_homg_point_2d<double> >& two,
                                          HMatrix2D* H);
-  double stdev(std::vector<double>& residuals);
+  double stdev(std::vector<double>& residuals) const;
 
   double std_;
   std::vector<int> basis_;

--- a/contrib/oxl/mvl/NViewMatches.cxx
+++ b/contrib/oxl/mvl/NViewMatches.cxx
@@ -242,7 +242,7 @@ int NViewMatches::incorporate(const NViewMatch& newtrack)
 }
 
 //: Build an NViewMatch from the triplet \p (base_view..base_view+2)
-NViewMatch NViewMatches::make_triplet_match(int base_view, int c1, int c2, int c3)
+NViewMatch NViewMatches::make_triplet_match(int base_view, int c1, int c2, int c3) const
 {
   assert(base_view+2 < nviews_);
   NViewMatch newtrack(nviews_);

--- a/contrib/oxl/mvl/NViewMatches.h
+++ b/contrib/oxl/mvl/NViewMatches.h
@@ -88,7 +88,7 @@ class NViewMatches : public std::vector<NViewMatch>
   int incorporate_triplet(int base_view, int c1, int c2, int c3);
   int incorporate(const NViewMatch& matches);
   void remove_inconsistencies();
-  NViewMatch make_triplet_match(int base_view, int c1, int c2, int c3);
+  NViewMatch make_triplet_match(int base_view, int c1, int c2, int c3) const;
 };
 
 class OffsetNViewMatch : public NViewMatch

--- a/contrib/oxl/mvl/PMatrix.cxx
+++ b/contrib/oxl/mvl/PMatrix.cxx
@@ -617,7 +617,7 @@ PMatrix::flip_sign()
 
 //: Splendid hack that tries to detect if the P is an image-coords P or a normalized P.
 bool
-PMatrix::looks_conditioned()
+PMatrix::looks_conditioned() const
 {
   double cond = svd()->W(0) / svd()->W(2);
   // std::cerr << "PMatrix::looks_conditioned: cond = " << cond << '\n';

--- a/contrib/oxl/mvl/PMatrix.h
+++ b/contrib/oxl/mvl/PMatrix.h
@@ -111,7 +111,7 @@ class PMatrix : public vbl_ref_count
   bool is_behind_camera(const HomgPoint3D&);
   bool is_behind_camera(vgl_homg_point_3d<double> const&);
   void flip_sign();
-  bool looks_conditioned();
+  bool looks_conditioned() const;
   void fix_cheirality();
 
   // Data Access---------------------------------------------------------------

--- a/contrib/oxl/osl/osl_edge.cxx
+++ b/contrib/oxl/osl/osl_edge.cxx
@@ -74,11 +74,11 @@ float osl_edge::GetStartY() const { return v1->y; }
 float osl_edge::GetEndX() const { return v2->x; }
 float osl_edge::GetEndY() const { return v2->y; }
 
-void osl_edge::SetStartX(float v) { v1->x = v; }
-void osl_edge::SetStartY(float v) { v1->y = v; }
+void osl_edge::SetStartX(float v) const { v1->x = v; }
+void osl_edge::SetStartY(float v) const { v1->y = v; }
 
-void osl_edge::SetEndX(float v) { v2->x = v; }
-void osl_edge::SetEndY(float v) { v2->y = v; }
+void osl_edge::SetEndX(float v) const { v2->x = v; }
+void osl_edge::SetEndY(float v) const { v2->y = v; }
 
 //--------------------------------------------------------------------------------
 

--- a/contrib/oxl/osl/osl_edge.h
+++ b/contrib/oxl/osl/osl_edge.h
@@ -34,12 +34,12 @@ class osl_edge : public osl_topology_base, public osl_edgel_chain
   float GetEndY() const;
 
   // set coordinates of end-vertices
-  void SetStartX(float v);
-  void SetStartY(float v);
+  void SetStartX(float v) const;
+  void SetStartY(float v) const;
   void SetStart(float x, float y);
 
-  void SetEndX(float v);
-  void SetEndY(float v);
+  void SetEndX(float v) const;
+  void SetEndY(float v) const;
   void SetEnd(float x, float y);
 };
 

--- a/contrib/oxl/osl/osl_edgel_chain.cxx
+++ b/contrib/oxl/osl/osl_edgel_chain.cxx
@@ -69,10 +69,10 @@ float  osl_edgel_chain::GetX(unsigned int i) const { return x[i]; }
 float *osl_edgel_chain::GetX() const { return x; }
 float  osl_edgel_chain::GetY(unsigned int i) const { return y[i]; }
 float *osl_edgel_chain::GetY() const { return y; }
-void osl_edgel_chain::SetGrad(float v, unsigned int i) { grad[i] = v; }
-void osl_edgel_chain::SetTheta(float v, unsigned int i) { theta[i] = v; }
-void osl_edgel_chain::SetX(float v, unsigned int i) { x[i] = v; }
-void osl_edgel_chain::SetY(float v, unsigned int i) { y[i] = v; }
+void osl_edgel_chain::SetGrad(float v, unsigned int i) const { grad[i] = v; }
+void osl_edgel_chain::SetTheta(float v, unsigned int i) const { theta[i] = v; }
+void osl_edgel_chain::SetX(float v, unsigned int i) const { x[i] = v; }
+void osl_edgel_chain::SetY(float v, unsigned int i) const { y[i] = v; }
 unsigned int osl_edgel_chain::size() const { return n; }
 
 void osl_edgel_chain::SetLength(unsigned int nn)

--- a/contrib/oxl/osl/osl_edgel_chain.h
+++ b/contrib/oxl/osl/osl_edgel_chain.h
@@ -32,10 +32,10 @@ struct osl_edgel_chain
   float *GetX() const;
   float  GetY(unsigned int i) const;
   float *GetY() const;
-  void SetGrad(float v, unsigned int i);
-  void SetTheta(float v, unsigned int i);
-  void SetX(float v, unsigned int i);
-  void SetY(float v, unsigned int i);
+  void SetGrad(float v, unsigned int i) const;
+  void SetTheta(float v, unsigned int i) const;
+  void SetX(float v, unsigned int i) const;
+  void SetY(float v, unsigned int i) const;
   unsigned int size() const;
   //
   void write_ascii(std::ostream &) const;

--- a/contrib/oxl/osl/osl_fit_lines_params.cxx
+++ b/contrib/oxl/osl/osl_fit_lines_params.cxx
@@ -23,7 +23,7 @@ osl_fit_lines_params::osl_fit_lines_params(unsigned int min_fit_len,
 {}
 
 //: Checks that parameters are within acceptable bounds
-bool osl_fit_lines_params::SanityCheck()
+bool osl_fit_lines_params::SanityCheck() const
 {
   bool valid = true;
 

--- a/contrib/oxl/osl/osl_fit_lines_params.h
+++ b/contrib/oxl/osl/osl_fit_lines_params.h
@@ -20,7 +20,7 @@ class osl_fit_lines_params
                        unsigned int ignore_end_edgels = 3);
 
   // Check parameters for consistency
-  bool SanityCheck();
+  bool SanityCheck() const;
 
   //The parameter members
   unsigned int min_fit_length_;   // Minimum number of pixels to fit lines to

--- a/contrib/rpl/rsdl/rsdl_kd_tree.cxx
+++ b/contrib/rpl/rsdl/rsdl_kd_tree.cxx
@@ -607,7 +607,7 @@ rsdl_kd_tree :: bounded_at_leaf ( const rsdl_point& query_point,
                                   int n,
                                   rsdl_kd_node* current,
                                   const std::vector< double >& sq_distances,
-                                  int & num_found )
+                                  int & num_found ) const
 {
   assert(n>0);
 #ifdef DEBUG

--- a/contrib/rpl/rsdl/rsdl_kd_tree.h
+++ b/contrib/rpl/rsdl/rsdl_kd_tree.h
@@ -151,7 +151,7 @@ class rsdl_kd_tree : public vbl_ref_count
                          int n,
                          rsdl_kd_node* current,
                          const std::vector< double >& sq_distances,
-                         int & num_found );
+                         int & num_found ) const;
 
   void points_in_bounding_box( rsdl_kd_node* current,
                                const rsdl_bounding_box& box,

--- a/core/vbl/io/tests/vbl_io_test_classes.cxx
+++ b/core/vbl/io/tests/vbl_io_test_classes.cxx
@@ -46,7 +46,7 @@ impl::~impl()
 }
 
 void
-impl::Print(std::ostream & str)
+impl::Print(std::ostream & str) const
 {
   str << "impl(" << n << ") ";
 }

--- a/core/vbl/io/tests/vbl_io_test_classes.h
+++ b/core/vbl/io/tests/vbl_io_test_classes.h
@@ -19,7 +19,7 @@ class impl : public vbl_ref_count
   impl(impl const& x) : vbl_ref_count(x), n(x.n) {}
   impl();
   ~impl() override;
-  void Print (std::ostream &str);
+  void Print (std::ostream &str) const;
   static void checkcount ();
 };
 

--- a/core/vbl/tests/vbl_test_classes.cxx
+++ b/core/vbl/tests/vbl_test_classes.cxx
@@ -32,7 +32,7 @@ base_impl::~base_impl()
 }
 
 void
-base_impl::Print(std::ostream & str)
+base_impl::Print(std::ostream & str) const
 {
   str << "base_impl(" << n << ") ";
 }

--- a/core/vbl/tests/vbl_test_classes.h
+++ b/core/vbl/tests/vbl_test_classes.h
@@ -18,7 +18,7 @@ class base_impl : public vbl_ref_count
   base_impl();
   base_impl(base_impl const& x) : vbl_ref_count(), n(x.n) {}
   ~base_impl() override;
-  void Print (std::ostream &str);
+  void Print (std::ostream &str) const;
   static bool checkcount ( int count = 0 );
 };
 

--- a/core/vgl/algo/vgl_h_matrix_2d_compute_linear.cxx
+++ b/core/vgl/algo/vgl_h_matrix_2d_compute_linear.cxx
@@ -52,7 +52,7 @@ bool
 vgl_h_matrix_2d_compute_linear::solve_linear_problem(int equ_count,
                                                      std::vector<vgl_homg_point_2d<double>> const & p1,
                                                      std::vector<vgl_homg_point_2d<double>> const & p2,
-                                                     vgl_h_matrix_2d<double> & H)
+                                                     vgl_h_matrix_2d<double> & H) const
 {
   // transform the point sets and fill the design matrix
   vnl_matrix<double> D(equ_count, TM_UNKNOWNS_COUNT);

--- a/core/vgl/algo/vgl_h_matrix_2d_compute_linear.h
+++ b/core/vgl/algo/vgl_h_matrix_2d_compute_linear.h
@@ -56,7 +56,7 @@ class vgl_h_matrix_2d_compute_linear : public vgl_h_matrix_2d_compute
   bool solve_linear_problem(int equ_count,
                             std::vector<vgl_homg_point_2d<double> > const& p1,
                             std::vector<vgl_homg_point_2d<double> > const& p2,
-                            vgl_h_matrix_2d<double>& H);
+                            vgl_h_matrix_2d<double>& H) const;
 
   //: for lines, the solution should be weighted by line length
   bool

--- a/core/vil/file_formats/vil_jpeg_compressor.cxx
+++ b/core/vil/file_formats/vil_jpeg_compressor.cxx
@@ -126,7 +126,7 @@ vil_jpeg_compressor::set_quality(int q)
 }
 
 int
-vil_jpeg_compressor::get_quality()
+vil_jpeg_compressor::get_quality() const
 {
   return quality;
 }

--- a/core/vil/file_formats/vil_jpeg_compressor.h
+++ b/core/vil/file_formats/vil_jpeg_compressor.h
@@ -27,7 +27,7 @@ class vil_jpeg_compressor
   bool write_scanline(unsigned line, JSAMPLE const *);
 
   void set_quality(int quality);
-  int get_quality();
+  int get_quality() const;
 
  private:
   bool ready;

--- a/core/vil/file_formats/vil_nitf2_field_formatter.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_formatter.cxx
@@ -51,7 +51,7 @@ vil_nitf2_field_formatter::read_c_str(std::istream & input, int length, char *& 
 }
 
 bool
-vil_nitf2_field_formatter::write_blank(std::ostream & output)
+vil_nitf2_field_formatter::write_blank(std::ostream & output) const
 {
   std::string str(field_width, ' ');
   output << str;
@@ -59,7 +59,7 @@ vil_nitf2_field_formatter::write_blank(std::ostream & output)
 }
 
 bool
-vil_nitf2_field_formatter::write_blank(vil_nitf2_ostream & output)
+vil_nitf2_field_formatter::write_blank(vil_nitf2_ostream & output) const
 {
   std::string str(field_width, ' ');
   output.write(str.c_str(), field_width);

--- a/core/vil/file_formats/vil_nitf2_field_formatter.h
+++ b/core/vil/file_formats/vil_nitf2_field_formatter.h
@@ -68,10 +68,10 @@ class vil_nitf2_field_formatter
 
   // Writes a blank instance of field value to output stream. Returns
   // true iff successfully written. No need to overload this method.
-  bool write_blank(std::ostream& output);
+  bool write_blank(std::ostream& output) const;
 
   // Same as above, but writes to a vil_stream.
-  bool write_blank(vil_stream& output);
+  bool write_blank(vil_stream& output) const;
 
   // Helper function which reads the specified number characters into
   // a string (if possible), which it returns as a null-terminated C string,

--- a/core/vil/file_formats/vil_nitf2_image_subheader.cxx
+++ b/core/vil/file_formats/vil_nitf2_image_subheader.cxx
@@ -473,7 +473,7 @@ get_date_time(int& year, int& month, int& day, int& hour, int& min)
 #endif // 0
 
 bool
-vil_nitf2_image_subheader::get_date_time(int & year, int & month, int & day, int & hour, int & min, int & sec)
+vil_nitf2_image_subheader::get_date_time(int & year, int & month, int & day, int & hour, int & min, int & sec) const
 {
   std::string date_time = "";
   bool success = this->get_property("IDATIM", date_time);
@@ -806,7 +806,7 @@ vil_nitf2_image_subheader::add_USE_definitions()
 
 // Collect the Sun angles
 bool
-vil_nitf2_image_subheader::get_sun_params(double & sun_el, double & sun_az)
+vil_nitf2_image_subheader::get_sun_params(double & sun_el, double & sun_az) const
 {
   // Now get the sub-header TRE parameters
   vil_nitf2_tagged_record_sequence isxhd_tres;
@@ -1033,7 +1033,7 @@ vil_nitf2_image_subheader::add_MPD26A_definitions()
 
 // obtain column and row offset from STDIDB /SDTDIDC
 bool
-vil_nitf2_image_subheader::get_correction_offset(double & u_off, double & v_off)
+vil_nitf2_image_subheader::get_correction_offset(double & u_off, double & v_off) const
 {
   // Now get the sub-header TRE parameters
   vil_nitf2_tagged_record_sequence isxhd_tres;
@@ -1100,7 +1100,7 @@ bool
 vil_nitf2_image_subheader::get_rpc_params(std::string & rpc_type,
                                           std::string & image_id,
                                           std::string & image_corner_geo_locations,
-                                          double * rpc_data)
+                                          double * rpc_data) const
 {
   // Get image ID and location from main header values
   std::string iid2 = "";

--- a/core/vil/file_formats/vil_nitf2_image_subheader.h
+++ b/core/vil/file_formats/vil_nitf2_image_subheader.h
@@ -114,17 +114,17 @@ class vil_nitf2_image_subheader
   //  Defined extensions are RPC00A and RPC00B.
   bool get_rpc_params( std::string& rpc_type, std::string& image_id,
                        std::string& image_corner_geo_locations,
-                       double* rpc_data );
+                       double* rpc_data ) const;
 
   //: Return the elevation and azimuth angles of the sun
   //  \a sun_el --> sun elevation angle
   //  \a sun_az --> sun azimuthal angle
-  bool get_sun_params( double& sun_el, double& sun_az);
+  bool get_sun_params( double& sun_el, double& sun_az) const;
 
   //: Extract the date and time
-  bool get_date_time(int& year, int& month, int& day, int& hour, int& min, int& sec);
+  bool get_date_time(int& year, int& month, int& day, int& hour, int& min, int& sec) const;
 
-  bool get_correction_offset(double & u_off, double & v_off);
+  bool get_correction_offset(double & u_off, double & v_off) const;
 
  protected:
   vil_nitf2_field_sequence m_field_sequence;

--- a/core/vil/file_formats/vil_tiff.cxx
+++ b/core/vil/file_formats/vil_tiff.cxx
@@ -1029,7 +1029,7 @@ vil_tiff_image::pad_block_with_zeros(unsigned ioff,
                                      unsigned iclip,
                                      unsigned jclip,
                                      unsigned bytes_per_pixel,
-                                     vxl_byte * block_buf)
+                                     vxl_byte * block_buf) const
 {
   unsigned jstep = size_block_i() * bytes_per_pixel;
   unsigned row_start = ioff * bytes_per_pixel;

--- a/core/vil/file_formats/vil_tiff.h
+++ b/core/vil/file_formats/vil_tiff.h
@@ -301,7 +301,7 @@ class vil_tiff_image : public vil_blocked_image_resource
   void pad_block_with_zeros(unsigned ioff, unsigned joff,
                             unsigned iclip, unsigned jclip,
                             unsigned bytes_per_pixel,
-                            vxl_byte* block_buf);
+                            vxl_byte* block_buf) const;
 
   //: fill the block with view data
   void fill_block_from_view(unsigned bi, unsigned bj,

--- a/core/vnl/algo/tests/test_sparse_lm.cxx
+++ b/core/vnl/algo/tests/test_sparse_lm.cxx
@@ -608,7 +608,7 @@ public:
   }
 
   double
-  mest(int /*k*/, double ek2)
+  mest(int /*k*/, double ek2) const
   {
     // Beaton-Tukey
     if (ek2 > scale2_)
@@ -621,7 +621,7 @@ public:
   }
 
   double
-  d_mest(int /*k*/, double ek2)
+  d_mest(int /*k*/, double ek2) const
   {
     // Beaton-Tukey
     if (ek2 > scale2_)

--- a/core/vpgl/algo/vpgl_fm_compute_2_point.cxx
+++ b/core/vpgl/algo/vpgl_fm_compute_2_point.cxx
@@ -21,7 +21,7 @@
 bool
 vpgl_fm_compute_2_point::compute(const std::vector<vgl_homg_point_2d<double>> & pr,
                                  const std::vector<vgl_homg_point_2d<double>> & pl,
-                                 vpgl_fundamental_matrix<double> & fm)
+                                 vpgl_fundamental_matrix<double> & fm) const
 {
   // Check that there are at least 2 points.
   if (pr.size() < 2 || pl.size() < 2)

--- a/core/vpgl/algo/vpgl_fm_compute_2_point.h
+++ b/core/vpgl/algo/vpgl_fm_compute_2_point.h
@@ -34,7 +34,7 @@ class vpgl_fm_compute_2_point
   // while the points pl are associated with the LHS.
   bool compute( const std::vector< vgl_homg_point_2d<double> >& pr,
                 const std::vector< vgl_homg_point_2d<double> >& pl,
-                vpgl_fundamental_matrix<double>& fm );
+                vpgl_fundamental_matrix<double>& fm ) const;
 
  protected:
   bool precondition_;

--- a/core/vpgl/algo/vpgl_fm_compute_7_point.cxx
+++ b/core/vpgl/algo/vpgl_fm_compute_7_point.cxx
@@ -18,7 +18,7 @@
 bool
 vpgl_fm_compute_7_point::compute(const std::vector<vgl_homg_point_2d<double>> & pr,
                                  const std::vector<vgl_homg_point_2d<double>> & pl,
-                                 std::vector<vpgl_fundamental_matrix<double> *> & fm)
+                                 std::vector<vpgl_fundamental_matrix<double> *> & fm) const
 {
   // Check that there are at least 7 points.
   if (pr.size() < 7 || pl.size() < 7)

--- a/core/vpgl/algo/vpgl_fm_compute_7_point.h
+++ b/core/vpgl/algo/vpgl_fm_compute_7_point.h
@@ -26,7 +26,7 @@ class vpgl_fm_compute_7_point
   // while the points pl are associated with the LHS.
   bool compute( const std::vector< vgl_homg_point_2d<double> >& pr,
                 const std::vector< vgl_homg_point_2d<double> >& pl,
-                std::vector< vpgl_fundamental_matrix<double>* >& fm );
+                std::vector< vpgl_fundamental_matrix<double>* >& fm ) const;
 
  protected:
   static std::vector<double> get_coeffs( vnl_double_3x3 const& F1,

--- a/core/vpgl/algo/vpgl_fm_compute_8_point.cxx
+++ b/core/vpgl/algo/vpgl_fm_compute_8_point.cxx
@@ -21,7 +21,7 @@
 bool
 vpgl_fm_compute_8_point::compute(const std::vector<vgl_homg_point_2d<double>> & pr,
                                  const std::vector<vgl_homg_point_2d<double>> & pl,
-                                 vpgl_fundamental_matrix<double> & fm)
+                                 vpgl_fundamental_matrix<double> & fm) const
 {
   // Check that there are at least 8 points.
   if (pr.size() < 8 || pl.size() < 8)

--- a/core/vpgl/algo/vpgl_fm_compute_8_point.h
+++ b/core/vpgl/algo/vpgl_fm_compute_8_point.h
@@ -31,7 +31,7 @@ class vpgl_fm_compute_8_point
   // while the points pl are associated with the LHS.
   bool compute( const std::vector< vgl_homg_point_2d<double> >& pr,
                 const std::vector< vgl_homg_point_2d<double> >& pl,
-                vpgl_fundamental_matrix<double>& fm );
+                vpgl_fundamental_matrix<double>& fm ) const;
 
  protected:
   bool precondition_;

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -674,7 +674,7 @@ vpgl_geo_camera::img_four_corners_in_utm(const unsigned ni,
                                          double & e1,
                                          double & n1,
                                          double & e2,
-                                         double & n2)
+                                         double & n2) const
 {
   if (!is_utm_)
   {

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -156,7 +156,7 @@ class vpgl_geo_camera : public vpgl_camera<double>
   int utm_zone() { return utm_zone_; }
   int utm_northing() { return northing_; }
 
-  bool img_four_corners_in_utm(const unsigned ni, const unsigned nj, double elev, double& e1, double& n1, double& e2, double& n2);
+  bool img_four_corners_in_utm(const unsigned ni, const unsigned nj, double elev, double& e1, double& n1, double& e2, double& n2) const;
 
   //: returns the corresponding geographical coordinate (lon, lat, elev) for a given pixel position (i,j,k)
   //  Note: not yet implemented -- PVr, 16 aug 2012

--- a/core/vpgl/vpgl_utm.cxx
+++ b/core/vpgl/vpgl_utm.cxx
@@ -183,7 +183,7 @@ vpgl_utm::transform(int utm_zone,
                     double & lon,
                     double & elev,
                     bool south_flag,
-                    double utm_central_meridian)
+                    double utm_central_meridian) const
 {
   // double D2R = vnl_math::pi_over_180;
   double e = std::sqrt((sqr(a_) - sqr(b_)) / sqr(a_));
@@ -302,7 +302,7 @@ vpgl_utm::transform(int utm_zone,
                     double & lat,
                     double & lon,
                     bool south_flag,
-                    double utm_central_meridian)
+                    double utm_central_meridian) const
 {
   double elev;
   this->transform(utm_zone, x, y, 0.0, lat, lon, elev, south_flag, utm_central_meridian);
@@ -312,7 +312,7 @@ vpgl_utm::transform(int utm_zone,
 }
 
 void
-vpgl_utm::transform(double lat, double lon, double & x, double & y, int & utm_zone)
+vpgl_utm::transform(double lat, double lon, double & x, double & y, int & utm_zone) const
 {
   // double D2R = vnl_math::pi_over_180;
   utm_zone = int((lon + 180) / 6.0) + 1;

--- a/core/vpgl/vpgl_utm.h
+++ b/core/vpgl/vpgl_utm.h
@@ -33,15 +33,15 @@ class vpgl_utm
   void transform(int utm_zone, double x, double y, double z,
                  double& lat, double& lon , double& elev,
                  bool south_flag = false,
-                 double utm_central_meridian = 0);
+                 double utm_central_meridian = 0) const;
 
   void transform(int utm_zone, double x, double y,
                  double& lat, double& lon,
                  bool south_flag = false,
-                 double utm_central_meridian = 0);
+                 double utm_central_meridian = 0) const;
   //: LatLon to UTM
   void transform(double lat, double lon,
-                 double& x, double& y, int& utm_zone);
+                 double& x, double& y, int& utm_zone) const;
 
  private:
   double a_, b_;

--- a/core/vul/vul_file_iterator.cxx
+++ b/core/vul/vul_file_iterator.cxx
@@ -204,7 +204,7 @@ struct vul_file_iterator_data
 
   // should be constish, and ret 0 when nuffink
   char const *
-  value()
+  value() const
   {
     if (!dir_handle_)
       return nullptr;
@@ -213,7 +213,7 @@ struct vul_file_iterator_data
 
   // Return non-dir part of fn
   char const *
-  value_filename()
+  value_filename() const
   {
     if (!dir_handle_)
       return nullptr;


### PR DESCRIPTION
Finds non-static member functions that can be made const because the functions
don’t use this in a non-const way.

This check tries to annotate methods according to logical constness (not
physical constness). Therefore, it will suggest adding a const qualifier to a
non-const method only if this method does something that is already possible
though the public interface on a const pointer to the object:

reading a public member variable calling a public const-qualified member
function returning const-qualified this passing const-qualified this as a
parameter.  This check will also suggest adding a const qualifier to a
non-const method if this method uses private data and functions in a limited
a number of ways where logical constness and physical constness coincide:
 - reading a member variable of builtin type
Specifically, this check will not suggest adding a const to a non-const
method if the method reads a private member variable of pointer type because
that allows modifying the pointee which might not preserve logical constness.
For the same reason, it does not allow to call private member functions or
member functions on private member variables.

In addition, this check ignores functions that
 - are declared virtual
 - contain a const_cast
 - are templated or part of a class template
 - have an empty body
 - do not (implicitly) use this at all (see readability-convert-member-functions-to-static).
