### PR TITLE
ENH: vxl_add_library refactor

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -53,7 +53,7 @@ macro(vxl_configure_file_copyonly infile outfile installprefix)
 endmacro()
 
 #
-# A macro to configure where libraries are to be installed for
+# A function to configure where libraries are to be installed for
 # vxl for adding a library, setting it's properties, and
 # setting it's install location
 #
@@ -66,75 +66,64 @@ endmacro()
 #                      not its default value; otherwise, the relative path in
 #                      the vxl source tree is used.
 #
-macro( vxl_add_library )
-  unset(lib_srcs)
-  unset(header_install_dir)
-  unset(_doing)
-  foreach(arg ${ARGN})
-    ### Parse itk_module named options
-    if("${arg}" MATCHES "^LIBRARY_NAME$")
-      set(_doing "${arg}")
-    elseif("${arg}" MATCHES "^LIBRARY_SOURCES$")
-      set(_doing "${arg}")
-    elseif("${arg}" MATCHES "^HEADER_INSTALL_DIR$")
-      set(_doing "${arg}")
-    ### Parse named option parameters
-    elseif("${_doing}" MATCHES "^LIBRARY_NAME$")
-      set(lib_name "${arg}")
-    elseif("${_doing}" MATCHES "^LIBRARY_SOURCES$")
-      list(APPEND lib_srcs "${arg}")
-    elseif("${_doing}" MATCHES "^HEADER_INSTALL_DIR$")
-      set(header_install_dir "${arg}")
-    endif()
-  endforeach()
+function( vxl_add_library )
+  cmake_parse_arguments(vxl_add
+     ""  # options
+     "LIBRARY_NAME;HEADER_INSTALL_DIR"  # oneValueArgs
+     "LIBRARY_SOURCES"  # multiValueArgs
+     ${ARGN} )
 
   ## If not source files, then no lib created
-  list(LENGTH lib_srcs num_src_files)
+  list(LENGTH vxl_add_LIBRARY_SOURCES num_src_files)
   if( ${num_src_files} GREATER 0 )
-    add_library(${lib_name} ${lib_srcs} )
+    add_library(${vxl_add_LIBRARY_NAME} ${vxl_add_LIBRARY_SOURCES} )
     if(MSVC) # This enables object-level build parallelism in VNL libraries for MSVC
-      target_compile_definitions(${lib_name} PRIVATE " /MP ")
+      target_compile_definitions(${vxl_add_LIBRARY_NAME} PRIVATE " /MP ")
     endif()
 
-    set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES ${lib_name})
+    set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES ${vxl_add_LIBRARY_NAME})
     if(VXL_LIBRARY_PROPERTIES)
-       set_target_properties(${lib_name} PROPERTIES ${VXL_LIBRARY_PROPERTIES})
+       set_target_properties(${vxl_add_LIBRARY_NAME} PROPERTIES ${VXL_LIBRARY_PROPERTIES})
     endif()
 
     # Installation
