### PR TITLE
ENH: contrib/brl - acal_io

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
@@ -10,22 +10,25 @@ if (WIN32)
 endif ()
 
 include_directories( ${BRL_INCLUDE_DIR}/bbas )
+include_directories( ${BRL_INCLUDE_DIR}/bbas/bpgl )
 
 set(ACAL_SOURCES
-  acal_f_utils.cxx                acal_f_utils.h
-  acal_match_utils.cxx            acal_match_utils.h
-  acal_match_tree.cxx             acal_match_tree.h
-  acal_match_graph.cxx            acal_match_graph.h
-  acal_match_tree_solver.cxx      acal_match_tree_solver.h
-  acal_intertile_graph_solver.cxx acal_intertile_graph_solver.h
-  acal_solution_error.h
-  acal_metadata.h
-  acal_planar_feature_matcher.h   acal_planar_feature_matcher.cxx
-  acal_tile_data_manager.h        acal_tile_data_manager.cxx
+    acal_f_utils.h                  acal_f_utils.cxx
+    acal_intertile_graph_solver.h   acal_intertile_graph_solver.cxx
+    acal_match_utils.h              acal_match_utils.cxx
+    acal_match_tree.h               acal_match_tree.cxx
+    acal_match_graph.h              acal_match_graph.cxx
+    acal_match_tree_solver.h        acal_match_tree_solver.cxx
+    acal_metadata.h
+    acal_planar_feature_matcher.h   acal_planar_feature_matcher.cxx
+    acal_solution_error.h
+    acal_tile_data_manager.h        acal_tile_data_manager.cxx
 )
 
-add_library(acal ${ACAL_SOURCES})
+vxl_add_library(LIBRARY_NAME acal LIBRARY_SOURCES ${ACAL_SOURCES})
 
 target_link_libraries(acal brip vpgl vpgl_algo bjson bvgl vbl vgl vil_algo vil vcl)
 
