### PR TITLE
ENH: bsgm min_overlap_fraction

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
@@ -99,6 +99,9 @@ struct pairwise_params
   // upsample the rectified images by scale factor
   float upsample_scale_factor_ = 1.0f;
 
+  // minimum fraction of points in the zero disparity plane (w/in scene box) that must project into both images
+  double min_overlap_fraction_ = 0.25;
+
   // the standard deviation of consistent disparity point distances
   float std_dev_ = 3.75*ground_sample_dist_;
 

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
@@ -27,6 +27,8 @@ void bsgm_prob_pairwise_dsm<CAM_T>::rectify()
   rectify_params rp;
   rp.min_disparity_z_ = mid_z_;
   rp.upsample_scale_ = params_.upsample_scale_factor_;
+  rp.min_overlap_fraction_ = params_.min_overlap_fraction_;
+
   // rectified images
   vil_image_view<float> fview0, fview1;
   rip_.set_params(rp);


### PR DESCRIPTION

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
Add a min_overlap_fraction_ parameter to the sgm_param struct used by bsgm_prob_pairwise_dsm, and pass it along to the bpgl rectification. This allows a caller to specify a min_overlap_fraction of 0, to indicate that they don't want a bounds check. This is helpful when purposefully using a scene box much larger than the scene you expect your cameras to cover.