### PR TITLE
BUG: install header files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,3 +68,25 @@ jobs:
           name: Install
           working_directory: /build
           command: ninja install
+      - run:
+          name: Test install
+          working_directory: /build
+          command: |
+
+            # some expected install files
+            install_files=(
+                "/install/include/vxl/vcl/vcl_compiler.h"
+                "/install/include/vxl/core/vnl/vnl_math.h"
+                "/install/include/vxl/core/vnl/vnl_config.h"
+                "/install/include/vxl/core/vgl/vgl_point_3d.h"
+                "/install/include/vxl/core/vgl/vgl_export.h"
+            )
+
+            # spot check file existence
+            for file in "${install_files[@]}"
+            do
+              if [ ! -f "${file}" ]; then
+                echo "Missing installed file <${file}>" >& 2
+                exit 1
+              fi
+            done

--- a/.travis.yml
+++ b/.travis.yml
@@ -200,3 +200,23 @@ script:
   - ctest -D ExperimentalTest --schedule-random -j2 --output-on-failure
   - ctest -D ExperimentalSubmit
   - ninja install
+
+  # spot check install
+  - |
+    # some expected install files
+    install_files=(
+        "${PROJ_INSTALL_DIR}/include/vxl/vcl/vcl_compiler.h"
+        "${PROJ_INSTALL_DIR}/include/vxl/core/vnl/vnl_math.h"
+        "${PROJ_INSTALL_DIR}/include/vxl/core/vnl/vnl_config.h"
+        "${PROJ_INSTALL_DIR}/include/vxl/core/vgl/vgl_point_3d.h"
+        "${PROJ_INSTALL_DIR}/include/vxl/core/vgl/vgl_export.h"
+    )
+
+    # spot check file existence
+    for file in "${install_files[@]}"
+    do
+      if [ ! -f "${file}" ]; then
+        echo "Missing install file <${file}>" >& 2
+        exit 1
+      fi
+    done

--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -127,7 +127,7 @@ function( vxl_add_library )
     )
   endif()
 
-  INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${vxl_add_LIBRARY_NAME})
+  INSTALL_NOBASE_HEADER_FILES(${relative_install_path} ${vxl_add_LIBRARY_SOURCES})
 
 endfunction()
 


### PR DESCRIPTION
Fix bug introduced in PR #797 - `INSTALL_NOBASE_HEADER_FILES` expects library source files, not library name.  Also add CI install tests to spot check core header files (both standard & build-generated headers) for existence.

Fixes issue #801.

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

