### PR TITLE
ENH: contrib/brl - acal io & tests

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_f_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_f_utils.h
@@ -39,11 +39,24 @@ struct f_params
   double F_similar_e_tol_;     //max abs value of offset, e to determine similar images
   double ray_uncertainty_tol_; //max ray uncertainty to keep camera pair
   size_t min_num_matches_;     //minimum number of required matches to output to fmatches file
+
+  bool operator==(f_params const& other) const {
+    return this->epi_dist_mul_ == other.epi_dist_mul_ &&
+           this->max_epi_dist_ == other.max_epi_dist_ &&
+           this->F_similar_abcd_tol_ == other.F_similar_abcd_tol_ &&
+           this->F_similar_e_tol_ == other.F_similar_e_tol_ &&
+           this->ray_uncertainty_tol_ == other.ray_uncertainty_tol_ &&
+           this->min_num_matches_ == other.min_num_matches_;
+  }
+  bool operator!=(f_params const& other) const {
+    return !(*this == other);
+  }
+
 };
 
 struct dtime
 {
-	dtime() {}
+  dtime() {}
   dtime(unsigned year, unsigned month, unsigned day, unsigned hours, unsigned minutes, unsigned seconds):
   year_(year), month_(month), day_(day), hours_(hours), minutes_(minutes), seconds_(seconds){}
 

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -9,6 +9,13 @@
 #include "vul/vul_file.h"
 
 acal_match_graph::acal_match_graph(
+    std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > const& incidence_matrix)
+{
+  bool success = this->load_incidence_matrix(incidence_matrix);
+}
+
+bool
+acal_match_graph::load_incidence_matrix(
     //       cam id i         cam id j            matches (i, j)
     std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > const& incidence_matrix)
 {
@@ -49,6 +56,8 @@ acal_match_graph::acal_match_graph(
       match_edges_.push_back(edge);
     }
   }
+
+  return true;
 }
 
 bool
@@ -59,7 +68,10 @@ acal_match_graph::load_from_fmatches(std::string const& fmatches_path)
   bool good = acal_f_utils::read_f_matches(fmatches_path, fmatches, image_paths);
   if (!good)
     return false;
-  *this = acal_match_graph(fmatches);
+
+  if (!this->load_incidence_matrix(fmatches))
+    return false;
+
   image_paths_ = image_paths;
   return true;
 }

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -103,7 +103,9 @@ class acal_match_graph
  public:
   acal_match_graph() {}
   //                         cam id i         cam id j            matches i -> j
-  acal_match_graph(std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > >const& incidence_matrix);
+  acal_match_graph(std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > const& incidence_matrix);
+
+  bool load_incidence_matrix(std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > const& incidence_matrix);
   bool load_from_fmatches(std::string const& fmatches_path);
   bool load_affine_cams(std::string const& affine_cam_path);
   void adjust_affine_cams(std::map<size_t, vgl_vector_2d<double> >& cam_translations);

--- a/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
@@ -45,6 +45,11 @@ struct acal_corr
   }
 };
 
+inline std::ostream& operator<<(std::ostream& os, acal_corr const& corr)
+{
+  return os << "(" << corr.id_ << ", " << corr.pt_ << ")";
+}
+
 
 // a structure to hold information regarding correspondence matches
 struct acal_match_pair
@@ -73,6 +78,11 @@ struct acal_match_pair
     return ((dist1 < tol) && (dist2 < tol));
   }
 };
+
+inline std::ostream& operator<<(std::ostream& os, acal_match_pair const& mp)
+{
+  return os << "[" << mp.corr1_ << ", " << mp.corr2_ << "]";
+}
 
 
 class acal_match_utils

