### PR TITLE
ENH: Windowed BSGM processing

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_image_pair.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_image_pair.h
@@ -3,126 +3,199 @@
 #define bpgl_rectify_image_pair_h_
 //:
 // \file/
-// \brief rectify two images into a stero pair given cameras for each
+// \brief rectify two images into a stereo pair given cameras for each
 // \author J. L. Mundy
 // \date February 15, 2020
+// \modification Noah Johnson January 14, 2021
 //
 // a generalization of bpgl_rectify_affine_image_pair
 //
 #include <iostream>
+#include <utility>
 #include <vil/vil_image_resource.h>
 #include <vil/vil_image_view.h>
 #include <vil/vil_new.h>
 #include <vnl/vnl_matrix_fixed.h>
+#include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_box_3d.h>
 #include "rectify_params.h"
 
+
 //
-// requires two images and associated affine cameras. Class can load the data from files if needed.
-// the output is a pair of images that have common epipolar lines along image rows. The difference in
-// column coordinates of corresponding points is minimized.
+// Rectification is split up into two parts, both of which are exposed as public methods.
+// compute_rectification() computes rectification homographies for a camera pair.
+// warp_image() warps an image using a homography.
+// process() will run both parts sequentially for you.
+// The output (rectified_fview0 and rectified_fview1) is a pair of images that
+// have common epipolar lines along image rows. The difference in column
+// coordinates of corresponding points is minimized.
 //
 template <class CAMT>
 class bpgl_rectify_image_pair
 {
  public:
-  bpgl_rectify_image_pair() { set_valid_types(); }
 
-  bpgl_rectify_image_pair(vil_image_view_base_sptr const& view0, CAMT const& cam0,
-                          vil_image_view_base_sptr const& view1, CAMT const& cam1)
+  //: constructor
+  bpgl_rectify_image_pair(double min_disparity_z = NAN, size_t n_points = 1000,
+                          double upsample_scale = 1.0, float invalid_pixel_val = 0.0f,
+                          double min_overlap_fraction = 0.25, int window_padding = 0,
+                          size_t kernel_margin = 0)
   {
-    bool good = this->set_images_and_cams(view0,cam0,view1,cam1);
-    set_valid_types();
-  }
+    this->set_valid_types();
 
-  bpgl_rectify_image_pair(vil_image_view<unsigned char> const& view0, CAMT const& cam0,
-                          vil_image_view<unsigned char> const& view1, CAMT const& cam1)
-  {
-    bool good = this->set_images_and_cams(view0,cam0,view1,cam1);
-    set_valid_types();
-  }
-
-  bpgl_rectify_image_pair(vil_image_resource_sptr const& resc0, CAMT const& cam0,
-                          vil_image_resource_sptr const& resc1, CAMT const& cam1)
-  {
-    bool good = this->set_images_and_cams(resc0,cam0,resc1,cam1);
-    set_valid_types();
-  }
-
-  //: set parameter values
-  void set_param_values(double min_disparity_z = NAN, size_t n_points = 1000,
-                        double upsample_scale =1.0, float invalid_pixel_val = 0.0f){
+    // if min_disparity_z_ is NAN then 1/2 the midpoint of scene_box z is used
     params_.min_disparity_z_ = min_disparity_z;
     params_.n_points_ = n_points;
     params_.upsample_scale_ = upsample_scale;
     params_.invalid_pixel_val_ = invalid_pixel_val;
+    params_.min_overlap_fraction_ = min_overlap_fraction;
+    params_.window_padding_ = window_padding;
+    params_.kernel_margin_ = kernel_margin;
   }
 
-  //: set images & cameras
-  bool set_images_and_cams(vil_image_view_base_sptr const& view0, CAMT const& cam0,
-                           vil_image_view_base_sptr const& view1, CAMT const& cam1);
+  //: setters
+  void set_params(rectify_params const& params) { params_ = params; }
 
-  bool set_images_and_cams(vil_image_view<unsigned char> const& view0, CAMT const& cam0,
-                           vil_image_view<unsigned char> const& view1, CAMT const& cam1)
+  void set_images(vil_image_view_base_sptr const& view0,
+                  vil_image_view_base_sptr const& view1);
+
+  void set_images(vil_image_view<unsigned char> const& view0,
+                  vil_image_view<unsigned char> const& view1)
   {
-    return set_images_and_cams(vil_new_image_resource_of_view(view0), cam0, vil_new_image_resource_of_view(view1), cam1);
+    this->set_images(vil_new_image_resource_of_view(view0), vil_new_image_resource_of_view(view1));
   }
 
-  bool set_images_and_cams(vil_image_resource_sptr const& resc0, CAMT const& cam0,
-                           vil_image_resource_sptr const& resc1, CAMT const& cam1);
+  void set_images(vil_image_resource_sptr const& resc0,
+                  vil_image_resource_sptr const& resc1);
+
+  void set_cameras(CAMT const& cam0, CAMT const& cam1)
+  {
+    cam0_ = cam0;
+    cam1_ = cam1;
+  }
+
+  void set_homographies(vnl_matrix_fixed<double, 3, 3>& H0,
+                        vnl_matrix_fixed<double, 3, 3>& H1,
+                        size_t out_ni, size_t out_nj)
+  {
+    H0_ = H0;
+    H1_ = H1;
+    out_ni_ = out_ni;
+    out_nj_ = out_nj;
+  }
 
   //: accessors
-  const CAMT& cam0()const{return cam0_;}
-  const CAMT& cam1()const{return cam1_;}
-  const CAMT& rect_cam0()const{return rect_cam0_;}
-  const CAMT& rect_cam1()const{return rect_cam1_;}
-  const vil_image_view<float>& input_float_view0()const{return fview0_;}
-  const vil_image_view<float>& input_float_view1()const{return fview1_;}
-  const vil_image_view<float>& rectified_fview0() const{return rect_fview0_;}
-  const vil_image_view<float>& rectified_fview1() const{return rect_fview1_;}
+  const vgl_box_2d<int>& rect_window0() const {return rect_window0_;}
+  const vgl_box_2d<int>& rect_window1() const {return rect_window1_;}
+  const CAMT& cam0() const {return cam0_;}
+  const CAMT& cam1() const {return cam1_;}
+  const vil_image_view<float>& input_float_view0() const {return fview0_;}
+  const vil_image_view<float>& input_float_view1() const {return fview1_;}
+  const vil_image_view<float>& rectified_fview0() const {return rect_fview0_;}
+  const vil_image_view<float>& rectified_fview1() const {return rect_fview1_;}
   vnl_matrix_fixed<double, 3, 3> H0() const {return H0_;}
   vnl_matrix_fixed<double, 3, 3> H1() const {return H1_;}
+  std::pair<size_t, size_t> rectified_dims() {return std::pair<size_t, size_t>(out_ni_, out_nj_);}
 
   //: utility methods
   bool load_camera(std::string const& cam_path, CAMT& cam);
-  void set_params(rectify_params const& params) { params_ = params; }
 
-  bool process(vgl_box_3d<double>const& scene_box)
-  {
-    // if min_disparity_z_ is NAN then 1/2 the midpoint of scene_box z is used
-    if(!compute_rectification(scene_box, params_.n_points_, params_.min_disparity_z_))
-      return false;
-    warp_pair();
-    return true;
-  }
-  //: rectified image dimensions
-  void rectified_dims(size_t& width, size_t& height){width = out_ni_; height = out_nj_;}
- protected:
-
-  // protected utility methods
-  bool compute_rectification(vgl_box_3d<double> const& scene_box, size_t n_points = 1000, double average_z = NAN);
-  void compute_warp_dimensions_offsets();
   void warp_image(vil_image_view<float> fview,
                   vnl_matrix_fixed<double, 3, 3> const& H,
                   vil_image_view<float>& fwarp,
-                  size_t out_ni, size_t out_nj);
-  void warp_pair();
+                  size_t out_ni, size_t out_nj,
+                  vgl_box_2d<int> const& rectified_window = vgl_box_2d<int>(),
+                  size_t margin = 0);
+
+  CAMT rectify_camera(CAMT cam, vnl_matrix_fixed<double, 3, 3> H);
+
+  vgl_box_2d<int> rectify_window(vgl_box_2d<int> const& window,
+                                 vnl_matrix_fixed<double, 3, 3> H,
+                                 size_t ni, size_t nj,
+                                 int padding = 0);
+
+  // part 1 of rectification
+  void compute_rectification(vgl_box_3d<double>const& scene_box,
+                             int ni0 = -1, int nj0 = -1,
+                             int ni1 = -1, int nj1 = -1);
+
+  // (optional) part 1.5 of rectification
+  void rectify_window_pair(vgl_box_2d<int> const& target_window,
+                           int min_disparity,
+                           int max_disparity);
+
+  // part 2 of rectification
+  void warp_image_pair();
+
+  // process method puts the pieces together for you
+  // assumes set_images() and set_cameras() have been called
+  void process(vgl_box_3d<double> const& scene_box,
+               vgl_box_2d<int> const& target_window = vgl_box_2d<int>(),
+               int min_disparity = 0, int max_disparity = 0)
+  {
+    this->compute_rectification(scene_box);
+    this->rectify_window_pair(target_window, min_disparity, max_disparity);
+    this->warp_image_pair();
+  }
+
+  // overloaded process methods allow functional approach
+  void process(vil_image_view_base_sptr const& view_sptr0,
+               vil_image_view_base_sptr const& view_sptr1,
+               CAMT& cam0, CAMT& cam1,
+               vgl_box_3d<double>const& scene_box,
+               vgl_box_2d<int> const& target_window = vgl_box_2d<int>(),
+               int min_disparity = 0, int max_disparity = 0)
+  {
+    this->set_images(view_sptr0, view_sptr1);
+    this->set_cameras(cam0, cam1);
+    this->process(scene_box, target_window, min_disparity, max_disparity);
+  }
+  void process(vil_image_view<unsigned char> const& view0,
+               vil_image_view<unsigned char> const& view1,
+               CAMT& cam0, CAMT& cam1,
+               vgl_box_3d<double>const& scene_box,
+               vgl_box_2d<int> const& target_window = vgl_box_2d<int>(),
+               int min_disparity = 0, int max_disparity = 0)
+  {
+    this->set_images(vil_new_image_resource_of_view(view0), vil_new_image_resource_of_view(view1));
+    this->set_cameras(cam0, cam1);
+    this->process(scene_box, target_window, min_disparity, max_disparity);
+  }
+  void process(vil_image_resource_sptr const& resc0,
+               vil_image_resource_sptr const& resc1,
+               CAMT& cam0, CAMT& cam1,
+               vgl_box_3d<double>const& scene_box,
+               vgl_box_2d<int> const& target_window = vgl_box_2d<int>(),
+               int min_disparity = 0, int max_disparity = 0)
+  {
+    this->set_images(resc0, resc1);
+    this->set_cameras(cam0, cam1);
+    this->process(scene_box, target_window, min_disparity, max_disparity);
+  }
+
+ protected:
+
+  void compute_warp_dimensions_offsets(int ni0, int nj0,
+                                       int ni1, int nj1);
 
  private:
