### PR TITLE
ENH: contrib/brl acal graph operators

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
+++ b/contrib/brl/bbas/bpgl/acal/CMakeLists.txt
@@ -27,7 +27,7 @@ set(ACAL_SOURCES
 
 vxl_add_library(LIBRARY_NAME acal LIBRARY_SOURCES ${ACAL_SOURCES})
 
-target_link_libraries(acal brip vpgl vpgl_algo bjson bvgl vbl vgl vil_algo vil vcl)
+target_link_libraries(acal bpgl brip vpgl vpgl_algo bjson bvgl vbl vgl vil_algo vil vcl)
 
 add_subdirectory(io)
 

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -56,11 +56,11 @@ struct match_params
 
 };
 
+
 class match_vertex
 {
  public:
-  match_vertex(): cam_id_(-1), mark_(false) {}
-  match_vertex(size_t cam_id): cam_id_(cam_id), mark_(false) {}
+  match_vertex(size_t cam_id = 0): cam_id_(cam_id) {}
 
   void add_edge(match_edge* edge) {
     std::vector<match_edge* >::iterator eit;
@@ -76,26 +76,46 @@ class match_vertex
     edges_.clear();
   }
 
+  std::vector<size_t> edge_ids() const;
+
+  bool operator==(match_vertex const& other) const;
+  bool operator!=(match_vertex const& other) const { return !(*this == other); }
+
   size_t cam_id_;
-  bool mark_;
+  bool mark_ = false;
   std::vector<match_edge*> edges_;
 };
+
+// streaming operator
+std::ostream& operator<<(std::ostream& os, match_vertex const& vertex);
+
 
 class match_edge
 {
  public:
-  match_edge(): id_(-1) {}
   match_edge(std::shared_ptr<match_vertex> v0,
              std::shared_ptr<match_vertex> v1,
              std::vector<acal_match_pair> const& matches,
-             size_t id = 0):
-    v0_(v0), v1_(v1), matches_(matches), id_(id) {}
+             size_t id = 0)
+    : v0_(v0), v1_(v1), matches_(matches), id_(id)
+  {
+    v0_->add_edge(this);
+    v1_->add_edge(this);
+  }
+
+  std::vector<size_t> vertex_ids() const;
+
+  bool operator==(match_edge const& other) const;
+  bool operator!=(match_edge const& other) const { return !(*this == other); }
 
   size_t id_;
   std::vector<acal_match_pair>  matches_;
   std::shared_ptr<match_vertex> v0_;
   std::shared_ptr<match_vertex> v1_;
 };
+
+// streaming operator
+std::ostream& operator<<(std::ostream& os, match_edge const& edge);
 
 
 class acal_match_graph
@@ -192,6 +212,11 @@ class acal_match_graph
   bool save_graph_dot_format(std::string const& path);
   bool save_focus_graphs_dot_format(size_t ccomp_index, std::string const& path);
   bool save_match_trees_dot_format(size_t ccomp_index, std::string const& path, size_t num_trees = -1);
+
+
+  bool operator==(acal_match_graph const& other) const;
+  bool operator!=(acal_match_graph const& other) const { return !(*this == other); }
+
 
  private:
   match_params params_;

--- a/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/tests/test_match_graph.cxx
@@ -77,6 +77,8 @@ test_match_graph()
       {2, "image2.tif"},
       {3, "image3.tif"},
       {4, "image4.tif"},
+      {5, "image5.tif"},
+      {6, "image6.tif"},
   };
 
   // cameras
@@ -162,6 +164,21 @@ test_match_graph()
 
   match_graph.validate_match_trees_and_set_metric();
   std::cout << "\nacal_match_graph::validate_match_trees_and_set_metric complete" << std::endl;
+
+
+  // equality test
+  acal_match_graph match_graph_copy;
+  match_graph_copy.set_image_paths(image_paths);
+  match_graph_copy.set_all_acams(cams);
+  success = match_graph_copy.load_incidence_matrix(incidence_matrix);
+  TEST("acal_match_graph !=", match_graph_copy != match_graph, true);
+
+  match_graph_copy.find_connected_components();
+  match_graph_copy.compute_focus_tracks();
+  match_graph_copy.compute_match_trees();
+  match_graph_copy.validate_match_trees_and_set_metric();
+
+  TEST("acal_match_graph ==", match_graph_copy, match_graph);
 
 }
 


### PR DESCRIPTION
contrib/brl - `acal_match_graph`updates
- operators for equality & output stream
- unit test for equality
- remove default constructors that allowed invalid vertex & edge
- link acal with parent bpgl

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