--- a/contrib/brl/bbas/bpgl/acal/io/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/io/CMakeLists.txt
@@ -1,6 +1,7 @@
 # acal/io/CMakeLists.txt
 
 set(acal_io_sources
+    acal_io_f_utils.h      acal_io_f_utils.cxx
     acal_io_match_graph.h  acal_io_match_graph.cxx
     acal_io_match_utils.h  acal_io_match_utils.cxx
 )

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_f_utils.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_f_utils.cxx
@@ -1,0 +1,47 @@
+#include <iostream>
+#include "acal_io_f_utils.h"
+
+
+// -----f_params-----
+
+//: Binary save object to stream.
+void
+vsl_b_write(vsl_b_ostream & os, const f_params& obj)
+{
+  constexpr short io_version_no = 1;
+  vsl_b_write(os, io_version_no);
+  vsl_b_write(os, obj.epi_dist_mul_);
+  vsl_b_write(os, obj.max_epi_dist_);
+  vsl_b_write(os, obj.F_similar_abcd_tol_);
+  vsl_b_write(os, obj.F_similar_e_tol_);
+  vsl_b_write(os, obj.ray_uncertainty_tol_);
+  vsl_b_write(os, obj.min_num_matches_);
+}
+
+//: Binary load object from stream.
+void
+vsl_b_read(vsl_b_istream & is, f_params& obj)
+{
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+      vsl_b_read(is, obj.epi_dist_mul_);
+      vsl_b_read(is, obj.max_epi_dist_);
+      vsl_b_read(is, obj.F_similar_abcd_tol_);
+      vsl_b_read(is, obj.F_similar_e_tol_);
+      vsl_b_read(is, obj.ray_uncertainty_tol_);
+      vsl_b_read(is, obj.min_num_matches_);
+      break;
+
+    default:
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, f_params&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit); // Set an unrecoverable IO error on stream
+      return;
+  }
+}
+

--- a/contrib/brl/bbas/bpgl/acal/io/acal_io_f_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/io/acal_io_f_utils.h
@@ -1,0 +1,17 @@
+// This is acal/io/acal_io_f_utils.h
+#ifndef acal_io_f_utils_h_
+#define acal_io_f_utils_h_
+
+#include <vsl/vsl_binary_io.h>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+#include <acal/acal_f_utils.h>
+
+//: acal_corr
+void vsl_b_write(vsl_b_ostream &os, const f_params& obj);
+void vsl_b_read(vsl_b_istream &is, f_params& obj);
+
+
+#endif

--- a/contrib/brl/bbas/bpgl/acal/io/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(acal_io_test_sources
     test_driver.cxx
     test_generic_io.h
 
+    test_f_utils_io.cxx
     test_match_graph_io.cxx
     test_match_utils_io.cxx
 )
