### PR TITLE
BUG: bsgm_prob_pairwise_dsm downscale_exponent

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.cxx
@@ -65,7 +65,8 @@ void bsgm_prob_pairwise_dsm::compute_disparity(
                            min_disparity_, num_disparities(), border_val);
 
   bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_,
-                                          num_disparities(), num_active_disparities());
+                                          num_disparities(), num_active_disparities(),
+                                          params_.downscale_exponent_);
 
   bool good = mde.compute(img, img_reference, invalid,
                           min_disparity_, invalid_disp, params_.multi_scale_mode_,
@@ -74,7 +75,7 @@ void bsgm_prob_pairwise_dsm::compute_disparity(
     throw std::runtime_error("Multiscale disparity estimator failed");
 }
 
-// compute foward disparity
+// compute forward disparity
 void bsgm_prob_pairwise_dsm::compute_disparity_fwd()
 {
   compute_disparity(rect_bview0_, rect_bview1_, invalid_map_fwd_, disparity_fwd_);

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
@@ -31,7 +31,7 @@
 // mde.compute(rect_bview0_, rect_bview1_, invalid_map_, min_disparity_,
 //             invalid_disp, params_.multi_scale_mode_, disp_r_);
 //
-// given a pixel (1182, 897) in rect_bview0 and the dispairity value at that location in the dispairity image,
+// given a pixel (1182, 897) in rect_bview0 and the disparity value at that location in the disparity image,
 // disp_r_, of -15.0, the corresponding pixel in rect_bview1 is (1167, 897)
 //
 #include <iostream>
@@ -63,7 +63,7 @@ struct pairwise_params
     quad_interp(quad_interp_);
   }
 
-  // accesors
+  // accessors
   void shadow_thresh(float thresh) {
     de_params_.shadow_thresh = thresh;
     shadow_thresh_ = thresh;
@@ -144,11 +144,11 @@ class bsgm_prob_pairwise_dsm
   void params(pairwise_params const& params) {params_ = params;}
   pairwise_params params() const {return params_;}
 
-  //: minimum dispartity to start search along an epipolar line
+  //: minimum disparity to start search along an epipolar line
   void min_disparity(int min_disparity) {min_disparity_ = min_disparity;}
   int min_disparity() const {return min_disparity_;}
 
-  //: maximum dispartity to end search along an epipolar line
+  //: maximum disparity to end search along an epipolar line
   void max_disparity(int max_disparity) {max_disparity_ = max_disparity;}
   int max_disparity() const{return max_disparity_;}
 
@@ -215,7 +215,7 @@ class bsgm_prob_pairwise_dsm
   void compute_height_fwd();
   void compute_height_rev();
 
-  //: comptute probablistic height
+  //: compute probabilistic height
   bool compute_prob();
 
   //: main process method
@@ -228,7 +228,7 @@ class bsgm_prob_pairwise_dsm
     this->compute_disparity_fwd();
     this->compute_height_fwd();
 
-    // consistency check & probablistic analysis
+    // consistency check & probabilistic analysis
     if (with_consistency_check) {
       this->compute_disparity_rev();
       this->compute_height_rev();


### PR DESCRIPTION
Even though bsgm_prob_pairwise_dsm has downscale_exponent as a parameter, it wasn't passing that parameter to the bsgm_multiscale_disparity_estimator constructor.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
