### PR TITLE
ENH: VSL tuple & array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 2.1.2.2 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 2.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vsl/CMakeLists.txt
+++ b/core/vsl/CMakeLists.txt
@@ -17,6 +17,7 @@ set(vsl_sources
   vsl_stream.h
   vsl_block_binary_rle.h
 
+  vsl_array_io.hxx vsl_array_io.h
   vsl_binary_loader.hxx vsl_binary_loader.h
   vsl_clipon_binary_loader.hxx vsl_clipon_binary_loader.h
   vsl_complex_io.hxx vsl_complex_io.h

--- a/core/vsl/CMakeLists.txt
+++ b/core/vsl/CMakeLists.txt
@@ -27,6 +27,7 @@ set(vsl_sources
   vsl_set_io.hxx vsl_set_io.h
   vsl_stack_io.hxx vsl_stack_io.h
   vsl_string_io.hxx vsl_string_io.h
+  vsl_tuple_io.hxx vsl_tuple_io.h
   vsl_vector_io.hxx vsl_vector_io.h vsl_vector_io_bool.cxx
                                     vsl_vector_io_vector_bool.cxx
   vsl_basic_xml_element.cxx vsl_basic_xml_element.h

--- a/core/vsl/tests/CMakeLists.txt
+++ b/core/vsl/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable( vsl_test_all
   test_set_io.cxx
   test_stack_io.cxx
   test_string_io.cxx
+  test_tuple_io.cxx
   test_vector_io.cxx
   test_vlarge_block_io.cxx
   test_block_rle_io.cxx
@@ -39,11 +40,12 @@ add_test( NAME vsl_test_polymorphic_io COMMAND $<TARGET_FILE:vsl_test_all> test_
 add_test( NAME vsl_test_set_io COMMAND $<TARGET_FILE:vsl_test_all> test_set_io)
 add_test( NAME vsl_test_stack_io COMMAND $<TARGET_FILE:vsl_test_all> test_stack_io)
 add_test( NAME vsl_test_string_io COMMAND $<TARGET_FILE:vsl_test_all> test_string_io)
+add_test( NAME vsl_test_tuple_io COMMAND $<TARGET_FILE:vsl_test_all> test_tuple_io)
 add_test( NAME vsl_test_vector_io COMMAND $<TARGET_FILE:vsl_test_all> test_vector_io)
 add_test( NAME vsl_test_block_rle_io COMMAND $<TARGET_FILE:vsl_test_all> test_block_rle_io)
 
 # Don't add test_vlarge_block_io to the automatic list. It does nasty things
-# to memory which can result in wierd error messages, system lockup, and other
+# to memory which can result in weird error messages, system lockup, and other
 # unpleasant behaviour on some platforms
 # The following manual tests have been tried.
 # x86, Win2k, MSVC7.1 Release mode - test passes

--- a/core/vsl/tests/CMakeLists.txt
+++ b/core/vsl/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable( vsl_test_all
   test_indent.cxx
   test_binary_io.cxx
   test_arbitrary_length_int_conversion.cxx
+  test_array_io.cxx
   test_clipon_polymorphic_io.cxx
   test_complex_io.cxx
   test_deque_io.cxx
@@ -31,6 +32,7 @@ add_test( NAME vsl_test_binary_io COMMAND $<TARGET_FILE:vsl_test_all> test_binar
 
 add_test( NAME vsl_test_arbitrary_length_int_conversion COMMAND $<TARGET_FILE:vsl_test_all>
                                            test_arbitrary_length_int_conversion)
+add_test( NAME vsl_test_array_io COMMAND $<TARGET_FILE:vsl_test_all> test_array_io)
 add_test( NAME vsl_test_clipon_polymorphic_io COMMAND $<TARGET_FILE:vsl_test_all> test_clipon_polymorphic_io)
 add_test( NAME vsl_test_complex_io COMMAND $<TARGET_FILE:vsl_test_all> test_complex_io)
 add_test( NAME vsl_test_deque_io COMMAND $<TARGET_FILE:vsl_test_all> test_deque_io)

--- a/core/vsl/tests/test_array_io.cxx
+++ b/core/vsl/tests/test_array_io.cxx
@@ -1,0 +1,89 @@
+// This is core/vsl/tests/test_array_io.cxx
+#include <iostream>
+#ifdef _MSC_VER
+#  include "vcl_msvc_warnings.h"
+#endif
+#include "vsl/vsl_binary_io.h"
+#include "testlib/testlib_test.h"
+#include "testlib/testlib_root_dir.h"
+#include "vpl/vpl.h"
+
+#include "vsl/vsl_array_io.hxx"
+
+
+#define VSL_TEST_ARRAY_N 10
+
+
+void
+test_array_io()
+{
+  std::cout << "****************************\n"
+            << "Testing std::array binary io\n"
+            << "****************************\n";
+
+  std::array<bool, VSL_TEST_ARRAY_N> a_bool_out;
+  for (int i = 0; i < VSL_TEST_ARRAY_N; ++i)
+    a_bool_out[i] = (i % 2 == 0);
+  std::array<int, VSL_TEST_ARRAY_N> a_int_out;
+  for (int i = 0; i < VSL_TEST_ARRAY_N; ++i)
+    a_int_out[i] = i;
+  std::array<float, VSL_TEST_ARRAY_N> a_float_out;
+  for (int i = 0; i < VSL_TEST_ARRAY_N; ++i)
+    a_float_out[i] = 0.1f * i;
+  std::array<unsigned char, VSL_TEST_ARRAY_N> a_uchar_out;
+  for (int i = 0; i < VSL_TEST_ARRAY_N; ++i)
+    a_uchar_out[i] = (unsigned char)(i + 'A');
+
+  vsl_b_ofstream bfs_out("vsl_array_io_test.bvl.tmp");
+  TEST("Created vsl_array_io_test.bvl.tmp for writing", (!bfs_out), false);
+  vsl_b_write(bfs_out, a_bool_out);
+  vsl_b_write(bfs_out, a_int_out);
+  vsl_b_write(bfs_out, a_float_out);
+  vsl_b_write(bfs_out, a_uchar_out);
+  bfs_out.close();
+
+  std::array<bool, VSL_TEST_ARRAY_N> a_bool_in;
+  std::array<int, VSL_TEST_ARRAY_N> a_int_in;
+  std::array<float, VSL_TEST_ARRAY_N> a_float_in;
+  std::array<unsigned char, VSL_TEST_ARRAY_N> a_uchar_in;
+
+  vsl_b_ifstream bfs_in("vsl_array_io_test.bvl.tmp");
+  TEST("Opened vsl_array_io_test.bvl.tmp for reading", (!bfs_in), false);
+  vsl_b_read(bfs_in, a_bool_in);
+  vsl_b_read(bfs_in, a_int_in);
+  vsl_b_read(bfs_in, a_float_in);
+  vsl_b_read(bfs_in, a_uchar_in);
+  TEST("Finished reading file successfully", (!bfs_in), false);
+  bfs_in.close();
+
+  vpl_unlink("vsl_array_io_test.bvl.tmp");
+
+  std::ostringstream ss;
+  ss << "std::array<bool, " << VSL_TEST_ARRAY_N << "> out == std::array<bool, " << VSL_TEST_ARRAY_N << "> in";
+  auto bool_str = ss.str();
+
+  ss.str("");
+  ss << "std::array<int, " << VSL_TEST_ARRAY_N << "> out == std::array<int, " << VSL_TEST_ARRAY_N << "> in";
+  auto int_str = ss.str();
+
+  ss.str("");
+  ss << "std::array<float, " << VSL_TEST_ARRAY_N << "> out == std::array<float, " << VSL_TEST_ARRAY_N << "> in";
+  auto float_str = ss.str();
+
+  ss.str("");
+  ss << "std::array<uchar, " << VSL_TEST_ARRAY_N << "> out == std::array<uchar, " << VSL_TEST_ARRAY_N << "> in";
+  auto uchar_str = ss.str();
+
+  TEST(bool_str.c_str(), a_bool_out, a_bool_in);
+  TEST(int_str.c_str(), a_int_out, a_int_in);
+  TEST(float_str.c_str(), a_float_out, a_float_in);
+  TEST(uchar_str.c_str(), a_uchar_out, a_uchar_in);
+
+  vsl_print_summary(std::cout, a_bool_in);
+  vsl_print_summary(std::cout, a_int_in);
+  vsl_print_summary(std::cout, a_float_in);
+  vsl_print_summary(std::cout, a_uchar_in);
+  std::cout << std::endl;
+}
+
+TESTMAIN(test_array_io);

--- a/core/vsl/tests/test_driver.cxx
+++ b/core/vsl/tests/test_driver.cxx
@@ -3,6 +3,7 @@
 DECLARE(test_indent);
 DECLARE(test_binary_io);
 DECLARE(test_arbitrary_length_int_conversion);
+DECLARE(test_array_io);
 DECLARE(test_clipon_polymorphic_io);
 DECLARE(test_complex_io);
 DECLARE(test_deque_io);
@@ -23,6 +24,7 @@ register_tests()
   REGISTER(test_indent);
   REGISTER(test_binary_io);
   REGISTER(test_arbitrary_length_int_conversion);
+  REGISTER(test_array_io);
   REGISTER(test_clipon_polymorphic_io);
   REGISTER(test_complex_io);
   REGISTER(test_deque_io);

--- a/core/vsl/tests/test_driver.cxx
+++ b/core/vsl/tests/test_driver.cxx
@@ -12,6 +12,7 @@ DECLARE(test_polymorphic_io);
 DECLARE(test_set_io);
 DECLARE(test_stack_io);
 DECLARE(test_string_io);
+DECLARE(test_tuple_io);
 DECLARE(test_vector_io);
 DECLARE(test_vlarge_block_io);
 DECLARE(test_block_rle_io);
@@ -31,6 +32,7 @@ register_tests()
   REGISTER(test_set_io);
   REGISTER(test_stack_io);
   REGISTER(test_string_io);
+  REGISTER(test_tuple_io);
   REGISTER(test_vector_io);
   REGISTER(test_vlarge_block_io);
   REGISTER(test_block_rle_io);

--- a/core/vsl/tests/test_include.cxx
+++ b/core/vsl/tests/test_include.cxx
@@ -1,4 +1,5 @@
 #include "vsl/vsl_fwd.h"
+#include "vsl/vsl_array_io.h"
 #include "vsl/vsl_basic_xml_element.h"
 #include "vsl/vsl_binary_io.h"
 #include "vsl/vsl_binary_explicit_io.h"

--- a/core/vsl/tests/test_include.cxx
+++ b/core/vsl/tests/test_include.cxx
@@ -19,6 +19,7 @@
 #include "vsl/vsl_stack_io.h"
 #include "vsl/vsl_stream.h"
 #include "vsl/vsl_string_io.h"
+#include "vsl/vsl_tuple_io.h"
 #include "vsl/vsl_vector_io.h"
 
 int

--- a/core/vsl/tests/test_tuple_io.cxx
+++ b/core/vsl/tests/test_tuple_io.cxx
@@ -1,0 +1,68 @@
+// This is core/vsl/tests/test_tuple_io.cxx
+#include <iostream>
+#include <string>
+#include <tuple>
+#ifdef _MSC_VER
+#  include "vcl_msvc_warnings.h"
+#endif
+#include "vsl/vsl_binary_io.h"
+#include "testlib/testlib_test.h"
+#include "testlib/testlib_root_dir.h"
+#include "vpl/vpl.h"
+
+#include "vsl/vsl_tuple_io.hxx"
+
+
+VSL_TUPLE_IO_INSTANTIATE(int);
+VSL_TUPLE_IO_INSTANTIATE(int, double, std::string);
+VSL_TUPLE_IO_INSTANTIATE(std::tuple<int>);
+
+
+void
+test_tuple_io()
+{
+  std::cout << "****************************\n"
+            << "Testing std::tuple binary io\n"
+            << "****************************\n";
+
+  int x1 = 7;
+  std::tuple<int> t_int_out(x1);
+
+  double x2 = 2.5;
+  std::string x3 = "test";
+  std::tuple<int, double, std::string> t_int_double_string_out(x1, x2, x3);
+
+  std::tuple<std::tuple<int> > t_t_int_out(t_int_out);
+
+  vsl_b_ofstream bfs_out("vsl_tuple_io_test.bvl.tmp");
+  TEST("Created vsl_tuple_io_test.bvl.tmp for writing", (!bfs_out), false);
+  vsl_b_write(bfs_out, t_int_out);
+  vsl_b_write(bfs_out, t_int_double_string_out);
+  vsl_b_write(bfs_out, t_t_int_out);
+  bfs_out.close();
+
+  std::tuple<int> t_int_in;
+  std::tuple<int, double, std::string> t_int_double_string_in;
+  std::tuple<std::tuple<int> > t_t_int_in;
+
+  vsl_b_ifstream bfs_in("vsl_tuple_io_test.bvl.tmp");
+  TEST("Opened vsl_tuple_io_test.bvl.tmp for reading", (!bfs_in), false);
+  vsl_b_read(bfs_in, t_int_in);
+  vsl_b_read(bfs_in, t_int_double_string_in);
+  vsl_b_read(bfs_in, t_t_int_in);
+  TEST("Finished reading file successfully", (!bfs_in), false);
+  bfs_in.close();
+
+  vpl_unlink("vsl_tuple_io_test.bvl.tmp");
+
+  TEST("std::tuple<int> out == std::tuple<int> in", t_int_out, t_int_in);
+  TEST("std::tuple<int, double, std::string> out == std::tuple<int, double, std::string> in", t_int_double_string_out, t_int_double_string_in);
+  TEST("std::tuple<std::tuple<int> > out == std::tuple<std::tuple<int> > in", t_t_int_out, t_t_int_in);
+
+  vsl_print_summary(std::cout, t_int_in);
+  vsl_print_summary(std::cout, t_int_double_string_in);
+  vsl_print_summary(std::cout, t_t_int_in);
+  std::cout << std::endl;
+}
+
+TESTMAIN(test_tuple_io);

--- a/core/vsl/vsl_array_io.h
+++ b/core/vsl/vsl_array_io.h
@@ -1,0 +1,30 @@
+// This is core/vsl/vsl_array_io.h
+#ifndef vsl_array_io_h_
+#define vsl_array_io_h_
+//:
+// \file
+// \brief   binary IO functions for std::array<T, N>
+// \author  Noah Johnson
+
+#include <array>
+#include <iosfwd>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+class vsl_b_ostream;
+class vsl_b_istream;
+
+//: Write array to binary stream
+template <class T, size_t N>
+void vsl_b_write(vsl_b_ostream& os, const std::array<T, N>& v);
+
+//: Read array from binary stream
+template <class T, size_t N>
+void vsl_b_read(vsl_b_istream& is, std::array<T, N>& v);
+
+//: Print human readable summary of array to a stream
+template <class T, size_t N>
+void vsl_print_summary(std::ostream& os, const std::array<T, N>& v);
+
+#endif  // vsl_array_io_h_

--- a/core/vsl/vsl_array_io.hxx
+++ b/core/vsl/vsl_array_io.hxx
@@ -1,0 +1,84 @@
+// This is core/vsl/vsl_array_io.hxx
+#ifndef vsl_array_io_hxx_
+#define vsl_array_io_hxx_
+//:
+// \file
+// \brief  binary IO functions for std::array<T, N>
+// \author Noah Johnson
+//
+// Implementation
+
+#include "vsl_array_io.h"
+
+#include <array>
+
+#include <vsl/vsl_binary_io.h>
+#include <vsl/vsl_block_binary.h>
+#include <vsl/vsl_indent.h>
+
+
+//: Write array to binary stream
+template <class T, size_t N>
+void vsl_b_write(vsl_b_ostream& os, const std::array<T, N>& arr) {
+
+  constexpr short version_no = 1;
+  vsl_b_write(os, version_no);
+
+  if (N != 0) {
+    vsl_block_binary_write(os, &arr.front(), N);
+  }
+}
+
+
+//: Read array from binary stream
+template <class T, size_t N>
+void vsl_b_read(vsl_b_istream& is, std::array<T, N>& arr) {
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+    {
+      if (N != 0) {
+        vsl_block_binary_read(is, &arr.front(), N);
+      }
+      break;
+    }
+    default:
+    {
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, std::array<T, N>&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit);  // Set an unrecoverable IO error on stream
+      return;
+    }
+  }
+}
+
+
+//: Print human readable summary of array to a stream
+template <class T, size_t N>
+void vsl_print_summary(std::ostream& os, const std::array<T, N>& arr)
+{
+  os << vsl_indent() << "Array length: " << N << std::endl;
+  for (size_t i = 0; i < N && i < 5; ++i)
+  {
+    os << vsl_indent() << ' ' << i << ": ";
+    vsl_indent_inc(os);
+    vsl_print_summary(os, arr[i]);
+    os << std::endl;
+    vsl_indent_dec(os);
+  }
+  if (N > 5)
+    os << vsl_indent() << " ..." << std::endl;
+}
+
+
+#undef VSL_ARRAY_IO_INSTANTIATE
+#define VSL_ARRAY_IO_INSTANTIATE(T, N) \
+template void vsl_print_summary<T, N>(std::ostream& os, const std::array<T, N>& v); \
+template void vsl_b_write<T, N>(vsl_b_ostream& os, const std::array<T, N>& v); \
+template void vsl_b_read<T, N>(vsl_b_istream& is, std::array<T, N>& v)
+
+#endif  // vsl_array_io_hxx_

--- a/core/vsl/vsl_tuple_io.h
+++ b/core/vsl/vsl_tuple_io.h
@@ -1,0 +1,30 @@
+// This is core/vsl/vsl_tuple_io.h
+#ifndef vsl_tuple_io_h_
+#define vsl_tuple_io_h_
+//:
+// \file
+// \brief   binary IO functions for std::tuple<T1, T2, ...>
+// \author  Noah Johnson
+
+#include <iosfwd>
+#include <tuple>
+#ifdef _MSC_VER
+#  include <vcl_msvc_warnings.h>
+#endif
+
+class vsl_b_ostream;
+class vsl_b_istream;
+
+//: Write tuple to binary stream
+template <typename ... Types>
+void vsl_b_write(vsl_b_ostream& os, const std::tuple<Types ...>& v);
+
+//: Read tuple from binary stream
+template <typename ... Types>
+void vsl_b_read(vsl_b_istream& is, std::tuple<Types ...>& v);
+
+//: Print human readable summary of tuple to a stream
+template <typename ... Types>
+void vsl_print_summary(std::ostream& os, const std::tuple<Types ...>& v);
+
+#endif  // vsl_tuple_io_h_

--- a/core/vsl/vsl_tuple_io.hxx
+++ b/core/vsl/vsl_tuple_io.hxx
@@ -1,0 +1,71 @@
+// This is core/vsl/vsl_tuple_io.hxx
+#ifndef vsl_tuple_io_hxx_
+#define vsl_tuple_io_hxx_
+//:
+// \file
+// \brief  binary IO functions for std::tuple<T1, T2, ...>
+// \author Noah Johnson
+//
+// Implementation
+
+#include "vsl_tuple_io.h"
+#include "vsl_utils.hxx"
+
+#include <tuple>
+
+#include <vsl/vsl_binary_io.h>
+
+
+//: Write tuple to binary stream
+template <typename ... Types>
+void vsl_b_write(vsl_b_ostream& os, const std::tuple<Types ...>& v) {
+
+  constexpr short version_no = 1;
+  vsl_b_write(os, version_no);
+
+  _vsl_for_each(v, _vsl_generic_write(os));
+}
+
+
+//: Read tuple from binary stream
+template <typename ... Types>
+void vsl_b_read(vsl_b_istream& is, std::tuple<Types ...>& v) {
+  if (!is) return;
+
+  short io_version_no;
+  vsl_b_read(is, io_version_no);
+  switch (io_version_no)
+  {
+    case 1:
+    {
+      _vsl_for_each(v, _vsl_generic_read(is));
+      break;
+    }
+    default:
+    {
+      std::cerr << "I/O ERROR: vsl_b_read(vsl_b_istream&, std::tuple<Types ...>&), "
+                << "Unknown version number "<< io_version_no << std::endl;
+      is.is().clear(std::ios::badbit);  // Set an unrecoverable IO error on stream
+      return;
+    }
+  }
+}
+
+
+//: Print human readable summary of tuple to a stream
+template <typename ... Types>
+void vsl_print_summary(std::ostream& os, const std::tuple<Types ...>& v) {
+
+  os << "Tuple size: " << std::tuple_size<std::tuple<Types ...> >::value << std::endl;
+  _vsl_for_each(v, _vsl_generic_print(os));
+  os << std::endl;
+}
+
+
+#undef VSL_TUPLE_IO_INSTANTIATE
+#define VSL_TUPLE_IO_INSTANTIATE(...) \
+template void vsl_print_summary<__VA_ARGS__>(std::ostream& os, const std::tuple<__VA_ARGS__>& v); \
+template void vsl_b_write<__VA_ARGS__>(vsl_b_ostream& os, const std::tuple<__VA_ARGS__>& v); \
+template void vsl_b_read<__VA_ARGS__>(vsl_b_istream& is, std::tuple<__VA_ARGS__>& v)
+
+#endif  // vsl_tuple_io_hxx_

--- a/core/vsl/vsl_tuple_io.hxx
+++ b/core/vsl/vsl_tuple_io.hxx
@@ -14,6 +14,7 @@
 #include <tuple>
 
 #include <vsl/vsl_binary_io.h>
+#include <vsl/vsl_indent.h>
 
 
 //: Write tuple to binary stream
@@ -56,9 +57,11 @@ void vsl_b_read(vsl_b_istream& is, std::tuple<Types ...>& v) {
 template <typename ... Types>
 void vsl_print_summary(std::ostream& os, const std::tuple<Types ...>& v) {
 
-  os << "Tuple size: " << std::tuple_size<std::tuple<Types ...> >::value << std::endl;
+  os << vsl_indent() << "Tuple size: " << std::tuple_size<std::tuple<Types ...> >::value << std::endl;
+  vsl_indent_inc(os);
   _vsl_for_each(v, _vsl_generic_print(os));
   os << std::endl;
+  vsl_indent_dec(os);
 }
 
 

--- a/core/vsl/vsl_utils.hxx
+++ b/core/vsl/vsl_utils.hxx
@@ -1,0 +1,95 @@
+// This is core/vsl/vsl_utils.hxx
+#ifndef vsl_utils_hxx_
+#define vsl_utils_hxx_
+//:
+// \file
+// \brief  Template metaprogramming functions for heterogeneous data structures
+// \author Noah Johnson
+//
+// Implementation
+
+#include <tuple>
+#include <type_traits>
+
+#include <vsl/vsl_binary_io.h>
+
+
+/*
+ * for_each support in C++11, since std::for_each isn't available yet.
+ * This implementation is based on the following: https://stackoverflow.com/a/26908596
+ */
+
+
+// This first overload is called if I is equal to the size of the tuple.
+// Nothing happens and the recursion ends.
+template<typename TupleType, typename FunctionType>
+void _vsl_for_each(TupleType&&, FunctionType,
+                   std::integral_constant<size_t,
+                     std::tuple_size<typename std::remove_reference<TupleType>::type>::value>) {}
+
+
+/* This second overload calls the function with the argument std::get<I>(t) and
+ * increases the index by one. The class std::integral_constant is needed in
+ * order to resolve the value of I at compile time. The std::enable_if SFINAE
+ * stuff is used to help the compiler separate this overload from the previous
+ * one, and call this overload only if I is smaller than the tuple size.
+ */
+template<std::size_t I, typename TupleType, typename FunctionType,
+         typename = typename std::enable_if<I!=std::tuple_size<typename std::remove_reference<TupleType>::type>::value>::type>
+void _vsl_for_each(TupleType&& t, FunctionType f, std::integral_constant<size_t, I>)
+{
+    f(std::get<I>(std::forward<TupleType>(t)));
+    _vsl_for_each(std::forward<TupleType>(t), f, std::integral_constant<size_t, I + 1>());
+}
+
+
+// This third overload starts the recursion with I=0. Users call this.
+template<typename TupleType, typename FunctionType>
+void _vsl_for_each(TupleType&& t, FunctionType f)
+{
+    _vsl_for_each(std::forward<TupleType>(t), f, std::integral_constant<size_t, 0>());
+}
+
+
+/*
+ * Write / read / print wrappers, templated for any type.
+ * Use with above code on arrays, tuples, etc.
+ * Can be replaced with generic lambdas once VXL requires C++14.
+ * This implementation is based on the following: https://stackoverflow.com/a/30071501
+ */
+
+
+struct _vsl_generic_write {
+  _vsl_generic_write(vsl_b_ostream& os) : os_(os) {}
+
+  template <class ElementType>
+  void operator()(const ElementType& elem) const {
+    vsl_b_write(this->os_, elem);
+  }
+
+  vsl_b_ostream& os_;
+};
+
+struct _vsl_generic_read {
+  _vsl_generic_read(vsl_b_istream& is) : is_(is) {}
+
+  template <class ElementType>
+  void operator()(ElementType& elem) const {
+    vsl_b_read(this->is_, elem);
+  }
+
+  vsl_b_istream& is_;
+};
+
+struct _vsl_generic_print {
+  _vsl_generic_print(std::ostream& os) : os_(os) {}
+
+  template <class ElementType>
+  void operator()(const ElementType& elem) const {
+    vsl_print_summary(this->os_, elem);
+  }
+
+  std::ostream& os_;
+};
+
+#endif  // vsl_utils_hxx_

--- a/core/vsl/vsl_utils.hxx
+++ b/core/vsl/vsl_utils.hxx
@@ -52,8 +52,8 @@ void _vsl_for_each(TupleType&& t, FunctionType f)
 
 
 /*
- * Write / read / print wrappers, templated for any type.
- * Use with above code on arrays, tuples, etc.
+ * Write / read / print generic functions, templated for any type.
+ * Use with above code on heterogeneous data structures, e.g. tuples.
  * Can be replaced with generic lambdas once VXL requires C++14.
  * This implementation is based on the following: https://stackoverflow.com/a/30071501
  */


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- [X] Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- [X] Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->

- Add std::tuple and std::array serialization capabilities to VSL
- Update VXL minor version from 2.1.2.2 to 2.2.0.0 