-    install(TARGETS ${lib_name}
+    install(TARGETS ${vxl_add_LIBRARY_NAME}
       EXPORT ${VXL_INSTALL_EXPORT_NAME}
       RUNTIME DESTINATION ${VXL_INSTALL_RUNTIME_DIR} COMPONENT RuntimeLibraries
       LIBRARY DESTINATION ${VXL_INSTALL_LIBRARY_DIR} COMPONENT RuntimeLibraries
       ARCHIVE DESTINATION ${VXL_INSTALL_ARCHIVE_DIR} COMPONENT Development)
   endif()
+
+  # build interface
+  set(vxl_add_BUILD_INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+  target_include_directories(${vxl_add_LIBRARY_NAME} PUBLIC
+      "$<BUILD_INTERFACE:${vxl_add_BUILD_INTERFACE}>"
+  )
+
+  # install interface
+
   # If VXL_INSTALL_INCLUDE_DIR is the default value
   if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
     ## Identify the relative path for installing the header files and txx files
     string(REPLACE ${VXL_ROOT_SOURCE_DIR} "${VXL_INSTALL_INCLUDE_DIR}" relative_install_path ${CMAKE_CURRENT_SOURCE_DIR})
-    target_include_directories(${lib_name}
-      PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    target_include_directories(${vxl_add_LIBRARY_NAME} PUBLIC
         $<INSTALL_INTERFACE:${relative_install_path}>
     )
   else()
     set(relative_install_path "${VXL_INSTALL_INCLUDE_DIR}")
-    if(DEFINED header_install_dir)
-      set(relative_install_path "${relative_install_path}/${header_install_dir}")
+    if(DEFINED vxl_add_HEADER_INSTALL_DIR)
+      set(relative_install_path "${relative_install_path}/${vxl_add_HEADER_INSTALL_DIR}")
     endif()
-    target_include_directories(${lib_name}
-      PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    target_include_directories(${vxl_add_LIBRARY_NAME} PUBLIC
         $<INSTALL_INTERFACE:${VXL_INSTALL_INCLUDE_DIR}>
     )
   endif()
-  INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${lib_srcs})
-  unset(lib_srcs)
-  unset(header_install_dir)
-  unset(_doing)
-endmacro()
 
-include(CMakeParseArguments)
+  INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${vxl_add_LIBRARY_NAME})
+
+endfunction()
+
+
 # This macro sets a targets visibility to
 # hidden, and configures the header that
 # contains the proper export defines

--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -61,6 +61,10 @@ endmacro()
 #  LIBRARY_SOURCES     (required) is a list of sources needed to create the
 #                      library. It should also contain headers to install for
 #                      building against the library.
+#  HEADER_BUILD_DIR    (optional) directory to append to library target
+#                      BUILD_INTERFACE. Useful to include a target build
+#                      directory (CMAKE_CURRENT_BINARY_DIR) containing files
+#                      generated via vxl_configure_file.
 #  HEADER_INSTALL_DIR  (optional) directory to install headers relative to
 #                      VXL_INSTALL_INCLUDE_DIR if VXL_INSTALL_INCLUDE_DIR is
 #                      not its default value; otherwise, the relative path in
@@ -69,7 +73,7 @@ endmacro()
 function( vxl_add_library )
   cmake_parse_arguments(vxl_add
      ""  # options
-     "LIBRARY_NAME;HEADER_INSTALL_DIR"  # oneValueArgs
+     "LIBRARY_NAME;HEADER_BUILD_DIR;HEADER_INSTALL_DIR"  # oneValueArgs
      "LIBRARY_SOURCES"  # multiValueArgs
      ${ARGN} )
 
@@ -95,9 +99,13 @@ function( vxl_add_library )
   endif()
 
   # build interface
-  set(vxl_add_BUILD_INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(build_interface "${CMAKE_CURRENT_SOURCE_DIR}")
+  if (DEFINED vxl_add_HEADER_BUILD_DIR)
+    list(APPEND build_interface "${vxl_add_HEADER_BUILD_DIR}")
+  endif()
+
   target_include_directories(${vxl_add_LIBRARY_NAME} PUBLIC
-      "$<BUILD_INTERFACE:${vxl_add_BUILD_INTERFACE}>"
+      "$<BUILD_INTERFACE:${build_interface}>"
   )
 
   # install interface

--- a/core/vgl/algo/vgl_compute_cremona_2d.h
+++ b/core/vgl/algo/vgl_compute_cremona_2d.h
@@ -29,7 +29,7 @@
 // UNITY_DENOMINATOR  - both denominators are 1 - so not a rational form (analogous to affine)
 //
 #include <iosfwd>
-#include <vgl_norm_trans_2d.h>
+#include <vgl/algo/vgl_norm_trans_2d.h>
 #include <vgl/vgl_homg_point_2d.h>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>

--- a/core/vgl/tests/test_quadric.cxx
+++ b/core/vgl/tests/test_quadric.cxx
@@ -7,7 +7,7 @@
 #ifdef _MSC_VER
 #  include "vcl_msvc_warnings.h"
 #endif
-#include <vgl_tolerance.h>
+#include <vgl/vgl_tolerance.h>
 // multiply square matrices
 static std::vector<std::vector<double>>
 mul(std::vector<std::vector<double>> const & a, std::vector<std::vector<double>> const & b)

--- a/core/vil/CMakeLists.txt
+++ b/core/vil/CMakeLists.txt
@@ -353,7 +353,10 @@ set( vil_network_sources
   vil_stream_url.cxx vil_stream_url.h
 )
 
-vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vil LIBRARY_SOURCES ${vil_sources} ${vil_network_sources})
+vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vil
+    HEADER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}"  # vil_config.h
+    LIBRARY_SOURCES ${vil_sources} ${vil_network_sources}
+)
 
 if(JPEG_FOUND)
   target_link_libraries( ${VXL_LIB_PREFIX}vil ${JPEG_LIBRARIES} )