-add_subdirectory(tests)
+if( BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
@@ -29,6 +29,8 @@ vxl_add_library(LIBRARY_NAME acal LIBRARY_SOURCES ${ACAL_SOURCES})
 
 target_link_libraries(acal brip vpgl vpgl_algo bjson bvgl vbl vgl vil_algo vil vcl)
 
+add_subdirectory(io)
+
 if( BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -33,10 +33,27 @@ struct match_params
 {
   match_params() : min_n_tracks_(3), min_n_cams_(3), max_proj_error_(1.0), max_uncal_proj_error_(20.0) {}
 
+  match_params(size_t min_n_tracks, size_t min_n_cams,
+               double max_proj_error, double max_uncal_proj_error)
+    : min_n_tracks_(min_n_tracks), min_n_cams_(min_n_cams),
+      max_proj_error_(max_proj_error), max_uncal_proj_error_(max_uncal_proj_error)
+  {}
+
   size_t min_n_tracks_;
   size_t min_n_cams_;
   double max_proj_error_;
   double max_uncal_proj_error_;
+
+  bool operator==(match_params const& other) const {
+    return this->min_n_tracks_ == other.min_n_tracks_ &&
+           this->min_n_cams_ == other.min_n_cams_ &&
+           this->max_proj_error_ == other.max_proj_error_ &&
+           this->max_uncal_proj_error_ == other.max_uncal_proj_error_;
+  }
+  bool operator!=(match_params const& other) const {
+    return !(*this == other);
+  }
+
 };
 
 class match_vertex

--- a/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
@@ -26,21 +26,45 @@
 
 
 // a simple feature structure, just id and location
-struct acal_corr{
-	acal_corr() : id_(-1) { pt_.set(-1, -1); }
-  acal_corr(size_t id, vgl_point_2d<double> const& pt):id_(id),pt_(pt) {}
+struct acal_corr
+{
+  acal_corr() : id_(-1) { pt_.set(-1, -1); }
+  acal_corr(size_t id, vgl_point_2d<double> const& pt)
+    : id_(id), pt_(pt)
+  {}
+
   size_t id_;
   vgl_point_2d<double> pt_; // correspondence point
+
+  bool operator==(acal_corr const& other) const {
+    return this->id_ == other.id_ &&
+           this->pt_ == other.pt_;
+  }
+  bool operator!=(acal_corr const& other) const {
+    return !(*this == other);
+  }
 };
 
 
 // a structure to hold information regarding correspondence matches
-struct acal_match_pair{
-acal_match_pair(){}
-acal_match_pair(acal_corr const& corr1, acal_corr const& corr2):
-  corr1_(corr1), corr2_(corr2){}
+struct acal_match_pair
+{
+  acal_match_pair() {}
+  acal_match_pair(acal_corr const& corr1, acal_corr const& corr2)
+    : corr1_(corr1), corr2_(corr2)
+  {}
+
   acal_corr corr1_;// sift feature id and position in image 1
   acal_corr corr2_;// sift feature id and position in image 2
+
+  bool operator==(acal_match_pair const& other) const {
+    return this->corr1_ == other.corr1_ &&
+           this->corr2_ == other.corr2_;
+  }
+  bool operator!=(acal_match_pair const& other) const {
+    return !(*this == other);
+  }
+
   static bool near_equal(acal_match_pair const& mpa, acal_match_pair const& mpb, double tol = 0.1){
     vgl_vector_2d<double> dif1 = mpa.corr1_.pt_-mpb.corr1_.pt_;
     vgl_vector_2d<double> dif2 = mpa.corr2_.pt_ -mpb.corr2_.pt_;

--- a/contrib/brl/bbas/bpgl/acal/io/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/io/CMakeLists.txt
@@ -1,0 +1,14 @@
+# acal/io/CMakeLists.txt
+
+set(acal_io_sources
+    acal_io_match_graph.h  acal_io_match_graph.cxx
+    acal_io_match_utils.h  acal_io_match_utils.cxx
+)
+
+vxl_add_library(LIBRARY_NAME acal_io LIBRARY_SOURCES ${acal_io_sources})
+
+target_link_libraries(acal_io ${VXL_LIB_PREFIX}acal ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vsl)
+
+if( BUILD_TESTING )
+  add_subdirectory(tests)
+endif()

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_match_graph.cxx
@@ -1,0 +1,76 @@
+#include <iostream>
+#include "acal_io_match_graph.h"
+
+
+// -----match_params-----
+
+//: Binary save object to stream
+void
+vsl_b_write(vsl_b_ostream & os, const match_params& obj)
+{
+  constexpr short io_version_no = 1;
+  vsl_b_write(os, io_version_no);
+  vsl_b_write(os, obj.min_n_tracks_);
+  vsl_b_write(os, obj.min_n_cams_);
+  vsl_b_write(os, obj.max_proj_error_);
+  vsl_b_write(os, obj.max_uncal_proj_error_);
+}
+
+//: Binary load object from stream
+void
+vsl_b_read(vsl_b_istream & is, match_params& obj)
+{
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+      vsl_b_read(is, obj.min_n_tracks_);
+      vsl_b_read(is, obj.min_n_cams_);
+      vsl_b_read(is, obj.max_proj_error_);
+      vsl_b_read(is, obj.max_uncal_proj_error_);
+      break;
+
+    default:
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, match_params&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit); // Set an unrecoverable IO error on stream
+      return;
+  }
+}
+
+
+// -----acal_match_graph-----
+
+//: Binary save object to stream
+void
+vsl_b_write(vsl_b_ostream & os, const acal_match_graph& obj)
+{
+  constexpr short io_version_no = 1;
+  vsl_b_write(os, io_version_no);
+  // TODO
+}
+
+//: Binary load object from stream
+void
+vsl_b_read(vsl_b_istream & is, acal_match_graph& obj)
+{
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+      // TODO
+      break;
+
+    default:
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, acal_match_graph&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit); // Set an unrecoverable IO error on stream
+      return;
+  }
+}

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_match_graph.h
@@ -1,0 +1,21 @@
+// This is acal/io/acal_io_match_graph.h
+#ifndef acal_io_match_graph_h_
+#define acal_io_match_graph_h_
+
+#include <vsl/vsl_binary_io.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <acal/acal_match_graph.h>
+
+//: match_params
+void vsl_b_write(vsl_b_ostream &os, const match_params& obj);
+void vsl_b_read(vsl_b_istream &is, match_params& obj);
+
+//: TODO acal_match_graph
+// void vsl_b_write(vsl_b_ostream &os, const acal_match_graph& obj);
+// void vsl_b_read(vsl_b_istream &is, acal_match_graph& obj);
+
+
+#endif // acal_io_match_graph_h_

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_match_utils.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_match_utils.cxx
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <vgl/io/vgl_io_point_2d.h>
+#include "acal_io_match_utils.h"
+
+
+// -----acal_corr-----
+
+//: Binary save object to stream.
+void
+vsl_b_write(vsl_b_ostream & os, const acal_corr& obj)
+{
+  constexpr short io_version_no = 1;
+  vsl_b_write(os, io_version_no);
+  vsl_b_write(os, obj.id_);
+  vsl_b_write(os, obj.pt_);
+}
+
+//: Binary load object from stream.
+void
+vsl_b_read(vsl_b_istream & is, acal_corr& obj)
+{
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+      vsl_b_read(is, obj.id_);
+      vsl_b_read(is, obj.pt_);
+      break;
+
+    default:
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, acal_corr&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit); // Set an unrecoverable IO error on stream
+      return;
+  }
+}
+
+
+// -----acal_match_pait-----
+
+//: Binary save object to stream.
+void
+vsl_b_write(vsl_b_ostream & os, const acal_match_pair& obj)
+{
+  constexpr short io_version_no = 1;
+  vsl_b_write(os, io_version_no);
+  vsl_b_write(os, obj.corr1_);
+  vsl_b_write(os, obj.corr2_);
+}
+
+//: Binary load object from stream.
+void
+vsl_b_read(vsl_b_istream & is, acal_match_pair& obj)
+{
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+      vsl_b_read(is, obj.corr1_);
+      vsl_b_read(is, obj.corr2_);
+      break;
+
+    default:
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, acal_match_pair&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit); // Set an unrecoverable IO error on stream
+      return;
+  }
+}
+

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_match_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_match_utils.h
@@ -1,0 +1,21 @@
+// This is acal/io/acal_io_match_utils.h
+#ifndef acal_io_match_utils_h_
+#define acal_io_match_utils_h_
+
+#include <vsl/vsl_binary_io.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <acal/acal_match_utils.h>
+
+//: acal_corr
+void vsl_b_write(vsl_b_ostream &os, const acal_corr& obj);
+void vsl_b_read(vsl_b_istream &is, acal_corr& obj);
+
+//: acal_match_pair
+void vsl_b_write(vsl_b_ostream &os, const acal_match_pair& obj);
+void vsl_b_read(vsl_b_istream &is, acal_match_pair& obj);
+
+
+#endif // acal_io_match_utils_h_

