### PR TITLE
ENH: vil_flatten & vil_math_value_range_percentiles(ignore_nan)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.1.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vil/tests/CMakeLists.txt
+++ b/core/vil/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable( vil_test_all
 
 
   # Math
+  test_flatten.cxx
   test_math_value_range.cxx
   test_math_median.cxx
   test_na.cxx
@@ -89,6 +90,7 @@ add_test( NAME vil_test_nearest_interp COMMAND $<TARGET_FILE:vil_test_all> test_
 add_test( NAME vil_test_resample_nearest COMMAND $<TARGET_FILE:vil_test_all> test_resample_nearest)
 
 # Math
+add_test( NAME vil_test_flatten COMMAND $<TARGET_FILE:vil_test_all> test_flatten)
 add_test( NAME vil_test_math_value_range COMMAND $<TARGET_FILE:vil_test_all> test_math_value_range)
 add_test( NAME vil_test_math_median COMMAND $<TARGET_FILE:vil_test_all> test_math_median)
 add_test( NAME vil_test_na COMMAND $<TARGET_FILE:vil_test_all> test_na)

--- a/core/vil/tests/test_driver.cxx
+++ b/core/vil/tests/test_driver.cxx
@@ -34,6 +34,7 @@ DECLARE(test_round);
 DECLARE(test_pyramid_image_view);
 DECLARE(test_na);
 DECLARE(test_rgb);
+DECLARE(test_flatten);
 
 void
 register_tests()
@@ -72,6 +73,7 @@ register_tests()
   REGISTER(test_pyramid_image_view);
   REGISTER(test_na);
   REGISTER(test_rgb);
+  REGISTER(test_flatten);
 }
 
 DEFINE_MAIN;

--- a/core/vil/tests/test_flatten.cxx
+++ b/core/vil/tests/test_flatten.cxx
@@ -1,0 +1,107 @@
+// This is core/vil/tests/test_flatten.cxx
+
+#include <iostream>
+#include <vector>
+#include "testlib/testlib_test.h"
+#ifdef _MSC_VER
+#  include "vcl_msvc_warnings.h"
+#endif
+#include "vil/vil_flatten.h"
+
+
+template <class T>
+void view_cout(const vil_image_view<T>& view)
+{
+  for (unsigned p = 0; p < view.nplanes(); ++p)
+  {
+    std::cout << "Plane " << p << "\n";
+    for (unsigned j = 0; j < view.nj(); ++j)
+    {
+      for (unsigned i = 0; i < view.ni(); ++i)
+      {
+        std::cout << view(i, j, p) << ' ';
+      }
+      std::cout << '\n';
+    }
+  }
+}
+
+template <class T>
+void vector_cout(std::string name, const std::vector<T>& vec)
+{
+  std::cout << name << "\n";
+  for (auto item : vec)
+    std::cout << item << " ";
+  std::cout << std::endl;
+}
+
+
+template <class T>
+static void
+_test_flatten(std::string type_name)
+{
+  std::cout << "************************************************\n"
+            << " test_flatten vil_image_view<" << type_name << ">\n"
+            << "************************************************\n";
+
+  // Create a test image (2 columns, 4 rows, 3 planes)
+  // plane0 [ 0, 1, 2, 3]
+  //        [ 4, 5, 6, 7]
+  // plane1 [ 8, 9,10,11]
+  //        [12,13,14,15]
+  // plane2 [16,17,18,19]
+  //        [20,21,22,23]
+
+  unsigned ni = 4, nj = 2, nplanes = 3;
+  vil_image_view<T> img(ni, nj, nplanes);
+  T val = T(0);
+
+  for (unsigned p = 0; p < nplanes; p++) // plane
+  {
+    for (unsigned j = 0; j < nj; ++j)  // row
+    {
+      for (unsigned i = 0; i < ni; ++i)  // column
+      {
+        img(i, j, p) = T(val);
+        val++;
+      }
+    }
+  }
+  view_cout(img);
+
+  // test row-major flattening
+  // [ (plane0, row0, col0), (p0, r0, c1), (p0, r0, c2) ... ]
+  std::vector<T> row_truth = { 0, 1 ,2, 3,
+                               4, 5, 6, 7,
+                               8, 9,10,11,
+                              12,13,14,15,
+                              16,17,18,19,
+                              20,21,22,23};
+  std::vector<T> row = vil_flatten_row_major(img);
+
+  vector_cout("flattened...", row);
+  vector_cout("expected....", row_truth);
+  TEST("vil_flatten_row_major()", row, row_truth);
+
+  // test column-major flattening
+  // [ (plane0, row0, col0), (p0, r1, c0), (p0, r2, c0) ... ]
+  std::vector<T> col_truth = { 0, 4, 1, 5, 2, 6, 3, 7,
+                               8,12, 9,13,10,14,11,15,
+                              16,20,17,21,18,22,19,23};
+  std::vector<T> col = vil_flatten_column_major(img);
+
+  vector_cout("flattened...", col);
+  vector_cout("expected....", col_truth);
+  TEST("vil_flatten_column_major()", col, col_truth);
+}
+
+static void
+test_flatten()
+{
+  _test_flatten<vxl_byte>("vxl_byte");
+  _test_flatten<int>("int");
+  _test_flatten<float>("float");
+  _test_flatten<double>("double");
+}
+
+TESTMAIN(test_flatten);

--- a/core/vil/vil_flatten.h
+++ b/core/vil/vil_flatten.h
@@ -5,6 +5,7 @@
 // \file
 // \author Ian Scott.
 
+#include <vector>
 #include "vil_image_view.h"
 #include "vil_crop.h"
 #include "vil_plane.h"
@@ -34,6 +35,52 @@ inline vil_image_view<T> vil_flatten_planes(const vil_image_view<T> &im)
   }
 
   return ret;
