### PR TITLE
BUG: bsgm_compute_invalid_map

### DIFF
--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -22,6 +22,6 @@ add_subdirectory( app )
 
 add_subdirectory( pro )
 
-#if( BUILD_TESTING )
-#  add_subdirectory(tests)
-#endif()
+if( BUILD_TESTING )
+  add_subdirectory(tests)
+endif()

--- a/contrib/brl/bseg/bsgm/bsgm_error_checking.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_error_checking.cxx
@@ -312,15 +312,17 @@ bsgm_compute_invalid_map(
 
     // Find the left border
     for( int x = 0; x < w; x++ ){
-      invalid_tar(x,y) = true;
-      if( img_tar(x,y) != border_val )
+      if( img_tar(x,y) == border_val )
+        invalid_tar(x,y) = true;
+      else
         break;
     } //x
 
     // Find the right border
     for( int x = w-1; x >= 0; x-- ){
-      invalid_tar(x,y) = true;
-      if( img_tar(x,y) != border_val )
+      if( img_tar(x,y) == border_val )
+        invalid_tar(x,y) = true;
+      else
         break;
     } //x
   } //y
@@ -347,7 +349,7 @@ bsgm_compute_invalid_map(
         break;
 
     // Mask any pixels in the target image which map into the right border
-    for( int x = std::max( 0, rb - max_disparity ); x < w ; x++ )
+    for( int x = std::max( 0, rb - max_disparity + 1 ); x < w ; x++ )
       invalid_tar(x,y) = true;
   } //y
 

--- a/contrib/brl/bseg/bsgm/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+# bseg/bsgm/tests/CMakeLists.txt
+
+add_executable( bsgm_test_all
+  test_driver.cxx
+  test_error_checking.cxx
+)
+
+target_link_libraries( bsgm_test_all bsgm ${VXL_LIB_PREFIX}testlib)
+
+add_test( NAME bsgm_test_error_checking COMMAND $<TARGET_FILE:bsgm_test_all> test_compute_invalid_map)
+
+add_executable( bsgm_test_include test_include.cxx )
+target_link_libraries( bsgm_test_include bsgm)
+add_executable( bsgm_test_template_include test_template_include.cxx )
+target_link_libraries( bsgm_test_template_include bsgm)

--- a/contrib/brl/bseg/bsgm/tests/test_driver.cxx
+++ b/contrib/brl/bseg/bsgm/tests/test_driver.cxx
@@ -1,0 +1,12 @@
+#include "testlib/testlib_register.h"
+
+
+DECLARE(test_compute_invalid_map);
+
+void
+register_tests()
+{
+  REGISTER(test_compute_invalid_map);
+}
+
+DEFINE_MAIN;

--- a/contrib/brl/bseg/bsgm/tests/test_error_checking.cxx
+++ b/contrib/brl/bseg/bsgm/tests/test_error_checking.cxx
@@ -1,0 +1,82 @@
+#include <testlib/testlib_test.h>
+
+#include <bsgm/bsgm_error_checking.h>
+#include <vil/vil_image_view.h>
+
+
+static void test_compute_invalid_map()
+{
+  /*
+   * Test the bsgm_error_checking::bsgm_compute_invalid_map function.
+   * We give as input the following one-pixel tall images
+   * (where x represents a filled in value, and space represents the border value):
+   *
+   *  0 1 2 3 4 5 6
+   * | | | |x|x| | |    <- Target image
+   *
+   *  0 1 2 3 4 5 6
+   * | | |x|x|x| | |    <- Reference image
+   *
+   * And we expect to get the following invalid map as output:
+   *
+   *  0 1 2 3 4 5 6
+   * |x|x|x| |x|x|x|    <- Invalid target image
+   */
+
+  // the value in the borders of our rectified images
+  // that represents no data
+  vxl_byte border_val = 0;
+
+  // target image
+  size_t width = 7;
+  size_t height = 1;
+  vil_image_view<vxl_byte> img_target(width, height);
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      img_target(x, y) = border_val;
+    }
+  }
+  img_target(3, 0) = 1;
+  img_target(4, 0) = 1;
+
+  // reference image
+  vil_image_view<vxl_byte> img_reference(width, height);
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      img_reference(x, y) = border_val;
+    }
+  }
+  img_reference(2, 0) = 1;
+  img_reference(3, 0) = 1;
+  img_reference(4, 0) = 1;
+
+  // disparity range
+  int min_disparity = -1;
+  int max_disparity = 1;
+
+  // compute the invalid map
+  vil_image_view<bool> invalid_target;
+  bsgm_compute_invalid_map(img_target, img_reference, invalid_target,
+                           min_disparity, (max_disparity - min_disparity),
+                           border_val);
+
+  // the invalid map we expect to get
+  vil_image_view<bool> expected_invalid_target(width, height);
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      expected_invalid_target(x, y) = true;
+    }
+  }
+  expected_invalid_target(3, 0) = false;
+
+  // check if the invalid map matches what we expected
+  bool good = true;
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      good = good && (invalid_target(x, y) == expected_invalid_target(x, y));
+    }
+  }
+  TEST("Testing BSGM Compute Invalid Map", good, true);
+}
+
+TESTMAIN(test_compute_invalid_map);

--- a/contrib/brl/bseg/bsgm/tests/test_include.cxx
+++ b/contrib/brl/bseg/bsgm/tests/test_include.cxx
@@ -1,0 +1,12 @@
+#include <bsgm/bsgm_align_pointsets_3d.h>
+#include <bsgm/bsgm_census.h>
+#include <bsgm/bsgm_disparity_estimator.h>
+#include <bsgm/bsgm_error_checking.h>
+#include <bsgm/bsgm_multiscale_disparity_estimator.h>
+#include <bsgm/bsgm_pair_selector.h>
+#include <bsgm/bsgm_prob_align_pointsets_3d.h>
+#include <bsgm/bsgm_prob_pairwise_dsm.h>
+#include <bsgm/bsgm_remove_spikes.h>
+
+
+int main() { return 0; }

--- a/contrib/brl/bseg/bsgm/tests/test_template_include.cxx
+++ b/contrib/brl/bseg/bsgm/tests/test_template_include.cxx
@@ -1,0 +1,5 @@
+#include <bsgm/bsgm_align_pointsets_3d.hxx>
+#include <bsgm/bsgm_prob_align_pointsets_3d.hxx>
+
+
+int main() { return 0; }


### PR DESCRIPTION
Fixed two bounds errors in bsgm_error_checking::bsgm_compute_invalid_map. Added bsgm tests to confirm fix.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