--- a/contrib/brl/bbas/bpgl/acal/io/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+# acal/io/tests/CMakeLists.txt
+
+set(acal_io_test_sources
+    test_driver.cxx
+    test_generic_io.h
+
+    test_match_graph_io.cxx
+    test_match_utils_io.cxx
+)
+
+add_executable(acal_io_test_all ${acal_io_test_sources})
+target_link_libraries(acal_io_test_all ${VXL_LIB_PREFIX}acal_io ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}testlib )
+
+add_test( NAME acal_test_match_graph_io COMMAND $<TARGET_FILE:acal_io_test_all> test_match_graph_io )
+add_test( NAME acal_test_match_utils_io COMMAND $<TARGET_FILE:acal_io_test_all> test_match_utils_io )
+
+add_executable( acal_io_test_include test_include.cxx )
+target_link_libraries( acal_io_test_include ${VXL_LIB_PREFIX}acal_io )

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_driver.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_driver.cxx
@@ -1,0 +1,13 @@
+#include "testlib/testlib_register.h"
+
+DECLARE(test_match_graph_io);
+DECLARE(test_match_utils_io);
+
+void
+register_tests()
+{
+  REGISTER(test_match_graph_io);
+  REGISTER(test_match_utils_io);
+}
+
+DEFINE_MAIN;

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_generic_io.h
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_generic_io.h
@@ -1,0 +1,58 @@
+// This is acal/io/test/test_utils.h
+#ifndef acal_io_test_utils_h_
+#define acal_io_test_utils_h_
+
+// This is acal/io/tests/test_acal_io_match_utils.cxx
+#include <iostream>
+#ifdef _MSC_VER
+#  include "vcl_msvc_warnings.h"
+#endif
+
+#include "testlib/testlib_test.h"
+#include "vsl/vsl_binary_io.h"
+#include "vsl/vsl_indent.h"
+#include "vpl/vpl.h"
+
+//: Generic test for acal io classes.  Requires the class TEST_T to have
+// defined vsl_b_write, vsl_b_read, and an equality operator
+template <class TEST_T>
+void test_generic_io(const TEST_T& obj, std::string name)
+{
+  // note
+  std::cout << "*******************************\n"
+            << " Testing " << name << "\n"
+            << "*******************************\n";
+
+  // temporary file & message
+  std::string tmp_file = name + ".bvl.tmp";
+
+  // output
+  vsl_b_ofstream os(tmp_file.c_str(), std::ios::out | std::ios::binary);
+  TEST(("Created " + tmp_file + " for writing").c_str(), (!os), false);
+  vsl_b_write(os, obj);
+  os.close();
+
+  // input
+  vsl_b_ifstream is(tmp_file.c_str(), std::ios::in | std::ios::binary);
+  TEST(("Opened " + tmp_file + " for reading").c_str(), (!is), false);
+
+  TEST_T obj_copy;
+  vsl_b_read(is, obj_copy);
+  TEST(("Finished reading " + tmp_file).c_str(), (!is), false);
+  is.close();
+
+  // remove file
+  vpl_unlink(tmp_file.c_str());
+
+  // test equality
+  TEST("object == vsl_b_read(vsl_b_write(object))", obj, obj_copy);
+
+  // // print summary
+  // vsl_print_summary(std::cout, obj_copy);
+  // std::cout << std::endl;
+
+  // cleanup
+  vsl_indent_clear_all_data();
+}
+
+#endif // acal_io_test_utils_h_

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_include.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_include.cxx
@@ -1,0 +1,7 @@
+#include <acal/io/acal_io_match_graph.h>
+#include <acal/io/acal_io_match_utils.h>
+
+int
+main() {
+  return 0;
+}

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_match_graph_io.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_match_graph_io.cxx
@@ -1,0 +1,17 @@
+// acal/io/tests/test_match_graph_io.cxx
+#include "test_generic_io.h"
+#include <acal/io/acal_io_match_graph.h>
+
+static void
+test_match_graph_io()
+{
+  // match_params io test
+  match_params mp(10, 10, 0.5f, 0.5f);
+  test_generic_io(mp, "match_params");
+
+  // acal_match_graph io test
+  // TODO
+
+}
+
+TESTMAIN(test_match_graph_io);

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_match_utils_io.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_match_utils_io.cxx
@@ -1,0 +1,20 @@
+// acal/io/tests/test_match_utils_io.cxx
+#include "test_generic_io.h"
+#include <acal/io/acal_io_match_utils.h>
+
+static void
+test_match_utils_io()
+{
+  // acal_corr io test
+  acal_corr ac(818, vgl_point_2d<double>(188.987, 227.430));
+  test_generic_io(ac, "acal_corr");
+
+  // acal_match_pair io test
+  acal_corr ac_a( 818, vgl_point_2d<double>(188.987, 227.430));
+  acal_corr ac_b(1617, vgl_point_2d<double>(278.163, 315.765));
+  acal_match_pair mp(ac_a, ac_b);
+  test_generic_io(mp, "acal_match_pair");
+
+}
+
+TESTMAIN(test_match_utils_io);

