### PR TITLE
STYLE: Small improvements of matrix `set_identity()` member functions

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -636,6 +636,19 @@ test_extract(T *)
   std::cout << "r=\n" << r << '\n';
   TEST("extract into existing matrix", r(0, 0) == 8 && r(0, 1) == 9 && r(0, 2) == 0, true);
 }
+
+
+void
+test_identity()
+{
+  // Test that a matrix initialized by `vnl_matrix_null` is not an identity matrix.
+  TEST("non-identity matrix", (vnl_matrix<float>(2, 2, vnl_matrix_null).is_identity()), false);
+
+  // Test that set_identity() yields an identity matrix, for two different matrix types.
+  TEST("identity matrix 1", (vnl_matrix<float>(2, 2).set_identity().is_identity()), true);
+  TEST("identity matrix 2", (vnl_matrix<double>(3, 3).set_identity().is_identity()), true);
+}
+
 } // end anonymous namespace
 
 
@@ -649,6 +662,7 @@ test_matrix()
   test_leak();
 #endif
   test_extract((double *)nullptr);
+  test_identity();
 }
 
 TESTMAIN(test_matrix);

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -516,6 +516,18 @@ test_extract(T *)
   TEST("extract into existing matrix", r(0, 0) == 8 && r(0, 1) == 9 && r(0, 2) == 0, true);
 }
 
+
+void
+test_identity()
+{
+  // Test that a matrix value-initialized by `()` is not an identity matrix.
+  TEST("non-identity matrix", (vnl_matrix_fixed<float, 2, 2>().is_identity()), false);
+
+  // Test that set_identity() yields an identity matrix, for two different matrix types.
+  TEST("identity matrix 1", (vnl_matrix_fixed<float, 2, 2>().set_identity().is_identity()), true);
+  TEST("identity matrix 2", (vnl_matrix_fixed<double, 3, 3>().set_identity().is_identity()), true);
+}
+
 } // end anonymous namespace
 
 void
@@ -586,6 +598,7 @@ test_matrix_fixed()
   test_double();
 
   test_extract((double *)nullptr);
+  test_identity();
 }
 
 TESTMAIN(test_matrix_fixed);

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -779,9 +779,13 @@ void vnl_matrix<T>::copy_out(T *p) const
 template <class T>
 vnl_matrix<T>& vnl_matrix<T>::set_identity()
 {
-  for (unsigned int i = 0; i < this->num_rows; ++i)    // For each row in the Matrix
-    for (unsigned int j = 0; j < this->num_cols; ++j)  // For each element in column
-      this->data[i][j] = (i==j) ? T(1) : T(0);
+  // Zero-filling all data, followed by a loop over the diagonal, is
+  // probably better than having a branch inside the loop. Similar to
+  // the set_identity() member function of vnl_matrix_fixed.
+  std::fill_n( this->data[0], this->num_rows * this->num_cols, T() );
+  const unsigned n = std::min( this->num_rows, this->num_cols );
+  for (unsigned int i = 0; i < n; ++i)
+    this->data[i][i] = 1;
   return *this;
 }
 

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -357,13 +357,13 @@ template<class T, unsigned nrows, unsigned ncols>
 vnl_matrix_fixed<T,nrows,ncols>&
 vnl_matrix_fixed<T,nrows,ncols>::set_identity()
 {
-  // Two simple loops are generally better than having a branch inside
-  // the loop. Probably worth the O(n) extra writes.
-  for (unsigned int i = 0; i < nrows; ++i)
-    for (unsigned int j = 0; j < ncols; ++j)
-      this->data_[i][j] = T(0);
-  for (unsigned int i = 0; i < nrows && i < ncols; ++i)
-    this->data_[i][i] = T(1);
+  // A reset of this object, followed by a loop over the diagonal, is
+  // probably better than having a branch inside the loop. Probably
+  // worth the O(n) extra writes.
+  *this = vnl_matrix_fixed();
+  const unsigned n = std::min( nrows, ncols );
+  for (unsigned int i = 0; i < n; ++i)
+    this->data_[i][i] = 1;
   return *this;
 }
 


### PR DESCRIPTION
- Replaced a hand-written `for` loop from `vnl_matrix_fixed`.
- Replaced a `for` loop from  from `vnl_matrix` that had a branch inside
the loop.
- Made the two `set_identity()` implementations more similar to each
other.
- Removed brute-force `T(x)` casts from `0` and `1`, as `T` should
support implicit conversion from `0` and `1`.

Added `test_identity()` unit tests.