### PR TITLE
COMP: Remove implicit addition of -msse2 flag

### DIFF
--- a/config/cmake/config/VXLIntrospectionConfig.cmake
+++ b/config/cmake/config/VXLIntrospectionConfig.cmake
@@ -442,6 +442,7 @@ if(NOT VXL_HAS_SSE2_HARDWARE_SUPPORT)
       " you may need to set VXL_UPDATE_CONFIGURATION to ON."
       CACHE INTERNAL "help string for how to enable SSE2 support" )
     set(CMAKE_REQUIRED_FLAGS ${VXL_SSE_TEST_FLAG_BACKUP})
+    unset(VXL_SSE_TEST_FLAG_BACKUP)
   endif()
 endif()
 

--- a/core/vnl/CMakeLists.txt
+++ b/core/vnl/CMakeLists.txt
@@ -254,12 +254,25 @@ set( vnl_sources
 aux_source_directory(Templates vnl_sources)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-  # gcc must have -msse2 option to enable sse2 support
   if(VNL_CONFIG_ENABLE_SSE2)
-    add_definitions( -msse2 )
+    if( NOT VXL_HAS_SSE2_HARDWARE_SUPPORT )
+      if( VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE )
+        message( ${VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE_HELP} )
+      endif()
+      message( SEND_ERROR "Cannot have VNL_CONFIG_ENABLE_SSE2 because"
+                          " there is no SSE2 hardware support" )
+      set(VNL_CONFIG_ENABLE_SSE2 FALSE)
+    endif()
   endif()
   if(VNL_CONFIG_ENABLE_SSE2_ROUNDING)
-    add_definitions( -msse2 )
+    if( NOT VXL_HAS_SSE2_HARDWARE_SUPPORT )
+      if( VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE )
+        message( ${VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE_HELP} )
+      endif()
+      message( SEND_ERROR "Cannot have VNL_CONFIG_ENABLE_SSE2_ROUNDING because"
+                          " there is no SSE2 hardware support" )
+      set(VNL_CONFIG_ENABLE_SSE2_ROUNDING FALSE)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
If sse2 build options are requested, require that they
be requested additions of compiler flags.