--- a/contrib/brl/bbas/bpgl/acal/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/tests/CMakeLists.txt
@@ -2,15 +2,19 @@
 add_executable( acal_test_all
   test_driver.cxx
   test_f_utils.cxx
-  test_metadata.cxx
-  test_match_utils.cxx
+  test_match_graph.cxx
   test_match_tree.cxx
+  test_match_utils.cxx
+  test_metadata.cxx
 )
 
 target_link_libraries( acal_test_all ${VXL_LIB_PREFIX}acal ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}testlib )
 
 add_test( NAME acal_test_f_utils COMMAND $<TARGET_FILE:acal_test_all> test_f_utils )
-add_test( NAME acal_test_metadata COMMAND $<TARGET_FILE:acal_test_all> test_metadata )
-add_test( NAME acal_test_match_utils COMMAND $<TARGET_FILE:acal_test_all> test_match_utils )
+add_test( NAME acal_test_match_graph COMMAND $<TARGET_FILE:acal_test_all> test_match_graph )
 add_test( NAME acal_test_match_tree COMMAND $<TARGET_FILE:acal_test_all> test_match_tree )
+add_test( NAME acal_test_match_utils COMMAND $<TARGET_FILE:acal_test_all> test_match_utils )
+add_test( NAME acal_test_metadata COMMAND $<TARGET_FILE:acal_test_all> test_metadata )
 