+
   void set_valid_types();
   bool valid_type(std::string const& type);
-  std::vector<std::string > valid_cam_types_;
+  std::vector<std::string> valid_cam_types_;
+  double scale_to_input_size(int ni0, int nj0,
+                             int ni1, int nj1);
   rectify_params params_;
-  double scale_to_input_size();
   vil_image_view<float> fview0_;
   vil_image_view<float> fview1_;
   vil_image_view<float> rect_fview0_;
   vil_image_view<float> rect_fview1_;
 
+  vgl_box_2d<int> rect_window0_;
+  vgl_box_2d<int> rect_window1_;
+
   CAMT cam0_;
   CAMT cam1_;
-  CAMT rect_cam0_;
-  CAMT rect_cam1_;
 
   // H0, H1 include a translation to keep
   // image coordinates positive definite
@@ -134,5 +207,6 @@ class bpgl_rectify_image_pair
   size_t out_ni_;
   size_t out_nj_;
 };
-#define BPGL_RECTIFY_IMAGE_PAIR_INSTANTIATE(T) extern "please include bpgl/bpgl_rectify_image_pair.txx first"
+
+#define BPGL_RECTIFY_IMAGE_PAIR_INSTANTIATE(T) extern "please include bpgl/bpgl_rectify_image_pair.hxx first"
 #endif // bpgl_rectify_image_pair_h_

--- a/contrib/brl/bbas/bpgl/algo/bpgl_rectify_image_pair.hxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_rectify_image_pair.hxx
@@ -16,72 +16,72 @@
 #include <vpgl/vpgl_fundamental_matrix.h>
 #include <vpgl/vpgl_affine_fundamental_matrix.h>
 
+
 template <class CAMT>
