### PR TITLE
STYLE: contrib/brl #include

### DIFF
--- a/contrib/brl/bbas/brad/brad_image_metadata.cxx
+++ b/contrib/brl/bbas/brad/brad_image_metadata.cxx
@@ -30,7 +30,7 @@
 
 #include <brad/brad_sun_pos.h>
 
-#include <bbas/bres/bres_find.h>
+#include <bres/bres_find.h>
 
 const std::string brad_image_metadata::gain_offset_file_name = std::string("contrib/brl/bbas/brad/brad_sat_img_calibration_table.txt");
 const std::string brad_image_metadata::sun_irradiance_file_name = std::string("contrib/brl/bbas/brad/brad_sat_img_sun_irradiance_table.txt");

--- a/contrib/brl/bbas/brad/brad_sun_dir_index.h
+++ b/contrib/brl/bbas/brad/brad_sun_dir_index.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <iostream>
 #include <iosfwd>
-#include <bbas/bsta/bsta_spherical_histogram.h>
+#include <bsta/bsta_spherical_histogram.h>
 #include <vnl/vnl_double_3.h>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>

--- a/contrib/brl/bbas/brad/brad_sun_pos.h
+++ b/contrib/brl/bbas/brad/brad_sun_pos.h
@@ -24,7 +24,7 @@
 #ifndef __BRAD_SUN_POS_H
 #define __BRAD_SUN_POS_H
 
-#include <bbas/bsta/bsta_spherical_histogram.h>
+#include <bsta/bsta_spherical_histogram.h>
 
 
 //: the position of the sun relative to the local tangent plane

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+float-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+float-.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_2d_geo_index<float>
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
 BVGL_2D_GEO_INDEX_INSTANTIATE(float);

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+int-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+int-.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_2d_geo_index<int>
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
 BVGL_2D_GEO_INDEX_INSTANTIATE(int);

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+vcl_vector+float--.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+vcl_vector+float--.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_2d_geo_index<std::vector<float> >
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
 BVGL_2D_GEO_INDEX_INSTANTIATE(std::vector<float> );

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+vcl_vector+int--.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_2d_geo_index+vcl_vector+int--.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_2d_geo_index<std::vector<int> >
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
 BVGL_2D_GEO_INDEX_INSTANTIATE(std::vector<int> );

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_ptset_3d_ops+double-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_ptset_3d_ops+double-.cxx
@@ -1,4 +1,4 @@
 // Instantiation of bvgl_ptset_3d_ops<double>
-#include <bbas/bvgl/algo/bvgl_ptset_3d_ops.hxx>
+#include <bvgl/algo/bvgl_ptset_3d_ops.hxx>
 BVGL_PTSET_3D_OPS_INSTANTIATE(double);
 

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_ptset_3d_ops+float-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_ptset_3d_ops+float-.cxx
@@ -1,4 +1,4 @@
 // Instantiation of bvgl_ptset_3d_ops<float>
-#include <bbas/bvgl/algo/bvgl_ptset_3d_ops.hxx>
+#include <bvgl/algo/bvgl_ptset_3d_ops.hxx>
 BVGL_PTSET_3D_OPS_INSTANTIATE(float);
 

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_register_ptsets_3d_rigid+double-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_register_ptsets_3d_rigid+double-.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_register_ptsets_3d_rigid<double>
-#include <bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx>
+#include <bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx>
 BVGL_REGISTER_PTSETS_3D_RIGID_INSTANTIATE(double);

--- a/contrib/brl/bbas/bvgl/algo/Templates/bvgl_register_ptsets_3d_rigid+float-.cxx
+++ b/contrib/brl/bbas/bvgl/algo/Templates/bvgl_register_ptsets_3d_rigid+float-.cxx
@@ -1,3 +1,3 @@
 // Instantiation of bvgl_register_ptsets_3d_rigid<float>
-#include <bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx>
+#include <bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx>
 BVGL_REGISTER_PTSETS_3D_RIGID_INSTANTIATE(float);

--- a/contrib/brl/bbas/volm/conf/Templates/bvgl_2d_geo_index+volm_conf_land_map_indexer-.cxx
+++ b/contrib/brl/bbas/volm/conf/Templates/bvgl_2d_geo_index+volm_conf_land_map_indexer-.cxx
@@ -1,5 +1,5 @@
 // Instantiation of bvgl_2d_geo_index<volm_conf_land_map_indexer>
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
-#include <bbas/volm/conf/volm_conf_land_map_indexer.h>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <volm/conf/volm_conf_land_map_indexer.h>
 BVGL_2D_GEO_INDEX_INSTANTIATE(volm_conf_land_map_indexer);
 BVGL_2D_GEO_INDEX_INSTANTIATE(volm_conf_land_map_indexer_sptr)

