### PR TITLE
BUG: Add missing VSL_EXPORT for io functions to fix VS build errors

### DIFF
--- a/core/vsl/vsl_map_io.hxx
+++ b/core/vsl/vsl_map_io.hxx
@@ -88,9 +88,9 @@ void vsl_print_summary(std::ostream& os, const std::map<Key, T, Compare> &v)
 
 
 #define VSL_MAP_IO_INSTANTIATE(Key, T, Compare) \
-template void vsl_print_summary(std::ostream&, const std::map<Key, T, Compare >&); \
-template void vsl_b_write(vsl_b_ostream& s, const std::map<Key, T, Compare >& v); \
-template void vsl_b_read(vsl_b_istream& s, std::map<Key, T, Compare >& v)
+template VSL_EXPORT void vsl_print_summary(std::ostream&, const std::map<Key, T, Compare >&); \
+template VSL_EXPORT void vsl_b_write(vsl_b_ostream& s, const std::map<Key, T, Compare >& v); \
+template VSL_EXPORT void vsl_b_read(vsl_b_istream& s, std::map<Key, T, Compare >& v)
 
 //====================================================================================
 //: Write multimap to binary stream
@@ -162,8 +162,8 @@ void vsl_print_summary(std::ostream& os, const std::multimap<Key, T, Compare> &v
 
 
 #define VSL_MULTIMAP_IO_INSTANTIATE(Key, T, Compare) \
-template void vsl_print_summary(std::ostream&, const std::multimap<Key, T, Compare >&); \
-template void vsl_b_write(vsl_b_ostream& s, const std::multimap<Key, T, Compare >& v); \
-template void vsl_b_read(vsl_b_istream& s, std::multimap<Key, T, Compare >& v)
+template VSL_EXPORT void vsl_print_summary(std::ostream&, const std::multimap<Key, T, Compare >&); \
+template VSL_EXPORT void vsl_b_write(vsl_b_ostream& s, const std::multimap<Key, T, Compare >& v); \
+template VSL_EXPORT void vsl_b_read(vsl_b_istream& s, std::multimap<Key, T, Compare >& v)
 
 #endif // vsl_map_io_hxx_

--- a/core/vsl/vsl_vector_io.hxx
+++ b/core/vsl/vsl_vector_io.hxx
@@ -122,8 +122,8 @@ void vsl_print_summary(std::ostream& os, const std::vector<T> &v)
 
 
 #define VSL_VECTOR_IO_INSTANTIATE(T) \
-template void vsl_print_summary(std::ostream& s, const std::vector<T >& v); \
-template void vsl_b_write(vsl_b_ostream& s, const std::vector<T >& v); \
-template void vsl_b_read(vsl_b_istream& s, std::vector<T >& v)
+template VSL_EXPORT void vsl_print_summary(std::ostream& s, const std::vector<T >& v); \
+template VSL_EXPORT void vsl_b_write(vsl_b_ostream& s, const std::vector<T >& v); \
+template VSL_EXPORT void vsl_b_read(vsl_b_istream& s, std::vector<T >& v)
 
 #endif // vsl_vector_io_hxx_


### PR DESCRIPTION
This PR fixes some of the Visual Studio link errors in vnl_io. These are unresolved external symbol errors that come from missing VSL_EXPORT decorations in the relative vsl class. There are still similar errors coming from vnl_io_real_polynomial and vnl_io_real_npolynomial but I'm not yet sure how to fix those.