-void bpgl_rectify_image_pair<CAMT>::set_valid_types(){
+void bpgl_rectify_image_pair<CAMT>::
+set_valid_types()
+{
   valid_cam_types_.push_back("vpgl_affine_camera");
   valid_cam_types_.push_back("vpgl_perspective_camera");
 }
+
+
 template <class CAMT>
-bool bpgl_rectify_image_pair<CAMT>::valid_type(std::string const& type){
-  for(size_t i = 0; i<valid_cam_types_.size(); ++i)
-    if(type == valid_cam_types_[i])
+bool bpgl_rectify_image_pair<CAMT>::
+valid_type(std::string const& type)
+{
+  for (size_t i = 0; i < valid_cam_types_.size(); ++i)
+    if (type == valid_cam_types_[i])
       return true;
   return false;
 }
+
+
 template <class CAMT>
-bool bpgl_rectify_image_pair<CAMT>::
-set_images_and_cams(vil_image_view_base_sptr const& view0, CAMT const& cam0,
-                    vil_image_view_base_sptr const& view1, CAMT const& cam1)
+void bpgl_rectify_image_pair<CAMT>::
+set_images(vil_image_view_base_sptr const& view0,
+           vil_image_view_base_sptr const& view1)
 {
   // convert images to float
   vil_image_view_base_sptr fview0 = vil_convert_cast(float(), view0);
-  if (!fview0) {
-    std::cerr << "can't convert view 0 to float" << std::endl;
-    return false;
-  }
+  if (!fview0)
+    throw std::runtime_error("can't convert view 0 to float");
 
   vil_image_view_base_sptr fview1 = vil_convert_cast(float(), view1);
-  if (!fview1) {
-    std::cerr << "can't convert view 1 to float" << std::endl;
-    return false;
-  }
+  if (!fview1)
+    throw std::runtime_error("can't convert view 1 to float");
 
   // save to instance
   fview0_ = *fview0;
-  cam0_  = cam0;
   fview1_ = *fview1;
-  cam1_  = cam1;
-  return true;
 }
 
+
 template <class CAMT>
-bool bpgl_rectify_image_pair<CAMT>::
-set_images_and_cams(vil_image_resource_sptr const& resc0, CAMT const& cam0,
-                    vil_image_resource_sptr const& resc1, CAMT const& cam1)
+void bpgl_rectify_image_pair<CAMT>::
+set_images(vil_image_resource_sptr const& resc0,
+           vil_image_resource_sptr const& resc1)
 {
   // get image views
   auto view0 = resc0->get_view();
-  if (!view0) {
-    std::cerr << "null view from resource 0" << std::endl;
-    return false;
-  }
+  if (!view0)
+    throw std::runtime_error("null view from resource 0");
 
   auto view1 = resc1->get_view();
-  if (!view1) {
-    std::cerr << "null view from resource 1" << std::endl;
-    return false;
-  }
+  if (!view1)
+    throw std::runtime_error("null view from resource 1");
 
   // save to instance
-  return this->set_images_and_cams(view0, cam0, view1, cam1);
+  this->set_images(view0, view1);
 }
+
 
 template <class CAMT>
 bool bpgl_rectify_image_pair<CAMT>::
 load_camera(std::string const& cam_path, CAMT& cam)
 {
   std::string ctype = cam.type_name();
-  if(!this->valid_type(ctype)){
+  if (!this->valid_type(ctype)) {
     std::cerr << "can't process camera of type " << ctype << std::endl;
     return false;
   }
@@ -97,219 +97,325 @@ load_camera(std::string const& cam_path, CAMT& cam)
 
 template <class CAMT>
 void bpgl_rectify_image_pair<CAMT>::
-compute_warp_dimensions_offsets()
+compute_warp_dimensions_offsets(int ni0, int nj0, int ni1, int nj1)
 {
-  double dni0 = fview0_.ni()-1, dnj0 = fview0_.nj()-1;
-  double dni1 = fview1_.ni()-1, dnj1 = fview1_.nj()-1;
+  double dni0 = static_cast<double>(ni0 - 1), dnj0 = static_cast<double>(nj0 - 1);
+  double dni1 = static_cast<double>(ni1 - 1), dnj1 = static_cast<double>(nj1 - 1);
+
   std::vector<vnl_vector_fixed<double, 3> > corners_0(4), corners_1(4);
   std::vector<vnl_vector_fixed<double, 3> > Hcorners_0(4), Hcorners_1(4);
-  corners_0[0] = vnl_vector_fixed<double, 3>(0,0,1);
-  corners_0[1] = vnl_vector_fixed<double, 3>(dni0,0,1);
-  corners_0[2] = vnl_vector_fixed<double, 3>(dni0,dnj0,1);
-  corners_0[3] = vnl_vector_fixed<double, 3>(0,dnj0,1);
 
-  corners_1[0] = vnl_vector_fixed<double, 3>(0,0,1);
-  corners_1[1] = vnl_vector_fixed<double, 3>(dni1,0,1);
-  corners_1[2] = vnl_vector_fixed<double, 3>(dni1,dnj1,1);
-  corners_1[3] = vnl_vector_fixed<double, 3>(0,dnj1,1);
-  for (size_t c = 0; c<4; ++c) {
-    Hcorners_0[c] =  H0_*corners_0[c];
+  corners_0[0] = vnl_vector_fixed<double, 3>(0, 0, 1);
+  corners_0[1] = vnl_vector_fixed<double, 3>(dni0, 0, 1);
+  corners_0[2] = vnl_vector_fixed<double, 3>(dni0, dnj0, 1);
+  corners_0[3] = vnl_vector_fixed<double, 3>(0, dnj0, 1);
+
+  corners_1[0] = vnl_vector_fixed<double, 3>(0, 0, 1);
+  corners_1[1] = vnl_vector_fixed<double, 3>(dni1, 0, 1);
+  corners_1[2] = vnl_vector_fixed<double, 3>(dni1, dnj1, 1);
+  corners_1[3] = vnl_vector_fixed<double, 3>(0, dnj1, 1);
+
+  for (size_t c = 0; c < 4; ++c) {
+    Hcorners_0[c] =  H0_ * corners_0[c];
     Hcorners_0[c] /= Hcorners_0[c][2];
-    Hcorners_1[c] =  H1_*corners_1[c];
+    Hcorners_1[c] =  H1_ * corners_1[c];
     Hcorners_1[c] /= Hcorners_1[c][2];
   }
+
   double mini0 = std::numeric_limits<double>::max(), maxi0 = -mini0;
   double minj0 = std::numeric_limits<double>::max(), maxj0 = -minj0;
   double mini1 = std::numeric_limits<double>::max(), maxi1 = -mini1;
   double minj1 = std::numeric_limits<double>::max(), maxj1 = -minj1;
+
   for (size_t c = 0; c<4; ++c) {
-    if(Hcorners_0[c][0] < mini0)
+    if (Hcorners_0[c][0] < mini0)
       mini0 = Hcorners_0[c][0];
-    if(Hcorners_1[c][0] < mini1)
+    if (Hcorners_1[c][0] < mini1)
       mini1 = Hcorners_1[c][0];
-    if(Hcorners_0[c][0] > maxi0)
+    if (Hcorners_0[c][0] > maxi0)
       maxi0 = Hcorners_0[c][0];
-    if(Hcorners_1[c][0] > maxi1)
+    if (Hcorners_1[c][0] > maxi1)
       maxi1 = Hcorners_1[c][0];
-    if(Hcorners_0[c][1] < minj0)
+    if (Hcorners_0[c][1] < minj0)
       minj0 = Hcorners_0[c][1];
-    if(Hcorners_1[c][1] < minj1)
+    if (Hcorners_1[c][1] < minj1)
       minj1 = Hcorners_1[c][1];
-    if(Hcorners_0[c][1] > maxj0)
+    if (Hcorners_0[c][1] > maxj0)
       maxj0 = Hcorners_0[c][1];
-    if(Hcorners_1[c][1] > maxj1)
+    if (Hcorners_1[c][1] > maxj1)
       maxj1 = Hcorners_1[c][1];
   }
-  double w0 = (maxi0-mini0), h0 = (maxj0-minj0);
-  double w1 = (maxi1-mini1), h1 = (maxj1-minj1);
+
+  double w0 = (maxi0 - mini0), h0 = (maxj0 - minj0);
+  double w1 = (maxi1 - mini1), h1 = (maxj1 - minj1);
   double w = w0, h = h0;
   du_off_ = mini0; dv_off_ = minj0;
-  if (w1<w) {
+  if (w1 < w) {
     w = w1;
     du_off_ = mini1;
   }
-  if (h1<h) {
+  if (h1 < h) {
     h = h1;
     dv_off_ = minj1;
   }
+
   //double scaled_w = w*params_.upsample_scale_, scaled_h = h*params_.upsample_scale_;
   // replaced by scale_to_input_size()
-  out_ni_ = static_cast<size_t>(w+0.5) +1;
-  out_nj_ = static_cast<size_t>(h+0.5) +1;
+  out_ni_ = static_cast<size_t>(w + 0.5) + 1;
+  out_nj_ = static_cast<size_t>(h + 0.5) + 1;
 }
+
+
 template <class CAMT>
-double bpgl_rectify_image_pair<CAMT>::scale_to_input_size(){
-  this->compute_warp_dimensions_offsets();
-  double ni0 = fview0_.ni(), nj0 = fview0_.nj();
-  double ni1=  fview1_.ni(), nj1 = fview1_.nj();
+double bpgl_rectify_image_pair<CAMT>::
+scale_to_input_size(int ni0, int nj0,
+                    int ni1, int nj1)
+{
+  this->compute_warp_dimensions_offsets(ni0, nj0, ni1, nj1);
   double w0 = std::max(ni0, ni1);
   double h0 = std::max(nj0, nj1);
-  double sw = w0/out_ni_;
-  double sh = h0/out_nj_;
+  double sw = w0 / out_ni_;
+  double sh = h0 / out_nj_;
   // 1.2 is geometric mean of 1 and sqrt(2)(45deg rotation)
   // as a compromise scale for a rotated image
-  double s = 1.2*params_.upsample_scale_*std::max(sw, sh);
+  double s = 1.2 * params_.upsample_scale_ * std::max(sw, sh);
   out_ni_ *= s;
   out_nj_ *= s;
   return s;
 }
+
+
 template <class CAMT>
-bool bpgl_rectify_image_pair<CAMT>::
-compute_rectification(vgl_box_3d<double>const& scene_box, size_t n_points, double average_z)
+void bpgl_rectify_image_pair<CAMT>::
+compute_rectification(vgl_box_3d<double>const& scene_box,
+                      int ni0, int nj0,
+                      int ni1, int nj1)
 {
+
+  // if explicit sizes not given, then look to see if we can get that information from loaded images
+  if (ni0 == -1) {
+    if (fview0_.size() > 0) {
+      ni0 = fview0_.ni();
+      nj0 = fview0_.nj();
+    } else {
+      throw std::runtime_error("compute_rectification called without explicit "
+                               "image 0 size given, and image 0 is not set");
+    }
+
+    if (fview1_.size() > 0) {
+      ni1 = fview1_.ni();
+      nj1 = fview1_.nj();
+    } else {
+      throw std::runtime_error("compute_rectification called without explicit "
+                               "image 1 size given, and image 1 is not set");
+    }
+  }
+
+  // image dimensions
+  double dni0 = static_cast<double>(ni0), dnj0 = static_cast<double>(nj0);
+  double dni1 = static_cast<double>(ni1), dnj1 = static_cast<double>(nj1);
+
+  // scene bounds
   double min_x = scene_box.min_x();
   double min_y = scene_box.min_y();
   double width = scene_box.width(), height = scene_box.height();
-  double ni0 = fview0_.ni(), nj0 = fview0_.nj();
-  double ni1=  fview1_.ni(), nj1 = fview1_.nj();
+
+  // min disparity Z plane elevation
+  double z0 = 0.5 * (scene_box.min_z() + scene_box.max_z());
+  if (vnl_math::isfinite(params_.min_disparity_z_))
+    z0 = params_.min_disparity_z_;
+
   vnl_random rng;
-  double z0 = 0.5*(scene_box.min_z() + scene_box.max_z());
-  if (vnl_math::isfinite(average_z))
-    z0 = average_z;
-  std::vector< vnl_vector_fixed<double, 3> > img_pts0, img_pts1;
+  std::vector<vnl_vector_fixed<double, 3> > img_pts0, img_pts1;
   double inside_pts = 0.0;
-  for (unsigned i = 0; i < n_points; i++) {
-    double x = rng.drand64()*width + min_x;  // sample in local coords
-    double y = rng.drand64()*height + min_y;
+  for (unsigned i = 0; i < params_.n_points_; i++) {
+    double x = rng.drand64() * width + min_x;  // sample in local coords
+    double y = rng.drand64() * height + min_y;
     double u0, v0, u1, v1;
 
-    cam0_.project(x,y,z0,u0,v0);
+    cam0_.project(x, y, z0, u0, v0);
     bool proj_0_good = (u0 >= 0 && u0 < ni0 && v0 >= 0 && v0 < nj0);
 
     cam1_.project(x, y, z0, u1, v1);
     bool proj_1_good = (u1 >= 0 && u1 < ni1 && v1 >= 0 && v1 < nj1);
 
     // store points regardless of if they project into each image
-    img_pts0.emplace_back(u0,v0,1);
-    img_pts1.emplace_back(u1,v1,1);
+    img_pts0.emplace_back(u0, v0, 1);
+    img_pts1.emplace_back(u1, v1, 1);
 
     // but accumulate the points that intersect each image
     if (proj_0_good && proj_1_good)
       inside_pts += 1.0;
   }
+
   // if too few points have both images in common - problem
-  double overlap_fraction = double(inside_pts) / double(n_points);
+  double overlap_fraction = double(inside_pts) / double(params_.n_points_);
   if (overlap_fraction < params_.min_overlap_fraction_) {
-    std::cout << "Fatal - an insufficient fraction of zero disparity plane points project into both images "
-              << overlap_fraction << " < " << params_.min_overlap_fraction_<< std::endl;
-    return false;
+    std::ostringstream buffer;
+    buffer << "Fatal - an insufficient fraction of zero disparity plane points project into both images "
+           << overlap_fraction << " < " << params_.min_overlap_fraction_ << std::endl;
+    throw std::runtime_error(buffer.str());
   }
+
   // sanity check
   bool epi_constraint = true;
   vnl_matrix_fixed<double, 3, 3> Fm;
-  if(cam0_.type_name() == "vpgl_perspective_camera"){
+  if (cam0_.type_name() == "vpgl_perspective_camera") {
     vnl_matrix_fixed<double, 3, 4> m0 = cam0_.get_matrix(), m1 = cam1_.get_matrix();
     vpgl_proj_camera<double> pc0(m0), pc1(m1);
     vpgl_fundamental_matrix<double> Fp(pc0, pc1);
     Fm = Fp.get_matrix();
-  }else if(cam0_.type_name() == "vpgl_affine_camera"){
+  } else if (cam0_.type_name() == "vpgl_affine_camera") {
     vnl_matrix_fixed<double, 3, 4> m0 = cam0_.get_matrix(), m1 = cam1_.get_matrix();
     vpgl_affine_camera<double> A0(m0), A1(m1);
     vpgl_affine_fundamental_matrix<double> Fa(A0, A1);
     Fm = Fa.get_matrix();
-  }else{
-    std::cerr << "Can't rectify image camera of type " << cam0_.type_name() << std::endl;
-    return false;
+  } else {
+    std::ostringstream buffer;
+    buffer << "Can't rectify image camera of type " << cam0_.type_name() << std::endl;
+    throw std::runtime_error(buffer.str());
   }
   for (size_t k = 0; k < img_pts0.size(); ++k) {
     vnl_vector_fixed<double, 3> pr = img_pts0[0], line_l, pl = img_pts1[0];
     line_l = Fm * pr;
-    //normalize line
+    // normalize line
     line_l /= sqrt(line_l[0] * line_l[0] + line_l[1] * line_l[1]);
     double dp = dot_product(line_l, pl);
     epi_constraint = epi_constraint && fabs(dp) < 1.0e-6;
   }
   if (!epi_constraint) {
-    std::cout << "epipolar constraint doesn't hold for F matrix and sampled points" << std::endl;
-    return false;
+    throw std::runtime_error("epipolar constraint doesn't hold for F matrix and sampled points");
   }
 
-  if(cam0_.type_name() == "vpgl_affine_camera"){
+  if (cam0_.type_name() == "vpgl_affine_camera") {
     vnl_matrix_fixed<double, 3, 4> m0 = cam0_.get_matrix(), m1 = cam1_.get_matrix();
     vpgl_affine_camera<double> A0(m0), A1(m1);
     if (!vpgl_equi_rectification::rectify_pair(A0, A1, img_pts0, img_pts1, H0_, H1_)) {
-      std::cout << "vpgl equi rectification failed" << std::endl;
-      return false;
+      throw std::runtime_error("vpgl equi rectification failed");
     }
-  }else if(cam0_.type_name() == "vpgl_perspective_camera"){
+  } else if (cam0_.type_name() == "vpgl_perspective_camera") {
     if (!vpgl_equi_rectification::rectify_pair(cam0_, cam1_, img_pts0, img_pts1, H0_, H1_)) {
-      std::cout << "vpgl equi rectification failed" << std::endl;
-      return false;
+      throw std::runtime_error("vpgl equi rectification failed");
     }
   }
   double singular_tol = 1.0e-6;
   if ((fabs(vnl_det(H0_)) < singular_tol) ||
       (fabs(vnl_det(H1_)) < singular_tol)) {
-    std::cout << "vpgl rectification produced singular homography(s)" << std::endl;
-    return false;
+    throw std::runtime_error("vpgl rectification produced singular homography(s)");
   }
 
   // second sanity check
   bool equal_y = true;
   for (size_t k = 0; k < img_pts0.size()&&equal_y; ++k) {
     vnl_vector_fixed<double, 3> p0 = img_pts0[k], hp0, p1 = img_pts1[k], hp1;
-    hp0 = H0_*p0;  hp1 = H1_*p1;
-    double y0 = hp0[1]/hp0[2], y1 = hp1[1]/hp1[2];
-    double dy = fabs(y1-y0);
-    if (dy>0.001)
+    hp0 = H0_ * p0; hp1 = H1_ * p1;
+    double y0 = hp0[1] / hp0[2], y1 = hp1[1] / hp1[2];
+    double dy = fabs(y1 - y0);
+    if (dy > 0.001)
       equal_y = false;
   }
   if (!equal_y) {
-    std::cout << "homographies do not map to equal row positions" << std::endl;
-    return false;
+    throw std::runtime_error("homographies do not map to equal row positions");
   }
 
   // third sanity check
   double x_dif_sum = 0.0;
   for (size_t k = 0; k < img_pts0.size(); ++k) {
     vnl_vector_fixed<double, 3> p0 = img_pts0[k], hp0, p1 = img_pts1[k], hp1;
-    hp0 = H0_*p0;  hp1 = H1_*p1;
-    double x0 = hp0[0]/hp0[2], x1 = hp1[0]/hp1[2];
-    double dx = x1-x0;
+    hp0 = H0_ * p0; hp1 = H1_ * p1;
+    double x0 = hp0[0] / hp0[2], x1 = hp1[0] / hp1[2];
+    double dx = x1 - x0;
     x_dif_sum += dx;
   }
   x_dif_sum /= img_pts0.size();
-  bool x_shift_min = fabs(x_dif_sum)<0.1;
+  bool x_shift_min = fabs(x_dif_sum) < 0.1;
   if (!x_shift_min) {
-    std::cout << "homographies do not minimize column shift" << std::endl;
-    return false;
+    throw std::runtime_error("homographies do not minimize column shift");
   }
-  double sf = this->scale_to_input_size();
+  double sf = this->scale_to_input_size(ni0, nj0, ni1, nj1);
   vnl_matrix_fixed<double, 3, 3> tr,sc;
   tr.set_identity();
   tr[0][2] = -du_off_; tr[1][2] = -dv_off_;
-  H0_ = tr*H0_;
-  H1_ = tr*H1_;
+  H0_ = tr * H0_;
+  H1_ = tr * H1_;
   sc.set_identity();
   sc[0][0] = sf; sc[1][1] = sc[0][0];
-  H0_ = sc*H0_;
-  H1_ = sc*H1_;
-  vnl_matrix_fixed<double, 3, 4> M0 = cam0_.get_matrix(), M1 = cam1_.get_matrix();
-  M0 = H0_*M0;  M1 = H1_*M1;
-  rect_cam0_.set_matrix(M0);
-  rect_cam1_.set_matrix(M1);
-  return true;
+  H0_ = sc * H0_;
+  H1_ = sc * H1_;
 }
+
+
+template <class CAMT>
+CAMT bpgl_rectify_image_pair<CAMT>::
+rectify_camera(CAMT cam,
+               vnl_matrix_fixed<double, 3, 3> H)
+{
+  vnl_matrix_fixed<double, 3, 4> M = cam.get_matrix();
+  M = H * M;
+  CAMT rect_cam;
+  rect_cam.set_matrix(M);
+  return rect_cam;
+}
+
+
+template <class CAMT>
+vgl_box_2d<int> bpgl_rectify_image_pair<CAMT>::
+rectify_window(vgl_box_2d<int> const& window,
+               vnl_matrix_fixed<double, 3, 3> H,
+               size_t ni, size_t nj,
+               int padding)
+{
+  if (window.is_empty()) {
+    return vgl_box_2d<int>();
+  }
+
+  // corners of window (homogeneous coordinates)
+  vnl_vector_fixed<double, 3> ll_corner(window.min_x(), window.min_y(), 1);
+  vnl_vector_fixed<double, 3> ur_corner(window.max_x(), window.max_y(), 1);
+
+  // apply homography to corners
+  vnl_vector_fixed<double, 3> ll_corner_rect = H * ll_corner;
+  vnl_vector_fixed<double, 3> ur_corner_rect = H * ur_corner;
+
+  // homogeneous -> cartesian coordinates
+  double ll_corner_rect_x = ll_corner_rect[0] / ll_corner_rect[2];
+  double ll_corner_rect_y = ll_corner_rect[1] / ll_corner_rect[2];
+  double ur_corner_rect_x = ur_corner_rect[0] / ur_corner_rect[2];
+  double ur_corner_rect_y = ur_corner_rect[1] / ur_corner_rect[2];
+
+  // axis-aligned bounding box around rectified corners
+  double min_x_rect_d = std::min(ll_corner_rect_x, ur_corner_rect_x);
+  double min_y_rect_d = std::min(ll_corner_rect_y, ur_corner_rect_y);
+  double max_x_rect_d = std::max(ll_corner_rect_x, ur_corner_rect_x);
+  double max_y_rect_d = std::max(ll_corner_rect_y, ur_corner_rect_y);
+
+  // snap to pixel
+  int min_x_rect = static_cast<int>(std::floor(min_x_rect_d));
+  int min_y_rect = static_cast<int>(std::floor(min_y_rect_d));
+  int max_x_rect = static_cast<int>(std::ceil(max_x_rect_d));
+  int max_y_rect = static_cast<int>(std::ceil(max_y_rect_d));
+
+  // expand by padding
+  min_x_rect -= padding;
+  min_y_rect -= padding;
+  max_x_rect += padding;
+  max_y_rect += padding;
+
+  // clip to image bounds
+  min_x_rect = std::max<int>(min_x_rect, 0);
+  min_y_rect = std::max<int>(min_y_rect, 0);
+  max_x_rect = std::min<int>(max_x_rect, ni);
+  max_y_rect = std::min<int>(max_y_rect, nj);
+
+  // degenerate case
+  if (min_x_rect >= max_x_rect || min_y_rect >= max_y_rect) {
+    /* throw std::runtime_error("rectified window is unusable"); */
+    return vgl_box_2d<int>();
+  }
+
+  return vgl_box_2d<int>(min_x_rect, max_x_rect, min_y_rect, max_y_rect);
+}
+
 
 // provide the possibility of NAN as an invalid pixel value. Useful for subsequent
 // processing to avoid the invalid warp regions in the rectified image.
@@ -318,8 +424,31 @@ void bpgl_rectify_image_pair<CAMT>::
 warp_image(vil_image_view<float> fview,
            vnl_matrix_fixed<double, 3, 3> const& H,
            vil_image_view<float>& fwarp,
-           size_t out_ni, size_t out_nj)
+           size_t out_ni, size_t out_nj,
+           vgl_box_2d<int> const& rectified_window,
+           size_t margin)  // margin needed for kernels
 {
+  size_t img_start_i, img_start_j, img_end_i, img_end_j;
+  if (rectified_window.is_empty()) {
+    img_start_i = 0;
+    img_start_j = 0;
+    img_end_i = out_ni;
+    img_end_j = out_nj;
+  }
+  else {
+    // pad the window by a margin (so we have image data outside the window for kernels)
+    img_start_i = rectified_window.min_x() - margin;
+    img_start_j = rectified_window.min_y() - margin;
+    img_end_i = rectified_window.max_x() + margin;
+    img_end_j = rectified_window.max_y() + margin;
+
+    // clip to image bounds
+    img_start_i = std::max<size_t>(0, img_start_i);
+    img_start_j = std::max<size_t>(0, img_start_j);
+    img_end_i = std::min<size_t>(out_ni, img_end_i);
+    img_end_j = std::min<size_t>(out_nj, img_end_j);
+  }
+
   size_t ni = fview.ni(), nj = fview.nj();
   double dni = static_cast<double>(ni);
   double dnj = static_cast<double>(nj);
@@ -331,14 +460,14 @@ warp_image(vil_image_view<float> fview,
   vnl_vector_fixed<double, 3> mpix(out_ni, out_nj, 1), hmpix;
   hmpix = Hinv * mpix;
 
-  for (size_t j =0; j<out_nj; ++j) {
-    for (size_t i =0; i<out_ni; ++i) {
+  for (size_t j = img_start_j; j < img_end_j; ++j) {
+    for (size_t i = img_start_i; i < img_end_i; ++i) {
       double du = static_cast<double>(i);
       double dv = static_cast<double>(j);
       vnl_vector_fixed<double, 3> pix(du, dv, 1), hpix;
-      hpix = Hinv*pix;
-      double du_h = hpix[0]/hpix[2], dv_h = hpix[1]/hpix[2];
-      if (du_h < 0.0 || du_h >= dni || dv_h < 0.0 ||dv_h >= dnj)
+      hpix = Hinv * pix;
+      double du_h = hpix[0] / hpix[2], dv_h = hpix[1] / hpix[2];
+      if (du_h < 0.0 || du_h >= dni || dv_h < 0.0 || dv_h >= dnj)
         continue;
       //float fval = vil_bilin_interp_safe_extend(fview, du_h, dv_h);
       float fval = vil_bicub_interp_safe_extend(fview, du_h, dv_h);
@@ -347,13 +476,49 @@ warp_image(vil_image_view<float> fview,
   }
 }
 
+
+// requires calling compute_rectification first
 template <class CAMT>
-void bpgl_rectify_image_pair<CAMT>::warp_pair()
+void bpgl_rectify_image_pair<CAMT>::rectify_window_pair(
+    vgl_box_2d<int> const& target_window,
+    int min_disparity,
+    int max_disparity)
 {
-  this->warp_image(fview0_, H0_, rect_fview0_, out_ni_, out_nj_);
-  this->warp_image(fview1_, H1_, rect_fview1_, out_ni_, out_nj_);
+
+  if (target_window.is_empty())
+    return;
+
+  // rectify the target window
+  rect_window0_ = this->rectify_window(target_window, H0_, out_ni_,
+                                       out_nj_, params_.window_padding_);
+
+  // estimate the reference window by expanding the target window using the
+  // min and max disparities.
+  int min_x = rect_window0_.min_x() + min_disparity;
+  int max_x = rect_window0_.max_x() + max_disparity;
+  int min_y = rect_window0_.min_y();
+  int max_y = rect_window0_.max_y();
+
+  // clip to image bounds
+  min_x = std::max<int>(0, min_x);
+  max_x = std::min<int>(out_ni_, max_x);
+
+  rect_window1_ = vgl_box_2d<int>(min_x, max_x, min_y, max_y);
 }
-  // Code for easy instantiation.
+
+
+template <class CAMT>
+void bpgl_rectify_image_pair<CAMT>::warp_image_pair()
+{
+  // warp first image into rect_fview0_
+  this->warp_image(fview0_, H0_, rect_fview0_, out_ni_, out_nj_, rect_window0_, params_.kernel_margin_);
+
+  // warp second image into rect_fview1_
+  this->warp_image(fview1_, H1_, rect_fview1_, out_ni_, out_nj_, rect_window1_, params_.kernel_margin_);
+}
+
+
+// Code for easy instantiation.
 #undef BPGL_RECTIFY_IMAGE_PAIR_INSTANTIATE
 #define BPGL_RECTIFY_IMAGE_PAIR_INSTANTIATE(CAMT) \
 template class bpgl_rectify_image_pair<CAMT>

--- a/contrib/brl/bbas/bpgl/algo/rectify_params.h
+++ b/contrib/brl/bbas/bpgl/algo/rectify_params.h
@@ -1,17 +1,26 @@
 // This is brl/bbas/bpgl/algo/rectify_params.h
 #ifndef rectify_params_h_
 #define rectify_params_h_
-struct rectify_params{
+
+#include <cstddef>
+#include <math.h>
+#include <ostream>
+
+struct rectify_params {
   rectify_params():
     min_disparity_z_(NAN), n_points_(1000), upsample_scale_(1.0),
-    invalid_pixel_val_(0.0f), min_overlap_fraction_(0.25) {}
+    invalid_pixel_val_(0.0f), min_overlap_fraction_(0.25),
+    window_padding_(0), kernel_margin_(0) {}
 
   double min_disparity_z_;       // horizontal plane where disparity at each pixel is minimum
   size_t n_points_;              // number of points used to create correspondences
   double upsample_scale_;        // scale factor to upsample rectified images
   float invalid_pixel_val_;
   double min_overlap_fraction_;  // minimum fraction of points in overlap with tile in both images
-  friend std::ostream& operator<<(std::ostream &os, const rectify_params& p){
+  int window_padding_;  // how many pixels to expand a window by, post-rectification (to allow SGM ramp-up)
+  size_t kernel_margin_;  // pixels to pad a window by when warping (so we have image data outside the window for kernels)
+
+  friend std::ostream& operator<<(std::ostream &os, const rectify_params& p) {
     {
       os << "BPGL affine rectification parameters:\n"
          << "  min_disparity_z ......... " << p.min_disparity_z_ << '\n'
@@ -24,5 +33,5 @@ struct rectify_params{
     }
   }
 };
-#endif
 
+#endif

--- a/contrib/brl/bbas/bpgl/algo/tests/test_rectify_image_pair.cxx
+++ b/contrib/brl/bbas/bpgl/algo/tests/test_rectify_image_pair.cxx
@@ -60,20 +60,18 @@ static void test_rectify_image_pair() {
   vgl_box_3d<double> scene_box;
   scene_box.add(pmin);   scene_box.add(pmax);
 
+  // this block throws std::runtime_error on failure
   bpgl_rectify_image_pair<vpgl_affine_camera<double> > rip;
-  bool success = rip.set_images_and_cams(res0, acam0, res1, acam1);
-  if (!success) {
-    std::cout << "bpgl_rectify_image_pair could not set images & cameras" << std::endl;
-  } else {
-    std::cout << "acam0: " << rip.cam0() << std::endl
-              << "acam1: " << rip.cam1() << std::endl;
-  }
+  rip.set_images(res0, res1);
+  rip.set_cameras(acam0, acam1);
+  std::cout << "acam0: " << rip.cam0() << std::endl
+            << "acam1: " << rip.cam1() << std::endl;
+  rip.process(scene_box);
+  TEST("rectify affine image pair", true, true);
 
-  success = success && rip.process(scene_box);
-  TEST("rectify affine image pair", success, true);
   std::cout << "max affine image dimensions (w,h) (" << ni0 << ' ' << nj0 << ")" << std::endl;
-  size_t width, height;
-  rip.rectified_dims(width, height);
+  std::pair<size_t, size_t> dims = rip.rectified_dims();
+  size_t width = dims.first, height = dims.second;
   std::cout << "affine rectified dimensions (w,h) (" << width << ' ' << height << ")" << std::endl;
   //=========== perspective case ==============
     //camera 0
@@ -131,12 +129,16 @@ static void test_rectify_image_pair() {
   vil_image_resource_sptr pres0 = vil_new_image_resource_of_view(pimg0);
   vil_image_resource_sptr pres1 = vil_new_image_resource_of_view(pimg1);
 
+  // this block throws std::runtime_error on failure
   bpgl_rectify_image_pair<vpgl_perspective_camera<double> > prect;
-  prect.set_images_and_cams(pres0, P0, pres1, P1);
-  good = prect.process(pscene_box);
-  TEST("perspective rectification", good, true);
+  prect.set_images(pres0, pres1);
+  prect.set_cameras(P0, P1);
+  prect.process(pscene_box);
+  TEST("perspective rectification", true, true);
+
   std::cout << "orig perspective image dimensions (w,h) (" << ni0 << ' ' << nj0 << ")" << std::endl;
-  prect.rectified_dims(width, height);
+  dims = prect.rectified_dims();
+  width = dims.first, height = dims.second;
   std::cout << "perspective rectified dimensions (w,h) (" << width << ' ' << height << ")" << std::endl;
 
 }

--- a/contrib/brl/bseg/bsgm/bsgm_error_checking.h
+++ b/contrib/brl/bseg/bsgm/bsgm_error_checking.h
@@ -8,6 +8,7 @@
 //#include <sstream>
 //#include <utility>
 
+#include <vgl/vgl_box_2d.h>
 #include <vil/vil_image_view.h>
 #include <vector>
 
@@ -31,7 +32,8 @@ void bsgm_check_nonunique(
   const vil_image_view<T>& img,
   float invalid_disparity,
   unsigned short shadow_thresh,
-  int disp_thresh = 1);
+  int disp_thresh = 1,
+  const vgl_box_2d<int>& img_window = vgl_box_2d<int>());
 
 
 //: Given two disparity maps, perform the full left-right check from the
@@ -53,7 +55,8 @@ void bsgm_compute_invalid_map(
   vil_image_view<bool>& invalid_tar,
   int min_disparity,
   int num_disparities,
-  T border_val = T(0) );
+  T border_val = T(0),
+  const vgl_box_2d<int>& target_window = vgl_box_2d<int>());
 
 //: Fill in disparity pixels flagged as errors via multi-directional
 // sampling.
@@ -63,7 +66,8 @@ void bsgm_interpolate_errors(
   const vil_image_view<bool>& invalid,
   const vil_image_view<T>& img,
   float invalid_disparity,
-  unsigned short shadow_thresh);
+  unsigned short shadow_thresh,
+  const vgl_box_2d<int>& img_window = vgl_box_2d<int>());
 
 
 //: Flip the sign of all disparities, swap invalid values.

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
@@ -3,6 +3,8 @@
 #include "bsgm_prob_pairwise_dsm.h"
 #include "bsgm_error_checking.h"
 #include "bsgm_multiscale_disparity_estimator.h"
+#include <algorithm>
+#include <cmath>
 #include <type_traits>
 #include <stdexcept>
 #include "vil/vil_convert.h"
@@ -17,9 +19,24 @@
 #include <bpgl/algo/bpgl_heightmap_from_disparity.h>
 #include <bpgl/algo/rectify_params.h>
 
+#define debug_print false
+
+
 // ----------
 // Rectification
 // ----------
+template <class CAM_T, class PIX_T>
+void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::rectify_windows()
+{
+  // target window -> rectified target + reference windows
+  if (!target_window_.is_empty()) {
+    rip_.rectify_window_pair(target_window_, min_disparity_, max_disparity_);
+    rect_target_window_ = rip_.rect_window0();
+    rect_reference_window_ = rip_.rect_window1();
+  }
+}
+
+
 template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::rectify()
 {
@@ -28,27 +45,110 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::rectify()
   rp.min_disparity_z_ = mid_z_;
   rp.upsample_scale_ = params_.upsample_scale_factor_;
   rp.min_overlap_fraction_ = params_.min_overlap_fraction_;
-
-  // rectified images
-  vil_image_view<float> fview0, fview1;
+  rp.window_padding_ = params_.window_padding_;
+  // census requires a margin for its kernel, and xgrad requires a margin of 1
+  rp.kernel_margin_ = std::max<size_t>(params_.de_params_.census_rad, 1);
   rip_.set_params(rp);
-  if (!rip_.process(scene_box_))
-    throw std::runtime_error("rectification failed");
 
-  fview0 = rip_.rectified_fview0(), fview1 = rip_.rectified_fview1();
+  // if rectification matrices weren't precomputed, compute them now
+  if (std::isnan(H0_(0, 0)) || std::isnan(H1_(0, 0)) || rect_ni_ == 0 || rect_nj_ == 0) {
+    std::cout << "computing rectification again in bsgm_prob_pairwise_dsm::rectify" << std::endl; // todo: remove
+    rip_.compute_rectification(scene_box_);
+    H0_ = rip_.H0();
+    H1_ = rip_.H1();
+    std::pair<size_t, size_t> dims_pair = rip_.rectified_dims();
+    rect_ni_ = dims_pair.first;
+    rect_nj_ = dims_pair.second;
+  }
+  else {
+    // TODO: Should we move this somewhere else: the header?
+    // if they were precomputed, then set them
+    std::cout << "setting homographies" << std::endl;  // todo: remove
+    rip_.set_homographies(H0_, H1_, rect_ni_, rect_nj_);
+  }
 
-  //get range of values in fview0 and fview1
-  ni_ = fview0.ni(); nj_ = fview0.nj();
-  float max_0=0.0f, max_1=0.0f;
-  for (size_t j = 0; j<nj_; ++j) {
-    for (size_t i = 0; i<ni_; ++i) {
-      float f0 = fview0(i,j), f1 = fview1(i,j);
+  // rectify cameras for later
+  rect_cam0_ = rip_.rectify_camera(cam0_, H0_);
+  rect_cam1_ = rip_.rectify_camera(cam1_, H1_);
+
+  // target window -> rectified target + reference windows
+  this->rectify_windows();
+
+  // warp images
+  rip_.warp_image_pair();
+  vil_image_view<float> rect_fview0 = rip_.rectified_fview0();
+  vil_image_view<float> rect_fview1 = rip_.rectified_fview1();
+
+  // get range of values in rect_fview0
+  int start_i_target, start_j_target, end_i_target, end_j_target;
+  if (rect_target_window_.is_empty()) {
+    start_i_target = 0;
+    start_j_target = 0;
+    end_i_target = rect_ni_;
+    end_j_target = rect_nj_;
+  }
+  else {
+    start_i_target = rect_target_window_.min_x() - rp.kernel_margin_;
+    start_j_target = rect_target_window_.min_y() - rp.kernel_margin_;
+    end_i_target = rect_target_window_.max_x() + rp.kernel_margin_;
+    end_j_target = rect_target_window_.max_y() + rp.kernel_margin_;
+
+    // clip to image bounds
+    start_i_target = std::max<int>(0, start_i_target);
+    start_j_target = std::max<int>(0, start_j_target);
+    end_i_target = std::min<int>(rect_ni_, end_i_target);
+    end_j_target = std::min<int>(rect_nj_, end_j_target);
+  }
+  float max_0 = 0.0f;
+  float f0;
+  for (size_t j = start_j_target; j < end_j_target; ++j) {
+    for (size_t i = start_i_target; i < end_i_target; ++i) {
+      f0 = rect_fview0(i, j);
       // remove small excursions below 0 due to interpolation
-      if (f0<0.0f) fview0(i,j) = 0.0f;
-      if (f1<0.0f) fview1(i,j) = 0.0f;
-      if(f0>max_0) max_0 = f0;
-      if(f1>max_1) max_1 = f1;
+      if (f0 < 0.0f)
+        rect_fview0(i, j) = 0.0f;
+      if (f0 > max_0)
+        max_0 = f0;
     }
+  }
+  if (max_0 == 0.0f) {
+    throw std::runtime_error("empty warped target image");
+  }
+
+  // get range of values in rect_fview1
+  int start_i_reference, start_j_reference, end_i_reference, end_j_reference;
+  if (rect_reference_window_.is_empty()) {
+    start_i_reference = 0;
+    start_j_reference = 0;
+    end_i_reference = rect_ni_;
+    end_j_reference = rect_nj_;
+  }
+  else {
+    start_i_reference = rect_reference_window_.min_x() - rp.kernel_margin_;
+    start_j_reference = rect_reference_window_.min_y() - rp.kernel_margin_;
+    end_i_reference = rect_reference_window_.max_x() + rp.kernel_margin_;
+    end_j_reference = rect_reference_window_.max_y() + rp.kernel_margin_;
+
+    // clip to image bounds
+    start_i_reference = std::max<int>(0, start_i_reference);
+    start_j_reference = std::max<int>(0, start_j_reference);
+    end_i_reference = std::min<int>(rect_ni_, end_i_reference);
+    end_j_reference = std::min<int>(rect_nj_, end_j_reference);
+  }
+  float max_1 = 0.0f;
+  float f1;
+  for (size_t j = start_j_reference; j < end_j_reference; ++j) {
+    for (size_t i = start_i_reference; i < end_i_reference; ++i) {
+      f1 = rect_fview1(i, j);
+      // remove small excursions below 0 due to interpolation
+      if (f1 < 0.0f)
+        rect_fview1(i, j) = 0.0f;
+      if (f1 > max_1)
+        max_1 = f1;
+    }
+  }
+  if (max_1 == 0.0f) {
+    throw std::runtime_error("empty warped reference image");
   }
 
   // PIX_T == unsigned short
@@ -60,19 +160,38 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::rectify()
 
   // stretch range according to bits per pixel
   float max_v = 255.0f;
-  if(pix_type_short)// use range of (0, 2^effective_bpp-1)
-    max_v = std::pow(2.0f, params_.effective_bits_per_pixel_)-1.0f;
-  float scale_0 = max_v/max_0, scale_1 = max_v/max_1;
-  rect_bview0_.set_size(ni_, nj_);
-  rect_bview1_.set_size(ni_, nj_);
-  for (size_t j = 0; j<nj_; ++j) {
-    for (size_t i = 0; i<ni_; ++i) {
-      float f0 = fview0(i,j), f1 = fview1(i,j);
-      rect_bview0_(i,j) = PIX_T(scale_0*f0);
-      rect_bview1_(i,j) = PIX_T(scale_1*f1);
+  if (pix_type_short)  // use range of (0, 2^effective_bpp-1)
+    max_v = std::pow(2.0f, params_.effective_bits_per_pixel_) - 1.0f;
+
+  // todo: remove
+  /* max_1 = 65659.97; */
+  if (debug_print) {
+    std::cout << "max_0 = " << max_0 << std::endl;
+    std::cout << "max_1 = " << max_1 << std::endl;
+    std::cout << "max_v = " << max_v << std::endl;
+  }
+
+  // stretch warped image 0
+  float scale_0 = max_v / max_0;
+  rect_bview0_.set_size(rect_ni_, rect_nj_);
+  for (size_t j = start_j_target; j < end_j_target; ++j) {
+    for (size_t i = start_i_target; i < end_i_target; ++i) {
+      float f0 = rect_fview0(i, j);
+      rect_bview0_(i, j) = PIX_T(scale_0 * f0);
+    }
+  }
+
+  // stretch warped image 1
+  float scale_1 = max_v / max_1;
+  rect_bview1_.set_size(rect_ni_, rect_nj_);
+  for (size_t j = start_j_reference; j < end_j_reference; ++j) {
+    for (size_t i = start_i_reference; i < end_i_reference; ++i) {
+      float f1 = rect_fview1(i, j);
+      rect_bview1_(i, j) = PIX_T(scale_1 * f1);
     }
   }
 }
+
 
 // ----------
 // Disparity
@@ -85,16 +204,18 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_disparity(
     const vil_image_view<PIX_T>& img_reference,
     bool forward,
     vil_image_view<bool>& invalid,
-    vil_image_view<float>& disparity)
+    vil_image_view<float>& disparity,
+    vgl_box_2d<int>& img_window,
+    vgl_box_2d<int>& img_reference_window)
 {
   vxl_byte border_val = 0;
   float invalid_disp = NAN; //required for triangulation implementation
   bool good = true;
   float dynamic_range_factor = bits_per_pix_factors_[params_.effective_bits_per_pixel_];
-  bsgm_compute_invalid_map<PIX_T>(img, img_reference, invalid,
-                           min_disparity_, num_disparities(), border_val);
+  bsgm_compute_invalid_map<PIX_T>(img, img_reference, invalid, min_disparity_,
+                                  num_disparities(), border_val, img_window);
   if (params_.coarse_dsm_disparity_estimate_) {
-    bsgm_multiscale_disparity_estimator mde(params_.de_params_, ni_, nj_,
+    bsgm_multiscale_disparity_estimator mde(params_.de_params_, rect_ni_, rect_nj_,
                                             num_disparities(), num_active_disparities());
 
     good = mde.compute(img, img_reference, invalid,
@@ -103,16 +224,30 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_disparity(
     if (!good)
       throw std::runtime_error("Multiscale disparity estimator failed");
   } else {  // use input min_disparity
-    size_t ni = img.ni(), nj = img.nj();
 
-    vil_image_view<int> min_disparity(ni, nj);
+    // SGM cost volume dimensions (full image size, or window)
+    size_t cost_volume_width, cost_volume_height;
+    if (img_window.is_empty()) {
+      cost_volume_width = img.ni();
+      cost_volume_height = img.nj();
+    }
+    else {
+      cost_volume_width = img_window.width();
+      cost_volume_height = img_window.height();
+    }
+
+    // default min disparity per pixel
+    vil_image_view<int> min_disparity(cost_volume_width, cost_volume_height);
     if (forward)  // img = img0, ref = img1
       min_disparity.fill(min_disparity_);
     else  // reverse img = img1, ref = img0
       min_disparity.fill(-(num_disparities() + min_disparity_));
 
-    bsgm_disparity_estimator bsgm(params_.de_params_, ni, nj, num_disparities());
-    good = bsgm.compute(img, img_reference, invalid, min_disparity, invalid_disp, disparity, dynamic_range_factor);
+    bsgm_disparity_estimator bsgm(params_.de_params_, cost_volume_width,
+                                  cost_volume_height, num_disparities());
+    good = bsgm.compute(img, img_reference, invalid, min_disparity,
+                        invalid_disp, disparity, dynamic_range_factor,
+                        false, img_window, img_reference_window);
     if (!good)
       throw std::runtime_error("disparity estimator failed");
   }
@@ -123,7 +258,9 @@ template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_disparity_fwd()
 {
   bool forward = true;
-  compute_disparity(rect_bview0_, rect_bview1_, forward, invalid_map_fwd_, disparity_fwd_);
+  compute_disparity(rect_bview0_, rect_bview1_, forward,
+                    invalid_map_fwd_, disparity_fwd_,
+                    rect_target_window_, rect_reference_window_);
 }
 
 // compute reverse disparity
@@ -131,7 +268,9 @@ template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_disparity_rev()
 {
   bool forward = false;
-  compute_disparity(rect_bview1_, rect_bview0_, forward, invalid_map_rev_, disparity_rev_);
+  compute_disparity(rect_bview1_, rect_bview0_, forward,
+                    invalid_map_rev_, disparity_rev_,
+                    rect_reference_window_, rect_target_window_);
 }
 
 
@@ -154,26 +293,83 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_height(const CAM_T& cam, cons
   bh.heightmap_from_pointset(ptset, heightmap);
 }
 
+// shift camera to match window
+template <class CAM_T, class PIX_T>
+void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::translate_camera_into_window(
+    CAM_T& cam, vgl_box_2d<int> window) {
+
+  auto M = cam.get_matrix();
+  auto M_shifted = M;  // copy to remove const-ness
+
+  // add shift to each row. multiply by last row to cancel out homogeneous effect
+  int u_shift = window.min_x();
+  int v_shift = window.min_y();
+
+  M_shifted(0, 0) -= u_shift * M_shifted(2, 0);
+  M_shifted(0, 1) -= u_shift * M_shifted(2, 1);
+  M_shifted(0, 2) -= u_shift * M_shifted(2, 2);
+  M_shifted(0, 3) -= u_shift * M_shifted(2, 3);
+
+  M_shifted(1, 0) -= v_shift * M_shifted(2, 0);
+  M_shifted(1, 1) -= v_shift * M_shifted(2, 1);
+  M_shifted(1, 2) -= v_shift * M_shifted(2, 2);
+  M_shifted(1, 3) -= v_shift * M_shifted(2, 3);
+
+  // adjust camera object's internal matrix
+  cam.set_matrix(M_shifted);
+}
+
+
 // compute forward height
 template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_height_fwd(bool compute_hmap)
 {
-  if(compute_hmap)
-    this->compute_height(rip_.rect_cam0(), rip_.rect_cam1(), disparity_fwd_,
+  // make copies so we can modify if we need to
+  CAM_T rect_cam0_window = rect_cam0_, rect_cam1_window = rect_cam1_;
+
+  // if we're using a window, we shift the cameras to correspond to that window
+  // (so the cameras project into the windowed disparity image)
+  if (!rect_target_window_.is_empty()) {
+    if (debug_print) {
+      std::cout << "rect_cam0 = " << rect_cam0_.get_matrix() << std::endl;
+      std::cout << "rect_cam1 = " << rect_cam1_.get_matrix() << std::endl;
+    }
+    translate_camera_into_window(rect_cam0_window, rect_target_window_);
+    translate_camera_into_window(rect_cam1_window, rect_target_window_);
+    if (debug_print) {
+      std::cout << "rect_cam0_ translated = " << rect_cam0_window.get_matrix() << std::endl;
+      std::cout << "rect_cam1_ translated = " << rect_cam1_window.get_matrix() << std::endl;
+    }
+  }
+
+  if (compute_hmap)
+    this->compute_height(rect_cam0_window, rect_cam1_window, disparity_fwd_,
                          tri_3d_fwd_, ptset_fwd_, heightmap_fwd_);
   else
-    tri_3d_fwd_ = bpgl_3d_from_disparity(rip_.rect_cam0(), rip_.rect_cam1(), disparity_fwd_, params_.disparity_sense_);
+    tri_3d_fwd_ = bpgl_3d_from_disparity(rect_cam0_window, rect_cam1_window,
+                                         disparity_fwd_, params_.disparity_sense_);
 }
 
 // compute reverse height
 template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_height_rev(bool compute_hmap)
 {
-  if(compute_hmap)
-    this->compute_height(rip_.rect_cam1(), rip_.rect_cam0(), disparity_rev_,
+  // make copies so we can modify if we need to
+  CAM_T rect_cam0_window = rect_cam0_, rect_cam1_window = rect_cam1_;
+
+  // if we're using a window, we shift the cameras to correspond to that window
+  // (so the cameras project into the windowed disparity image)
+  if (!rect_reference_window_.is_empty()) {
+    translate_camera_into_window(rect_cam0_window, rect_reference_window_);
+    translate_camera_into_window(rect_cam1_window, rect_reference_window_);
+  }
+
+  if (compute_hmap)
+    this->compute_height(rect_cam1_window, rect_cam0_window, disparity_rev_,
                          tri_3d_rev_, ptset_rev_, heightmap_rev_);
   else
-    tri_3d_rev_ = bpgl_3d_from_disparity(rip_.rect_cam1(), rip_.rect_cam0(), disparity_rev_, params_.disparity_sense_);
+    tri_3d_rev_ = bpgl_3d_from_disparity(rect_cam1_window, rect_cam0_window,
+                                         disparity_rev_, params_.disparity_sense_);
 }
 
 
@@ -181,9 +377,9 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_height_rev(bool compute_hmap)
 // Probabilistic heightmaps
 // ----------
 
-// compute probablistic height (ptset, heightmap, probability)
+// compute probabilistic height (ptset, heightmap, probability)
 template <class CAM_T, class PIX_T>
-bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_prob()
+bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_prob(bool compute_prob_heightmap)
 {
   // check number of points
   if (ptset_fwd_.size() == 0) {
@@ -234,51 +430,82 @@ bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_prob()
   }
 
   // convert pointset to images
-  auto bh = this->get_bpgl_heightmap();
-  //bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_, prob_heightmap_prob_);
-  bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_, prob_heightmap_prob_, radial_std_dev_image_);
+  if (compute_prob_heightmap) {
+    auto bh = this->get_bpgl_heightmap();
+    //bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_, prob_heightmap_prob_);
+    bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_,
+                               prob_heightmap_prob_, radial_std_dev_image_);
+  }
   return true;
 }
+
+
 // assumes disparity_fwd, xyz_fwd_ and xyz_rev_ are available
 template <class CAM_T, class PIX_T>
-void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_xyz_prob(){
+void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_xyz_prob(bool compute_prob_heightmap) {
   int ni = disparity_fwd_.ni(), nj = disparity_fwd_.nj();
+  int rev_ni = tri_3d_rev_.ni(), rev_nj = tri_3d_rev_.nj();
   xyz_prob_.set_size(ni, nj, 4);
   xyz_prob_.fill(NAN);
   float sdsq = params_.std_dev_;
   sdsq *= sdsq;
   prob_distr_ = bsta_histogram<float>(0.0f, 1.0f, 100);
   prob_ptset_.clear();
-  for( int j = 0; j<nj; ++j)
-    for( int i = 0; i<ni; ++i){
+  for (int j = 0; j < nj; ++j) {
+    if (j >= rev_nj) continue;
+    for (int i = 0; i < ni; ++i) {
       // 3-d point at (i, j)
       float xf = tri_3d_fwd_(i, j, 0), yf = tri_3d_fwd_(i, j, 1), zf = tri_3d_fwd_(i, j, 2);
-      if(!vnl_math::isfinite(xf) || !vnl_math::isfinite(yf) || !vnl_math::isfinite(zf))
+      if (!vnl_math::isfinite(xf) || !vnl_math::isfinite(yf) || !vnl_math::isfinite(zf))
         continue;
-      bool hit = (fabs(xf -172.799)<0.01) && (fabs(199.817-yf) < 0.01);
+      bool hit = (fabs(xf - 172.799) < 0.01) && (fabs(199.817 - yf) < 0.01);
       // disparity at (i,j)
-      int disp = static_cast<int>(disparity_fwd_(i,j));
-      if(!vnl_math::isfinite(disp))
+      int disp = static_cast<int>(disparity_fwd_(i, j));
+      if (!vnl_math::isfinite(disp))
         continue;
       int ir = i + disp;
-      float xr = tri_3d_rev_(ir, j, 0), yr = tri_3d_rev_(ir, j, 1), zr = tri_3d_rev_(ir, j, 2);
-      if(!vnl_math::isfinite(xr) || !vnl_math::isfinite(yr) || !vnl_math::isfinite(zr))
+      if (ir < 0 || ir >= ni || ir >= rev_ni)
         continue;
-      float d = sqrt((xf-xr)*(xf-xr) + (yf-yr)*(yf-yr) + (zf-zr)*(zf-zr));
-      float prob = exp(-d*d/sdsq);
+      float xr = tri_3d_rev_(ir, j, 0), yr = tri_3d_rev_(ir, j, 1), zr = tri_3d_rev_(ir, j, 2);
+      if (!vnl_math::isfinite(xr) || !vnl_math::isfinite(yr) || !vnl_math::isfinite(zr))
+        continue;
+      float d = sqrt((xf - xr) * (xf - xr) + (yf - yr) * (yf - yr) + (zf - zr) * (zf - zr));
+      float prob = exp(-d * d / sdsq);
       xyz_prob_(i, j, 0) = xf; xyz_prob_(i, j, 1) = yf; xyz_prob_(i, j, 2) = zf;
       xyz_prob_(i, j, 3) = prob;
       prob_distr_.upcount(prob, 1.0);
       prob_ptset_.add_point_with_scalar(vgl_point_3d<float>(xf, yf, zf), prob);
     }
+  }
   size_t n = prob_ptset_.size();
   if (n == 0) {
     std::runtime_error("prob_ptset_ is empty");
   }
+
   // convert pointset to images
-  auto bh = this->get_bpgl_heightmap();
-  bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_, prob_heightmap_prob_, radial_std_dev_image_);
+  if (compute_prob_heightmap) {
+    auto bh = this->get_bpgl_heightmap();
+    bh.heightmap_from_pointset(prob_ptset_, prob_heightmap_z_, prob_heightmap_prob_, radial_std_dev_image_);
+  }
 }
+
+
+template <class CAM_T, class PIX_T>
+void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_ptset(){
+  int ni = disparity_fwd_.ni(), nj = disparity_fwd_.nj();
+  prob_distr_ = bsta_histogram<float>(0.0f, 1.0f, 100);
+  prob_distr_.upcount(1.0, 1.0);
+  prob_ptset_.clear();
+  for (int j = 0; j < nj; ++j)
+    for (int i = 0; i < ni; ++i) {
+      // 3-d point at (i, j)
+      float xf = tri_3d_fwd_(i, j, 0), yf = tri_3d_fwd_(i, j, 1), zf = tri_3d_fwd_(i, j, 2);
+      if (!vnl_math::isfinite(xf) || !vnl_math::isfinite(yf) || !vnl_math::isfinite(zf))
+        continue;
+      prob_ptset_.add_point_with_scalar(vgl_point_3d<float>(xf, yf, zf), 1.1f);
+    }
+}
+
 
 template <class CAM_T, class PIX_T>
 bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::z_vs_disparity_scale(double& scale) const


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
- Modify bsgm_prob_pairwise_dsm, bsgm_disparity_estimator, and others to accept a vgl_box_2d<int> target window. SGM processing will then occur within those image bounds. The minimum box values are inclusive, while the maximum values are treated as exclusive.
- Re-design bpgl_rectify_image_pair to separate homography computation from warping, and also support a target window.