+add_executable( acal_test_include test_include.cxx )
+target_link_libraries( acal_test_include ${VXL_LIB_PREFIX}acal )

--- a/contrib/brl/bbas/bpgl/acal/tests/test_driver.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_driver.cxx
@@ -1,15 +1,19 @@
 #include "testlib/testlib_register.h"
 
 DECLARE( test_f_utils );
-DECLARE( test_metadata );
-DECLARE( test_match_utils );
+DECLARE( test_match_graph );
 DECLARE( test_match_tree );
+DECLARE( test_match_utils );
+DECLARE( test_metadata );
 
-void register_tests()
+void
+register_tests()
 {
   REGISTER( test_f_utils );
-  REGISTER( test_metadata );
-  REGISTER( test_match_utils );
+  REGISTER( test_match_graph );
   REGISTER( test_match_tree );
+  REGISTER( test_match_utils );
+  REGISTER( test_metadata );
 }
+
 DEFINE_MAIN;

--- a/contrib/brl/bbas/bpgl/acal/tests/test_include.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_include.cxx
@@ -1,0 +1,15 @@
+#include <acal/acal_f_utils.h>
+#include <acal/acal_intertile_graph_solver.h>
+#include <acal/acal_match_graph.h>
+#include <acal/acal_match_tree.h>
+#include <acal/acal_match_tree_solver.h>
+#include <acal/acal_match_utils.h>
+#include <acal/acal_match_utils.h>
+#include <acal/acal_planar_feature_matcher.h>
+#include <acal/acal_solution_error.h>
+#include <acal/acal_tile_data_manager.h>
+
+int
+main() {
+  return 0;
+}

--- a/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
@@ -1,0 +1,14 @@
+#include "testlib/testlib_test.h"
+
+#include <acal/acal_match_graph.h>
+
+static void test_match_graph()
+{
+  // eqaulity tests
+  match_params mp1(10, 10, 0.5f, 0.5f), mp2(10, 10, 0.5f, 0.5f), mp3;
+  TEST("match_params equality", mp1, mp2);
+  TEST("match_params inequality", mp1 != mp3, true);
+
+}
+
+TESTMAIN(test_match_graph);

--- a/contrib/brl/bbas/bpgl/acal/tests/test_match_utils.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_match_utils.cxx
@@ -12,6 +12,25 @@
 
 static void test_match_utils()
 {
+  // equality tests
+  acal_corr ac_a( 818, vgl_point_2d<double>(188.987, 227.430));
+  acal_corr ac_b(1617, vgl_point_2d<double>(278.163, 315.765));
+  acal_match_pair mp_ab(ac_a, ac_b);
+
+  acal_corr ac_c( 818, vgl_point_2d<double>(188.987, 227.430));
+  acal_corr ac_d(1617, vgl_point_2d<double>(278.163, 315.765));
+  acal_match_pair mp_cd(ac_c, ac_d);
+
+  acal_corr ac_e( 983, vgl_point_2d<double>(109.553, 284.380));
+  acal_corr ac_f(1834, vgl_point_2d<double>(150.748, 361.344));
+  acal_match_pair mp_ef(ac_e, ac_f);
+
+  TEST("acal_corr equality", ac_a, ac_c);
+  TEST("acal_corr inequality", ac_a != ac_b, true);
+
+  TEST("acal_match_pair equality", mp_ab, mp_cd);
+  TEST("acal_match_pair inequality", mp_ab != mp_ef, true);
+
   // 12 -> 21
   acal_corr c11( 818, vgl_point_2d<double>(188.987, 227.430));
   acal_corr c12(1617, vgl_point_2d<double>(278.163, 315.765));


### PR DESCRIPTION
Add contrib/brl acal I/O operations via `vsl_b_write` and `vsl_b_read`.  New unit tests for IO operations.  Other supporting changes.

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