--- a/contrib/brl/bbas/volm/tests/test_camera_space.cxx
+++ b/contrib/brl/bbas/volm/tests/test_camera_space.cxx
@@ -4,7 +4,7 @@
 #ifdef _MSC_VER
 #  include "vcl_msvc_warnings.h"
 #endif
-#include <bbas/volm/volm_camera_space.h>
+#include <volm/volm_camera_space.h>
 
 static void test_camera_space()
 {

--- a/contrib/brl/bbas/volm/tests/test_index.cxx
+++ b/contrib/brl/bbas/volm/tests/test_index.cxx
@@ -9,9 +9,9 @@
 #include "vil/vil_save.h"
 #include "vsl/vsl_binary_io.h"
 #include "vul/vul_timer.h"
-#include <bbas/volm/volm_tile.h>
-#include <bbas/volm/volm_geo_index.h>
-#include <bbas/volm/volm_io.h>
+#include <volm/volm_tile.h>
+#include <volm/volm_geo_index.h>
+#include <volm/volm_io.h>
 #include <bkml/bkml_parser.h>
 
 static void test_index()

--- a/contrib/brl/bbas/volm/tests/test_io.cxx
+++ b/contrib/brl/bbas/volm/tests/test_io.cxx
@@ -8,9 +8,9 @@
 #include <depth_map/depth_map_scene.h>
 #include <depth_map/depth_map_region_sptr.h>
 #include "vsl/vsl_binary_io.h"
-#include <bbas/volm/volm_tile.h>
-#include <bbas/volm/volm_geo_index.h>
-#include <bbas/volm/volm_io.h>
+#include <volm/volm_tile.h>
+#include <volm/volm_geo_index.h>
+#include <volm/volm_io.h>
 #include <volm/volm_category_io.h>
 #include <bkml/bkml_parser.h>
 #include <vcl_where_root_dir.h>

--- a/contrib/brl/bbas/volm/tests/test_loc_hyp.cxx
+++ b/contrib/brl/bbas/volm/tests/test_loc_hyp.cxx
@@ -9,7 +9,7 @@
 #include "vil/vil_save.h"
 #include "vsl/vsl_binary_io.h"
 #include "vul/vul_timer.h"
-#include <bbas/volm/volm_loc_hyp.h>
+#include <volm/volm_loc_hyp.h>
 #include "vgl/vgl_polygon.h"
 #include <bkml/bkml_parser.h>
 

--- a/contrib/brl/bbas/volm/tests/test_spherical_container.cxx
+++ b/contrib/brl/bbas/volm/tests/test_spherical_container.cxx
@@ -5,7 +5,7 @@
 #endif
 #include "vpl/vpl.h"
 #include "vsl/vsl_binary_io.h"
-#include <bbas/volm/volm_spherical_container.h>
+#include <volm/volm_spherical_container.h>
 
 static void test_spherical_container()
 {

--- a/contrib/brl/bbas/volm/tests/test_spherical_shell_container.cxx
+++ b/contrib/brl/bbas/volm/tests/test_spherical_shell_container.cxx
@@ -4,8 +4,8 @@
 #  include "vcl_msvc_warnings.h"
 #endif
 #include "vpl/vpl.h"
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
 
 static void test_spherical_shell_container()
 {

--- a/contrib/brl/bbas/volm/tests/test_tile.cxx
+++ b/contrib/brl/bbas/volm/tests/test_tile.cxx
@@ -10,7 +10,7 @@
 #include "vil/vil_save.h"
 #include "vsl/vsl_binary_io.h"
 #include "vul/vul_timer.h"
-#include <bbas/volm/volm_tile.h>
+#include <volm/volm_tile.h>
 
 static void test_tile()
 {

--- a/contrib/brl/bbas/volm/volm_buffered_index.cxx
+++ b/contrib/brl/bbas/volm/volm_buffered_index.cxx
@@ -4,7 +4,7 @@
 #include "volm_buffered_index.h"
 //:
 // \file
-#include <bbas/volm/volm_spherical_container.h>
+#include <volm/volm_spherical_container.h>
 #include <boxm2/volm/boxm2_volm_locations.h>
 #include "vgl/vgl_box_3d.h"
 #ifdef _MSC_VER

--- a/contrib/brl/bseg/boxm2/Templates/bvgl_2d_geo_index+vcl_vector+boxm2_block_id--.cxx
+++ b/contrib/brl/bseg/boxm2/Templates/bvgl_2d_geo_index+vcl_vector+boxm2_block_id--.cxx
@@ -1,4 +1,4 @@
 // Instantiation of bvgl_2d_geo_index<std::vector<boxm2_block_id> >
-#include <bbas/bvgl/algo/bvgl_2d_geo_index.hxx>
+#include <bvgl/algo/bvgl_2d_geo_index.hxx>
 #include <boxm2/basic/boxm2_block_id.h>
 BVGL_2D_GEO_INDEX_INSTANTIATE(std::vector<boxm2_block_id> );

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.cxx
@@ -5,7 +5,7 @@
 //:
 // \file
 #include <cassert>
-#include <bbas/imesh/imesh_vertex.h>
+#include <imesh/imesh_vertex.h>
 #include <imesh/algo/imesh_intersect.h>
 #include <imesh/imesh_operations.h>
 #include <bvgl/bvgl_intersection.h>

--- a/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.h
+++ b/contrib/brl/bseg/boxm2/cpp/algo/boxm2_points_to_volume_function.h
@@ -11,7 +11,7 @@
 #include <boxm2/cpp/algo/boxm2_mog3_grey_processor.h>
 #include <boxm2/io/boxm2_cache.h>
 #include <boct/boct_bit_tree.h>
-#include <bbas/imesh/imesh_mesh.h>
+#include <imesh/imesh_mesh.h>
 #include <imesh/algo/imesh_kd_tree.h>
 #include <bvgl/bvgl_triangle_3d.h>
 #include <vnl/vnl_vector_fixed.h>

--- a/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_points_to_volume_process.cxx
+++ b/contrib/brl/bseg/boxm2/cpp/pro/processes/boxm2_cpp_points_to_volume_process.cxx
@@ -21,8 +21,8 @@
 #include <boxm2/cpp/algo/boxm2_points_to_volume_function.h>
 
 //imesh/point cloud stuff
-#include <bbas/imesh/imesh_mesh.h>
-#include <bbas/imesh/imesh_fileio.h>
+#include <imesh/imesh_mesh.h>
+#include <imesh/imesh_fileio.h>
 
 //directory utility
 #include <vcl_where_root_dir.h>

--- a/contrib/brl/bseg/boxm2/io/boxm2_asio_mgr.h
+++ b/contrib/brl/bseg/boxm2/io/boxm2_asio_mgr.h
@@ -13,7 +13,7 @@
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
-#include <bbas/baio/baio.h>
+#include <baio/baio.h>
 #include <vul/vul_file.h>
 
 //: disk level storage class.

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.cxx
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.cxx
@@ -3,7 +3,7 @@
 #include "boxm2_volm_wr3db_index.h"
 //:
 // \file
-#include <bbas/volm/volm_spherical_container.h>
+#include <volm/volm_spherical_container.h>
 #include <boxm2/volm/boxm2_volm_locations.h>
 #include "vgl/vgl_box_3d.h"
 #ifdef _MSC_VER

--- a/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.h
+++ b/contrib/brl/bseg/boxm2/volm/boxm2_volm_wr3db_index.h
@@ -34,8 +34,8 @@
 #include <iostream>
 #include <fstream>
 #include <vbl/vbl_ref_count.h>
-#include <bbas/volm/volm_spherical_container.h>
-#include <bbas/volm/volm_spherical_container_sptr.h>
+#include <volm/volm_spherical_container.h>
+#include <volm/volm_spherical_container_sptr.h>
 #include <boxm2/boxm2_scene.h>
 #include <boxm2/volm/boxm2_volm_locations_sptr.h>
 #ifdef _MSC_VER

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_volm_segment_index.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_volm_segment_index.cxx
@@ -20,8 +20,8 @@
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p0.h>
 #include <bkml/bkml_parser.h>
-#include <bbas/volm/volm_io.h>
-#include <bbas/volm/volm_vrml_io.h>
+#include <volm/volm_io.h>
+#include <volm/volm_vrml_io.h>
 
 int main(int argc, char** argv)
 {

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p0.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p0.cxx
@@ -19,12 +19,12 @@
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p0.h>
-#include <bbas/bocl/bocl_manager.h>
-#include <bbas/bocl/bocl_device.h>
+#include <bocl/bocl_manager.h>
+#include <bocl/bocl_device.h>
 #include <bkml/bkml_parser.h>
 #include "vil/vil_save.h"
-#include <bbas/volm/volm_io.h>
-#include <bbas/volm/volm_vrml_io.h>
+#include <volm/volm_io.h>
+#include <volm/volm_vrml_io.h>
 
 
 int main(int argc, char** argv)

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p1.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p1.cxx
@@ -24,8 +24,8 @@
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p1.h>
-#include <bbas/bocl/bocl_manager.h>
-#include <bbas/bocl/bocl_device.h>
+#include <bocl/bocl_manager.h>
+#include <bocl/bocl_device.h>
 #include <bkml/bkml_parser.h>
 
 int main(int argc, char** argv)

--- a/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p1_integration.cxx
+++ b/contrib/brl/bseg/boxm2/volm/exe/boxm2_volumetric_matcher_p1_integration.cxx
@@ -26,8 +26,8 @@
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p1.h>
-#include <bbas/bocl/bocl_manager.h>
-#include <bbas/bocl/bocl_device.h>
+#include <bocl/bocl_manager.h>
+#include <bocl/bocl_device.h>
 #include <bkml/bkml_parser.h>
 
 int main(int argc, char** argv)

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_change_scene_res_by_geo_cover_process.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_change_scene_res_by_geo_cover_process.cxx
@@ -16,8 +16,8 @@
 #include <volm/volm_tile.h>
 #include <volm/volm_category_io.h>
 #include "vgl/vgl_intersection.h"
-#include <bseg/boxm2/boxm2_block_metadata.h>
-#include <bseg/boxm2/boxm2_scene.h>
+#include <boxm2/boxm2_block_metadata.h>
+#include <boxm2/boxm2_scene.h>
 
 
 //: A process to change the resolution/refinement of blocks based on the land type

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_all_index_process.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_all_index_process.cxx
@@ -17,10 +17,10 @@
 #include <boxm2/boxm2_scene.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
-#include <bbas/volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_geo_index.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_loc_hyp.h>
+#include <volm/volm_geo_index.h>
 #include "vul/vul_timer.h"
 #include <bkml/bkml_write.h>
 

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_index_process.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_index_process.cxx
@@ -13,10 +13,10 @@
 #include <boxm2/boxm2_scene.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
-#include <bbas/volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_geo_index.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_loc_hyp.h>
+#include <volm/volm_geo_index.h>
 #include "vul/vul_timer.h"
 #include "vul/vul_file.h"
 #include "vul/vul_file_iterator.h"

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_index_process2.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_index_process2.cxx
@@ -14,10 +14,10 @@
 #include <boxm2/boxm2_scene.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
-#include <bbas/volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_geo_index.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_loc_hyp.h>
+#include <volm/volm_geo_index.h>
 #include "vul/vul_timer.h"
 #include "vul/vul_file.h"
 #include "vil/vil_save.h"

--- a/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_label_index_process.cxx
+++ b/contrib/brl/bseg/boxm2/volm/pro/processes/boxm2_create_label_index_process.cxx
@@ -15,10 +15,10 @@
 #include <boxm2/boxm2_scene.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
-#include <bbas/volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_geo_index.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_loc_hyp.h>
+#include <volm/volm_geo_index.h>
 #include "vul/vul_timer.h"
 #include "vul/vul_file.h"
 #include "vil/vil_save.h"

--- a/contrib/brl/bseg/boxm2/volm/tests/test_volm_matcher_p0.cxx
+++ b/contrib/brl/bseg/boxm2/volm/tests/test_volm_matcher_p0.cxx
@@ -4,8 +4,8 @@
 
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_query.h>
-#include <bbas/volm/volm_query_sptr.h>
+#include <volm/volm_query.h>
+#include <volm/volm_query_sptr.h>
 #include <volm/volm_camera_space.h>
 #include <volm/volm_camera_space_sptr.h>
 #include <volm/volm_spherical_region_query.h>
@@ -14,8 +14,8 @@
 #include <volm/volm_spherical_shell_container_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p0.h>
 #include <volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_io.h>
-#include <bbas/volm/volm_tile.h>
+#include <volm/volm_io.h>
+#include <volm/volm_tile.h>
 #include <boxm2/volm/boxm2_volm_locations.h>
 #include <boxm2/volm/boxm2_volm_locations_sptr.h>
 #ifdef _MSC_VER

--- a/contrib/brl/bseg/boxm2/volm/tests/test_volm_matcher_p1.cxx
+++ b/contrib/brl/bseg/boxm2/volm/tests/test_volm_matcher_p1.cxx
@@ -5,8 +5,8 @@
 #if HAS_OPENCL
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_query.h>
-#include <bbas/volm/volm_query_sptr.h>
+#include <volm/volm_query.h>
+#include <volm/volm_query_sptr.h>
 #include <volm/volm_camera_space.h>
 #include <volm/volm_camera_space_sptr.h>
 #include <volm/volm_spherical_container.h>
@@ -15,12 +15,12 @@
 #include <volm/volm_spherical_shell_container_sptr.h>
 #include <boxm2/volm/boxm2_volm_matcher_p1.h>
 #include <volm/volm_loc_hyp.h>
-#include <bbas/volm/volm_io.h>
-#include <bbas/volm/volm_tile.h>
+#include <volm/volm_io.h>
+#include <volm/volm_tile.h>
 #include <boxm2/volm/boxm2_volm_locations.h>
 #include <boxm2/volm/boxm2_volm_locations_sptr.h>
-#include <bbas/bocl/bocl_manager.h>
-#include <bbas/bocl/bocl_device.h>
+#include <bocl/bocl_manager.h>
+#include <bocl/bocl_device.h>
 #ifdef _MSC_VER
 #  include "vcl_msvc_warnings.h"
 #endif

--- a/contrib/brl/bseg/boxm2/volm/tests/test_volm_wr3db_ind.cxx
+++ b/contrib/brl/bseg/boxm2/volm/tests/test_volm_wr3db_ind.cxx
@@ -1,9 +1,9 @@
 #include "testlib/testlib_test.h"
 #include <boxm2/volm/boxm2_volm_wr3db_index.h>
 #include <boxm2/volm/boxm2_volm_wr3db_index_sptr.h>
-#include <bbas/volm/volm_spherical_container.h>
-#include <bbas/volm/volm_spherical_shell_container.h>
-#include <bbas/volm/volm_spherical_shell_container_sptr.h>
+#include <volm/volm_spherical_container.h>
+#include <volm/volm_spherical_shell_container.h>
+#include <volm/volm_spherical_shell_container_sptr.h>
 #include "vnl/vnl_random.h"
 
 static void test_volm_wr3db_ind()

--- a/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_particle_filter.h
+++ b/contrib/brl/bseg/bstm/ocl/algo/bstm_ocl_particle_filter.h
@@ -20,7 +20,7 @@
 #include <bstm/ocl/bstm_ocl_util.h>
 #include <vnl/vnl_matrix_fixed.h>
 #include <vnl/vnl_random.h>
-#include <bbas/bsta/bsta_gaussian_indep.h>
+#include <bsta/bsta_gaussian_indep.h>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif

--- a/contrib/brl/bseg/bvpl/pro/Templates/brdb_value_t+bvxm_voxel_grid_base_sptr-.cxx
+++ b/contrib/brl/bseg/bvpl/pro/Templates/brdb_value_t+bvxm_voxel_grid_base_sptr-.cxx
@@ -1,4 +1,4 @@
-#include <bseg/bvxm/grid/bvxm_voxel_grid_base_sptr.h>
+#include <bvxm/grid/bvxm_voxel_grid_base_sptr.h>
 #include <brdb/brdb_value.hxx>
 
 BRDB_VALUE_INSTANTIATE(bvxm_voxel_grid_base_sptr, "bvxm_voxel_grid_base_sptr");

--- a/contrib/brl/bseg/sdet/sdet_image_mesh.cxx
+++ b/contrib/brl/bseg/sdet/sdet_image_mesh.cxx
@@ -24,7 +24,7 @@
 #include <sdet/sdet_detector.h>
 #include <sdet/sdet_fit_lines_params.h>
 #include <sdet/sdet_fit_lines.h>
-#include <bbas/bil/algo/bil_cedt.h>
+#include <bil/algo/bil_cedt.h>
 #include <bvgl/bvgl_triangle_interpolation_iterator.h>
 #include <imesh/algo/imesh_generate_mesh.h>
 


### PR DESCRIPTION
In contrib/brl, BRL style dictates that the bbas/bseg folders are not appended to #include statements. Update #include statements that include `<bbas/...>` or `<bseg/...>` to remove extra folder identifier.

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
