### PR TITLE
COMP: set CMake policy 0120 to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 # cmake versions.
 foreach(p
     ## Only policies introduced after the cmake_minimum_required
-    ## version need to explicitly be set to NEW.
+    ## version need to be set.
 
     ##----- Policies Introduced by CMake 3.12
     CMP0075  #: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
@@ -64,6 +64,19 @@ foreach(p
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
+
+# Set old policies we have not adjusted to yet
+foreach(p
+    ## Only policies introduced after the cmake_minimum_required
+    ## version need to be set.
+
+    ##----- Policies Introduced by CMake 3.20
+    CMP0120  #: The WriteCompilerDetectionHeader module is removed.
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} OLD)
   endif()
 endforeach()
 


### PR DESCRIPTION
CMP0120: The WriteCompilerDetectionHeader module is removed.

This gets rid of the warning:
```text
CMake Warning (dev) at vcl/CMakeLists.txt:19 (include):
  Policy CMP0120 is not set: The WriteCompilerDetectionHeader module is
  removed.  Run "cmake --help-policy CMP0120" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.20/Modules/WriteCompilerDetectionHeader.cmake:255 (message):
  The WriteCompilerDetectionHeader module will be removed by policy CMP0120.
  Projects should be ported away from the module, perhaps by bundling a copy
  of the generated header or using a third-party alternative.
Call Stack (most recent call first):
  vcl/CMakeLists.txt:19 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