--- a/core/vnl/CMakeLists.txt
+++ b/core/vnl/CMakeLists.txt
@@ -278,6 +278,7 @@ endif()
 
 vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}vnl
   LIBRARY_SOURCES ${vnl_sources}
+  HEADER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}"  # vnl_config.h
   HEADER_INSTALL_DIR vnl)
 target_link_libraries( ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vcl )
 set(_curr_lib_name vnl)

--- a/core/vpgl/algo/tests/test_lens_warp_mapper.cxx
+++ b/core/vpgl/algo/tests/test_lens_warp_mapper.cxx
@@ -5,7 +5,7 @@
 #endif
 #include "vgl/vgl_point_2d.h"
 #include "vpgl/vpgl_poly_radial_distortion.h"
-#include <vpgl_radial_tangential_distortion.h>
+#include <vpgl/vpgl_radial_tangential_distortion.h>
 #include <vpgl/algo/vpgl_lens_warp_mapper.h>
 #include "vil/vil_image_view.h"
 #include "vil/vil_save.h"

--- a/core/vpgl/algo/vpgl_backproject_dem.h
+++ b/core/vpgl/algo/vpgl_backproject_dem.h
@@ -18,7 +18,7 @@
 #include <vpgl/vpgl_rational_camera.h>
 #include <vnl/vnl_double_2.h>
 #include <vnl/vnl_double_3.h>
-#include <vgl_point_3d.h>
+#include <vgl/vgl_point_3d.h>
 #include <vil/vil_image_resource_sptr.h>
 #include <vil/vil_image_view.h>
 class vpgl_geo_camera; //forward declare for ptr

--- a/core/vpgl/algo/vpgl_equi_rectification.cxx
+++ b/core/vpgl/algo/vpgl_equi_rectification.cxx
@@ -5,8 +5,8 @@
 #include "vgl/vgl_homg_point_2d.h"
 #include "vgl/vgl_tolerance.h"
 #include <math.h>
-#include <vnl_det.h>
-#include <vnl_inverse.h>
+#include <vnl/vnl_det.h>
+#include <vnl/vnl_inverse.h>
 #include <vpgl/vpgl_essential_matrix.h>
 bool vpgl_equi_rectification::column_transform(const std::vector<vnl_vector_fixed<double, 3> >& img_pts0,
                                                const std::vector<vnl_vector_fixed<double, 3> >& img_pts1,


### PR DESCRIPTION
Refactor `vxl_add_library` as function (local scope eliminates need for `unset` commands) and replace custom parsing code with `cmake_parse_arguments`. 

Add `HEADER_BUILD_DIR` argument to `vxl_add_library`. This lets us conveniently attach the build directory (e.g., `$CMAKE_CURRENT_BUILD_DIR`) to a target's `BUILD_INTERFACE` for build-generated header files (e.g., files derived from *.h.in generated via the `vxl_configure_file` macro).

Add `HEADER_BUILD_DIR` to vnl & vil targets.

Additionally update several core/algo #include directives to standard form

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative)
- ❌ Adds documentation