@@ -11,6 +12,7 @@ set(acal_io_test_sources
 add_executable(acal_io_test_all ${acal_io_test_sources})
 target_link_libraries(acal_io_test_all ${VXL_LIB_PREFIX}acal_io ${VXL_LIB_PREFIX}vpl ${VXL_LIB_PREFIX}testlib )
 
+add_test( NAME acal_test_f_utils_io COMMAND $<TARGET_FILE:acal_io_test_all> test_f_utils_io )
 add_test( NAME acal_test_match_graph_io COMMAND $<TARGET_FILE:acal_io_test_all> test_match_graph_io )
 add_test( NAME acal_test_match_utils_io COMMAND $<TARGET_FILE:acal_io_test_all> test_match_utils_io )
 

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_driver.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_driver.cxx
@@ -1,11 +1,13 @@
 #include "testlib/testlib_register.h"
 
+DECLARE(test_f_utils_io);
 DECLARE(test_match_graph_io);
 DECLARE(test_match_utils_io);
 
 void
 register_tests()
 {
+  REGISTER(test_f_utils_io);
   REGISTER(test_match_graph_io);
   REGISTER(test_match_utils_io);
 }

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_f_utils_io.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_f_utils_io.cxx
@@ -1,0 +1,21 @@
+// acal/io/tests/test_f_utils_io.cxx
+#include "test_generic_io.h"
+#include <acal/io/acal_io_f_utils.h>
+
+static void
+test_f_utils_io()
+{
+  // f_params io test
+  f_params fp;
+  fp.epi_dist_mul_ = 3.5;
+  fp.max_epi_dist_ = 6.0;
+  fp.F_similar_abcd_tol_ = 0.05;
+  fp.F_similar_e_tol_ = 2.0;
+  fp.ray_uncertainty_tol_ = 60.0;
+  fp.min_num_matches_ = 10;
+
+  test_generic_io(fp, "f_params");
+
+}
+
+TESTMAIN(test_f_utils_io);

--- a/contrib/brl/bbas/bpgl/acal/io/tests/test_include.cxx
+++ b/contrib/brl/bbas/bpgl/acal/io/tests/test_include.cxx
@@ -1,3 +1,4 @@
+#include <acal/io/acal_io_f_utils.h>
 #include <acal/io/acal_io_match_graph.h>
 #include <acal/io/acal_io_match_utils.h>
 

--- a/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
@@ -1,13 +1,167 @@
 #include "testlib/testlib_test.h"
 
-#include <acal/acal_match_graph.h>
+#include <vgl/vgl_point_2d.h>
+#include <vgl/vgl_point_3d.h>
+#include <vgl/vgl_vector_3d.h>
+#include <vpgl/vpgl_affine_camera.h>
 
-static void test_match_graph()
+#include <acal/acal_match_graph.h>
+#include <acal/acal_match_utils.h>
+
+
+// helper: create affine cameras with defaults.
+// This function uses the vpgl_affine_camera constructor:
+// vpgl_affine_camera<T>(vgl_vector_3d<T> ray, vgl_vector_3d<T> up,
+//                       vgl_point_3d<T> stare_pt, T u0, T v0, T su, T sv)
+template <class T>
+vpgl_affine_camera<T>
+make_affine_camera(T rayx, T rayy, T rayz,
+                   T upx = T(0), T upy = T(0), T upz = T(1),
+                   T ptx = T(0), T pty = T(0), T ptz = T(0),
+                   T u0 = T(0), T v0 = T(0), T su = T(1), T sv = T(1))
 {
-  // eqaulity tests
+  return vpgl_affine_camera<T>(vgl_vector_3d<T>(rayx, rayy, rayz),
+                               vgl_vector_3d<T>(upx, upy, upz),
+                               vgl_point_3d<T>(ptx, pty, ptz),
+                               u0, v0, su, sv);
+}
+
+// helper: update incidence_matrix with points & pairs of cams
+void
+update_incidence_matrix(
+    std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > >& incidence_matrix,
+    std::vector<vgl_point_3d<double> > const& pts,
+    std::vector<std::pair<size_t, size_t> > const& pairs,
+    std::map<size_t, vpgl_affine_camera<double> > const& cams)
+{
+  for (auto pair : pairs) {
+    size_t i = pair.first, j = pair.second;
+
+    std::vector<acal_match_pair> vec;
+    for (size_t k = 0; k < pts.size(); k++) {
+      auto pti = cams.at(i).project(pts[k]);
+      auto ptj = cams.at(j).project(pts[k]);
+      acal_match_pair mp(acal_corr(k, pti), acal_corr(k, ptj));
+      vec.push_back(mp);
+    }
+
+    incidence_matrix[i][j] = vec;
+  }
+}
+
+// main test function
+static void
+test_match_graph()
+{
+  bool success = true;
+
+  // equality tests
   match_params mp1(10, 10, 0.5f, 0.5f), mp2(10, 10, 0.5f, 0.5f), mp3;
   TEST("match_params equality", mp1, mp2);
   TEST("match_params inequality", mp1 != mp3, true);
+
+
+  // -----
+  // Test graph containing two connected components
+  //   component "A" = 0-1-2-3
+  //   component "B" = 4-5-6
+  // For each image/camera, we project 3d points into the 2d image space
+  // to serve as feature correspondences. We then process the correspondences
+  // into the acal_match_graph to confirm expected operation
+  // -----
+
+  // images (not actual paths)
+  std::map<size_t, std::string> image_paths = {
+      {0, "image0.tif"},
+      {1, "image1.tif"},
+      {2, "image2.tif"},
+      {3, "image3.tif"},
+      {4, "image4.tif"},
+  };
+
+  // cameras
+  std::map<size_t, vpgl_affine_camera<double> > cams = {
+
+      // camsA
+      {0, make_affine_camera<double>( 1,  0, 0)},
+      {1, make_affine_camera<double>( 0,  1, 0)},
+      {2, make_affine_camera<double>(-1,  0, 0)},
+      {3, make_affine_camera<double>( 0, -1, 0)},
+
+      // camsB
+      {4, make_affine_camera<double>( 1,  1, 0)},
+      {5, make_affine_camera<double>(-1,  1, 0)},
+      {6, make_affine_camera<double>(-1, -1, 0)},
+  };
+
+  // incidence matrix
+  std::map<size_t, std::map<size_t, std::vector<acal_match_pair> > > incidence_matrix;
+
+  // connected component "A"
+  std::vector<vgl_point_3d<double> > ptsA = {
+    vgl_point_3d<double>(1,0,0),
+    vgl_point_3d<double>(0,1,0),
+    vgl_point_3d<double>(0,0,1),
+    vgl_point_3d<double>(0,0,-1),
+  };
+
+  std::vector<std::pair<size_t, size_t> > pairsA = {{0,1},{1,2},{2,3},{3,0}};
+  update_incidence_matrix(incidence_matrix, ptsA, pairsA, cams);
+
+  // connected component "B"
+  std::vector<vgl_point_3d<double> > ptsB = {
+    vgl_point_3d<double>(2,0,0),
+    vgl_point_3d<double>(0,2,0),
+    vgl_point_3d<double>(0,0,2),
+  };
+
+  std::vector<std::pair<size_t, size_t> > pairsB = {{4,5},{5,6},{6,4}};
+  update_incidence_matrix(incidence_matrix, ptsB, pairsB, cams);
+
+  // DEBUG: print incidence_matrix
+  std::cout << "\nIncidence matrix:\n";
+  for (auto const& row : incidence_matrix) {
+    for (auto const& item : row.second) {
+      std::cout << "image pair " << row.first << "/" << item.first << "\n";
+      for (auto const& pair : item.second) {
+        std::cout << "  " << pair << "\n";
+      }
+    }
+  }
+  std::cout << std::endl;
+
+  // initialize match graph
+  acal_match_graph match_graph;
+  match_graph.set_image_paths(image_paths);
+  match_graph.set_all_acams(cams);
+  success = match_graph.load_incidence_matrix(incidence_matrix);
+  TEST("acal_match_graph::load_incidence_matrix", success, true);
+
+  // connected components
+  match_graph.find_connected_components();
+  std::cout << "\nacal_match_graph::find_connected_components complete" << std::endl;
+  //  match_graph.print_connected_components();
+
+  auto components = match_graph.get_connected_components();
+  TEST("acal_match_graph 2 connected components", components.size(), 2);
+  TEST("acal_match_graph component[0].size == 4", components[0].size(), 4);
+  TEST("acal_match_graph component[1].size == 3", components[1].size(), 3);
+
+  // focus tracks
+  match_graph.compute_focus_tracks();
+  std::cout << "\nacal_match_graph::compute_focus_tracks complete" << std::endl;
+  // match_graph.print_focus_tracks();
+
+  auto tracks = match_graph.get_focus_tracks();
+  TEST("acal_match_graph tracks[0][0].size == 4", tracks[0][0].size(), 4);
+  TEST("acal_match_graph tracks[1][4].size == 3", tracks[1][4].size(), 3);
+
+  // match trees
+  match_graph.compute_match_trees();
+  std::cout << "\nacal_match_graph::compute_match_trees complete" << std::endl;
+
+  match_graph.validate_match_trees_and_set_metric();
+  std::cout << "\nacal_match_graph::validate_match_trees_and_set_metric complete" << std::endl;
 
 }
 


### PR DESCRIPTION
- Additional acal_io functionality for `f_params` structure (including serialization & equality operator for serialization unit test)
- `acal_match_graph` unit test.  Includes minor addition to class interface for unit test of incidence matrix load as well as some additional output operators.

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️Adds tests and baseline comparison (quantitative).
- ❌Adds Documentation.

