### PR TITLE
ENH: contrib/brl - acal_match_tree update

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -366,10 +366,7 @@ acal_match_graph::compute_match_trees()
     for (size_t v = 0; v<nv; ++v) {
       std::shared_ptr<match_vertex> f_vert = conn_comps_[c][v];
       size_t fidx = f_vert->cam_id_;
-      // make the match tree a pointer so a delete isn't called when exiting the scope of a function
-      // note that delete clears the children in a bottom up order and sets the parent pointer to 0
-      std::shared_ptr<acal_match_node> root(new acal_match_node(fidx));
-      std::shared_ptr<acal_match_tree> mt_ptr(new acal_match_tree(root));
+      auto mt_ptr = std::make_shared<acal_match_tree>(fidx);
       std::map<size_t, std::shared_ptr<match_vertex> > active_verts;
       active_verts[fidx] = f_vert;
       std::set<size_t> used_verts;     // vertices already explored for a given focus vertex

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
@@ -34,13 +34,13 @@ class acal_match_node : public std::enable_shared_from_this<acal_match_node>
   acal_match_node(size_t node_id = 0) : cam_id_(node_id) {}
 
   //: property accessors
-  size_t size() { return children_.size(); }
-  bool is_leaf() { return children_.empty(); }
-  bool is_root() { return !has_parent_; }
-  bool has_parent() { return has_parent_; }
+  size_t size() const { return children_.size(); }
+  bool is_leaf() const { return children_.empty(); }
+  bool is_root() const { return !has_parent_; }
+  bool has_parent() const { return has_parent_; }
 
   //: parent accessors
-  std::shared_ptr<acal_match_node> parent() { return parent_.lock(); }
+  std::shared_ptr<acal_match_node> parent() const { return parent_.lock(); }
   void parent(std::shared_ptr<acal_match_node> node) {
     has_parent_ = true;
     parent_ = node;
@@ -53,6 +53,14 @@ class acal_match_node : public std::enable_shared_from_this<acal_match_node>
     children_.push_back(child);
     self_to_child_matches_.push_back(self_to_child_matches);
   }
+
+  //: parent & children node id
+  size_t parent_id() const;
+  std::vector<size_t> children_ids() const;
+
+  //: equality operators
+  bool operator==(acal_match_node const& other) const;
+  bool operator!=(acal_match_node const& other) const { return !(*this == other); }
 
   //: find the index (cindx) of a node in the set of parent's children
   bool child_index(std::shared_ptr<acal_match_node> const& node, size_t& cidx) {
@@ -78,6 +86,10 @@ class acal_match_node : public std::enable_shared_from_this<acal_match_node>
   std::weak_ptr<acal_match_node> parent_;
 
 };
+
+// streaming operator
+std::ostream& operator<<(std::ostream& os, acal_match_node const& node);
+
 
 
 class acal_match_tree
@@ -125,8 +137,18 @@ class acal_match_tree
   //: reorganize correspondences in track format
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks();
 
+  //: return nodes
+  std::vector<std::shared_ptr<acal_match_node> > nodes() const;
+
   //: return sorted cam ids
-  std::vector<size_t> cam_ids();
+  std::vector<size_t> cam_ids() const;
+
+  //: print tree
+  void print(std::ostream& os) const;
+
+  //: equality operators
+  bool operator==(acal_match_tree const& other) const;
+  bool operator!=(acal_match_tree const& other) const { return !(*this == other); }
 
   // members
   size_t n_ = 1;
@@ -135,9 +157,15 @@ class acal_match_tree
 
  private:
 
-  // recursively locate camera ids
-  void cam_ids_recursive(std::vector<size_t>& ids, std::shared_ptr<acal_match_node> node);
+  // recursively process tree info
+  void nodes_recursive(std::vector<std::shared_ptr<acal_match_node> >& nodes, std::shared_ptr<acal_match_node> node) const;
+  void cam_ids_recursive(std::vector<size_t>& ids, std::shared_ptr<acal_match_node> node) const;
+  void print_recursive(std::ostream& os, std::shared_ptr<acal_match_node> node, std::string indent = "  ") const;
 
 };
+
+// streaming operator
+std::ostream& operator<<(std::ostream& os, acal_match_tree const& tree);
+
 
 #endif


### PR DESCRIPTION
Update in contrib/brl for `acal_match_tree`:

- nodes now use `std::weak_ptr` to point to parent node, simplifying parent retrieval and eliminating need for custom destructor
- `operator==` & `operator<<` for node & tree
- related updates & unit tests

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
