### PR TITLE
ENH: acal_match_graph adding getters / setters

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -1,33 +1,36 @@
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
 #include <set>
-#include "vul/vul_file.h"
+#include <sstream>
+
 #include "acal_match_graph.h"
+#include "vul/vul_file.h"
 
 acal_match_graph::acal_match_graph(
-//           cam id i         cam id j            matches (i, j)
+    //       cam id i         cam id j            matches (i, j)
     std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > const& incidence_matrix)
 {
   // construct vertices
   for (std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > >::const_iterator iit = incidence_matrix.begin();
       iit != incidence_matrix.end(); ++iit) {
-      size_t i = iit->first;
-      if (!match_vertices_[i]) {
-        match_vertices_[i] = std::make_shared<match_vertex>(i);
+    size_t i = iit->first;
+    if (!match_vertices_[i]) {
+      match_vertices_[i] = std::make_shared<match_vertex>(i);
+    }
+    const std::map<size_t, std::vector<acal_match_pair> >& temp = iit->second;
+    for (std::map<size_t, std::vector<acal_match_pair> >::const_iterator jit = temp.begin();
+        jit != temp.end(); ++jit) {
+      size_t j = jit->first;
+      if (!match_vertices_[j]) {
+        match_vertices_[j] = std::make_shared<match_vertex>(j);
       }
-      const std::map<size_t, std::vector<acal_match_pair> >& temp = iit->second;
-      for (std::map<size_t, std::vector<acal_match_pair> >::const_iterator jit = temp.begin();
-          jit != temp.end(); ++jit) {
-        size_t j = jit->first;
-        if (!match_vertices_[j]) {
-          match_vertices_[j] = std::make_shared<match_vertex>(j);
-        }
-      }
+    }
   }
 
+  // construct edges
+  size_t edge_id = 0;
   for (std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > >::const_iterator iit = incidence_matrix.begin();
       iit != incidence_matrix.end(); ++iit) {
     size_t i = iit->first;
@@ -40,7 +43,8 @@ acal_match_graph::acal_match_graph(
       if (matches.size() == 0)
         continue;
       std::shared_ptr<match_vertex> v1 = match_vertices_[j];
-      std::shared_ptr<match_edge> edge(new match_edge(v0, v1, matches));
+      std::shared_ptr<match_edge> edge(new match_edge(v0, v1, matches, edge_id));
+      edge_id++;
       v0->add_edge(edge.get()); v1->add_edge(edge.get());
       match_edges_.push_back(edge);
     }

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -87,10 +87,8 @@ class acal_match_graph
   acal_match_graph() {}
   //                         cam id i         cam id j            matches i -> j
   acal_match_graph(std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > >const& incidence_matrix);
-  void set_params(match_params const& params){params_ = params;}
   bool load_from_fmatches(std::string const& fmatches_path);
   bool load_affine_cams(std::string const& affine_cam_path);
-  std::map<size_t, vpgl_affine_camera<double> >& all_acams(){return all_acams_;}
   void adjust_affine_cams(std::map<size_t, vgl_vector_2d<double> >& cam_translations);
   void clear_vertex_marks();
   std::vector<std::shared_ptr<match_vertex> > adjacent_verts(std::shared_ptr<match_vertex> const& v);
@@ -111,8 +109,48 @@ class acal_match_graph
   std::shared_ptr<acal_match_tree> largest_tree(size_t conn_comp_index);
   std::vector<std::shared_ptr<acal_match_tree> > trees(size_t conn_comp_index);
 
-  std::shared_ptr<match_vertex> vert(size_t index){return match_vertices_[index];}
-  std::map<size_t, std::shared_ptr<match_vertex> >& vertices(){return match_vertices_;}
+  // Getters
+  match_params& get_params() {return params_;}
+  std::map<size_t, std::string>& get_image_paths() {return image_paths_;}
+  std::map<size_t, vpgl_affine_camera<double> >& all_acams() {return all_acams_;}
+  std::shared_ptr<match_vertex> vert(size_t index) {return match_vertices_[index];}
+  std::map<size_t, std::shared_ptr<match_vertex> >& vertices() {return match_vertices_;}
+  std::vector<std::shared_ptr<match_edge> >& edges() {return match_edges_;}
+  std::vector<std::vector<std::shared_ptr<match_vertex> > >& get_connected_components() {return conn_comps_;}
+  std::map<size_t, std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double> > > > >& get_focus_tracks() {return focus_tracks_;}
+  std::vector<double>& get_focus_track_metrics() {return focus_track_metric_;}
+  std::map<size_t, std::map<size_t, std::shared_ptr<acal_match_tree> > >& get_match_trees() {return match_trees_;}
+  std::vector<size_t>& get_match_tree_metrics() {return match_tree_metric_;}
+
+  // Setters
+  void set_params(match_params const& params) {params_ = params;}
+  void set_image_paths(std::map<size_t, std::string> const& image_paths) {image_paths_ = image_paths;}
+  void set_all_acams(std::map<size_t, vpgl_affine_camera<double> > const& all_acams) {
+    all_acams_ = all_acams;
+  }
+  void set_vertices(std::map<size_t, std::shared_ptr<match_vertex> > const& vertices) {
+    match_vertices_ = vertices;
+  }
+  void set_edges(std::vector<std::shared_ptr<match_edge> > const& edges) {
+    match_edges_ = edges;
+  }
+  void set_connected_components(std::vector<std::vector<std::shared_ptr<match_vertex> > > const& conn_comps) {
+    conn_comps_ = conn_comps;
+  }
+  void set_focus_tracks(std::map<size_t, std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double> > > > > const& focus_tracks) {
+    focus_tracks_ = focus_tracks;
+  }
+  void set_focus_track_metrics(std::vector<double> const& focus_track_metrics) {
+    focus_track_metric_ = focus_track_metrics;
+  }
+  void set_match_trees(std::map<size_t, std::map<size_t, std::shared_ptr<acal_match_tree> > > const& match_trees) {
+    match_trees_ = match_trees;
+  }
+  void set_match_tree_metrics(std::vector<size_t> const& match_tree_metrics) {
+    match_tree_metric_ = match_tree_metrics;
+  }
+
+
 
   std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double> > > > & focus_tracks(size_t connected_comp_idx){
     return focus_tracks_[connected_comp_idx];


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->

- Adds getter and setter methods
- Properly assigns an ID to each match_edge object in the graph