### PR TITLE
COMP: Fix OpenJPEG build error with Visual Studio 16.9

### DIFF
--- a/v3p/openjpeg2/opj_includes.h
+++ b/v3p/openjpeg2/opj_includes.h
@@ -90,7 +90,7 @@ Most compilers implement their own version of this keyword ...
 
 /* MSVC 64bits doesn't support _asm */
 #if !defined(_WIN64)
-static INLINE long lrintf(float f){
+static INLINE long opj_lrintf(float f){
         int i;
 
         _asm{
@@ -101,7 +101,7 @@ static INLINE long lrintf(float f){
   return i;
 }
 #else
-static INLINE long lrintf(float x){
+static INLINE long opj_lrintf(float x){
   long r;
   if (x>=0.f)
   {


### PR DESCRIPTION
Fixes OpenJPEG build error with Visual Studio 16.9

> SRC\vxl\v3p\openjpeg2\opj_includes.h(104,35): error C2169: 'lrintf': intrinsic function, cannot be defined (compiling source file SRC\vxl\v3p\openjpeg2\tcd.c) [BUILD\vxl-build\v3p\openjpeg2\openjpeg2.vcxproj]

Solution copied from ITK
https://github.com/InsightSoftwareConsortium/ITK/pull/2388
https://github.com/InsightSoftwareConsortium/ITK/issues/1967

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

