### PR TITLE
ENH: append pointsets

### DIFF
--- a/core/vgl/vgl_pointset_3d.h
+++ b/core/vgl/vgl_pointset_3d.h
@@ -132,7 +132,10 @@ class vgl_pointset_3d
 
   void append_pointset(vgl_pointset_3d<Type> const& ptset){
     if(this->has_normals_ != ptset.has_normals())
+    {
+      std::cout<< "WARNING, cannot append a pointset without normals to one with normals." << std::endl;
       return; // can't be done
+    }
     unsigned npts = ptset.npts();
     for(unsigned i = 0; i<npts; ++i){
       if(!this->has_normals_&& !this->has_scalars_)


### PR DESCRIPTION
Adding a warning message to appending pointsets with and without normals. There is not really a good solution to what to do in this case, but it should not silently fail to append.


## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign:Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- :no_entry_sign:  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
