### PR TITLE
BUG: bsgm_disparity_estimator overflow

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.h
+++ b/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.h
@@ -111,9 +111,9 @@ class bsgm_disparity_estimator
   //: Construct from parameters
   bsgm_disparity_estimator(
     const bsgm_disparity_estimator_params& params,
-    int img_width,
-    int img_height,
-    int num_disparities );
+    long long int img_width,
+    long long int img_height,
+    long long int num_disparities );
 
   //: Destructor
   ~bsgm_disparity_estimator();
@@ -144,10 +144,10 @@ class bsgm_disparity_estimator
   bsgm_disparity_estimator_params params_;
 
   //: Size of image
-  int w_, h_;
+  long long int w_, h_;
 
   //: Number of disparities to search over.
-  int num_disparities_;
+  long long int num_disparities_;
 
   //: All appearance and smoothing costs will be normalized to discrete
   // values such that this unit corresponds to 1.0 standard deviation of
@@ -177,11 +177,11 @@ class bsgm_disparity_estimator
   void setup_cost_volume(
     std::vector<unsigned char>& cost_data,
     std::vector< std::vector< unsigned char* > >& cost,
-    int depth );
+    long long int depth );
   void setup_cost_volume(
     std::vector<unsigned short>& cost_data,
     std::vector< std::vector< unsigned short* > >& cost,
-    int depth );
+    long long int depth );
 
   //: Compute appearance data costs
   void compute_census_data(


### PR DESCRIPTION

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->

bsgm_disparity_estimator stores the SGM cost volume as a flattened 1-D vector. The size of this vector is width * height * num_disparities. With moderate image sizes and disparity ranges, this product surpasses the size of a 32 bit signed int, overflowing to a negative value. When this is passed to std::vector::resize(size_t), a much-too-large vector allocation is requested, and the program crashes.

This PR changes the type of the width, height, and num_disparities variables to long long int (64 bit) from int (32 bit on some Windows machines). I also added some range checking to the constructor.