### PR TITLE
BUG: acal match_tree destructor

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -356,8 +356,8 @@ acal_match_graph::compute_match_trees()
       size_t fidx = f_vert->cam_id_;
       // make the match tree a pointer so a delete isn't called when exiting the scope of a function
       // note that delete clears the children in a bottom up order and sets the parent pointer to 0
-      std::shared_ptr<acal_match_tree> mt_ptr(new acal_match_tree());
-      mt_ptr->root_ = std::shared_ptr<acal_match_node>(new acal_match_node(fidx));
+      std::shared_ptr<acal_match_node> root(new acal_match_node(fidx));
+      std::shared_ptr<acal_match_tree> mt_ptr(new acal_match_tree(root));
       std::map<size_t, std::shared_ptr<match_vertex> > active_verts;
       active_verts[fidx] = f_vert;
       std::set<size_t> used_verts;     // vertices already explored for a given focus vertex

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
@@ -259,6 +259,10 @@ acal_match_tree::depth_sorted_nodes()
 
 acal_match_tree::~acal_match_tree()
 {
+  if (root_ == nullptr) {
+    return;
+  }
+
   std::vector<acal_match_node*> dsort = this->depth_sorted_nodes();
   for (std::vector<acal_match_node*>::iterator nit = dsort.begin();
        nit != dsort.end(); ++nit) {

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
@@ -24,6 +24,7 @@ acal_match_tree::add_child_node(
     size_t parent_id, size_t child_id,
     std::vector<acal_match_pair> const& parent_to_child_matches)
 {
+
   size_t min_n = 0;
   if(min_n_tracks_>=1)
     min_n = min_n_tracks_ -1;
@@ -259,10 +260,6 @@ acal_match_tree::depth_sorted_nodes()
 
 acal_match_tree::~acal_match_tree()
 {
-  if (root_ == nullptr) {
-    return;
-  }
-
   std::vector<acal_match_node*> dsort = this->depth_sorted_nodes();
   for (std::vector<acal_match_node*>::iterator nit = dsort.begin();
        nit != dsort.end(); ++nit) {
@@ -276,11 +273,11 @@ void
 acal_match_tree::n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n)
 {
   size_t nc = node->size();
-  if(nc == 0){
+  if (nc == 0) {
     n++;
     return;
   }
-  for(size_t c = 0; c<nc; ++c)
+  for (size_t c = 0; c<nc; ++c)
     n_nodes(node->children_[c], n);
   n++;
   return;

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
@@ -92,6 +92,8 @@ class acal_match_tree
 {
  public:
 
+  acal_match_tree()
+    : n_(0), min_n_tracks_(1), root_(nullptr) {}
   acal_match_tree(std::shared_ptr<acal_match_node> root)
     : n_(1), min_n_tracks_(1), root_(root) {}
   ~acal_match_tree();

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
@@ -92,23 +92,26 @@ class acal_match_tree
 {
  public:
 
-  acal_match_tree():n_(0), min_n_tracks_(1){}
+  acal_match_tree(std::shared_ptr<acal_match_node> root)
+    : n_(1), min_n_tracks_(1), root_(root) {}
   ~acal_match_tree();
-  size_t size(){return n_;}
-  void update_tree_size(){
+
+  size_t size() {return n_;}
+
+  void update_tree_size() {
     n_ = 0;
     n_nodes(root_, n_);
   }
 
-  //: initialize the tree
-  void create_root(size_t node_id, size_t child_id, std::vector<acal_match_pair> const& node_to_child_matches){
-    root_ = std::shared_ptr<acal_match_node>(new acal_match_node(node_id, child_id, node_to_child_matches));
-  }
+  /* //: initialize the tree */
+  /* void create_root(size_t node_id, size_t child_id, std::vector<acal_match_pair> const& node_to_child_matches){ */
+  /*   root_ = std::shared_ptr<acal_match_node>(new acal_match_node(node_id, child_id, node_to_child_matches)); */
+  /* } */
 
-  //: add a child node and reconcile the correpondence pairs globally over the full tree
+  //: add a child node and reconcile the correspondence pairs globally over the full tree
   bool add_child_node(size_t parent_id, size_t child_id, std::vector<acal_match_pair> const& parent_to_child_matches);
 
-  //: prune correpondence pairs to insure consistent tracks over the full tree
+  //: prune correspondence pairs to insure consistent tracks over the full tree
   bool prune_tree(std::shared_ptr<acal_match_node> const& mutated_parent_node, size_t child_index);
 
   //: recursively remove correspondence pairs that are not present in reduced node corrs
@@ -118,7 +121,7 @@ class acal_match_tree
   static std::shared_ptr<acal_match_node> find(std::shared_ptr<acal_match_node> const& node, size_t cam_id);
 
   //: recursively find the number of nodes below a node in the tree
-  void  n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n);
+  void n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n);
 
   // debug methods
   //: save the tree in dot format for display

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
@@ -105,11 +105,6 @@ class acal_match_tree
     n_nodes(root_, n_);
   }
 
-  /* //: initialize the tree */
-  /* void create_root(size_t node_id, size_t child_id, std::vector<acal_match_pair> const& node_to_child_matches){ */
-  /*   root_ = std::shared_ptr<acal_match_node>(new acal_match_node(node_id, child_id, node_to_child_matches)); */
-  /* } */
-
   //: add a child node and reconcile the correspondence pairs globally over the full tree
   bool add_child_node(size_t parent_id, size_t child_id, std::vector<acal_match_pair> const& parent_to_child_matches);
 

--- a/contrib/brl/bbas/bpgl/acal/tests/test_match_tree.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_match_tree.cxx
@@ -63,8 +63,7 @@ static void test_match_tree()
   std::shared_ptr<acal_match_node> child = acal_match_tree::find(root, 21);
   TEST("test parent child constructor, find", bool(child), true);
 
-  acal_match_tree mt;
-  mt.root_ = root;
+  acal_match_tree mt(root);
 
   mt.add_child_node(21, 22, mpairs_a);
   mt.add_child_node(12, 210, mpairs_b);


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
-  :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
Adds a guard to the acal_match_tree destructor to prevent segfaults when root_ hasn't been initialized.