+}
+
+//: Return a copy of a vil_image_view collapsed into one dimension.
+// Row-major order (C-style); iterate plane, row, column.
+// Consecutive elements of a row are adjacent in the resulting vector.
+// [ (plane0, row0, col0), (p0, r0, c1), (p0, r0, c2) ... ]
+template <class T>
+inline std::vector<T> vil_flatten_row_major(const vil_image_view<T> &im)
+{
+  std::vector<T> vec(im.size(), T(0));
+  size_t vec_i = 0;
+  for (unsigned int p=0; p<im.nplanes(); ++p)  // plane
+  {
+    for (unsigned int j=0; j<im.nj(); ++j)  // row
+    {
+      for (unsigned int i=0; i<im.ni(); ++i)  // column
+      {
+        vec[vec_i] = im(i,j,p);
+        ++vec_i;
+      }
+    }
+  }
+  return vec;
+}
+
+//: Return a copy of a vil_image_view collapsed into one dimension.
+// Column-major order (Fortran-style); iterate plane, column, row.
+// Consecutive elements of a column are adjacent in the resulting vector.
+// [ (plane0, row0, col0), (p0, r1, c0), (p0, r2, c0) ... ]
+template <class T>
+inline std::vector<T> vil_flatten_column_major(const vil_image_view<T> &im)
+{
+  std::vector<T> vec(im.size(), T(0));
+  size_t vec_i = 0;
+  for (unsigned int p=0; p<im.nplanes(); ++p)  // plane
+  {
+    for (unsigned int i=0; i<im.ni(); ++i)  // column
+    {
+      for (unsigned int j=0; j<im.nj(); ++j)  // row
+      {
+        vec[vec_i] = im(i,j,p);
+        ++vec_i;
+      }
+    }
+  }
+  return vec;
 }
 
 #endif // vil_flatten_h_


### PR DESCRIPTION
ENH: add `vil_flatten` to copy `vil_image_view` data into a 1D `std::vector`.  Provides both row-major and column-major implementations.  Add tests.

ENH: add `ignore_nan` argument to `vil_math_value_range_percentiles`, allowing users to process floating point images containing nans.  Add/expand tests.

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✔️ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
