### PR TITLE
vpgl_geo_camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.3.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vil/file_formats/vil_geotiff_header.h
+++ b/core/vil/file_formats/vil_geotiff_header.h
@@ -52,6 +52,11 @@ class vil_geotiff_header
   //: returns true if in geographic coords, linear units are in meters and angular units are in degrees
   bool GCS_WGS84_MET_DEG();
 
+  //: other header fields
+  bool gtif_modeltype(modeltype_t& type);
+  bool gtif_rastertype(rastertype_t& type);
+  bool geounits(geounits_t& units);
+
   //: <key> : key id
   // <value>: a single value or an array of values
   // <size>:  the size of individual key values
@@ -77,15 +82,6 @@ class vil_geotiff_header
   // the number of keys defined in the rest of the tag
   int number_of_geokeys_;
 
-  modeltype_t model_type_;
-  rastertype_t raster_type_;
-  geographic_t geographic_type_;
-  geounits_t geounits_;
-
-  bool gtif_modeltype (modeltype_t& type);
-  bool gtif_rastertype (rastertype_t&);
-  bool geounits (geounits_t&);
-  bool geographic_type(geographic_t&);
 };
 
 #endif //vil_geotiff_header_h_

--- a/core/vpgl/file_formats/CMakeLists.txt
+++ b/core/vpgl/file_formats/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set( vpgl_file_formats_sources
   vpgl_nitf_rational_camera.h  vpgl_nitf_rational_camera.cxx
+  vpgl_geo_camera.h            vpgl_geo_camera.cxx
 )
 
 include(${VXL_CMAKE_DIR}/FindTIFF.cmake)
@@ -13,10 +14,6 @@ if(TIFF_FOUND)
   include( ${VXL_CMAKE_DIR}/FindGEOTIFF.cmake)
   if(GEOTIFF_FOUND)
     include_directories(${GEOTIFF_INCLUDE_DIR})
-
-    set( vpgl_file_formats_sources ${vpgl_file_formats_sources}
-         vpgl_geo_camera.h         vpgl_geo_camera.cxx)
-
   endif()
 endif()
 

--- a/core/vpgl/file_formats/tests/CMakeLists.txt
+++ b/core/vpgl/file_formats/tests/CMakeLists.txt
@@ -1,2 +1,11 @@
+add_executable( vpgl_file_formats_test_all
+  test_driver.cxx
+
+  test_geo_camera.cxx
+)
+
+target_link_libraries( vpgl_file_formats_test_all ${VXL_LIB_PREFIX}vpgl_file_formats ${VXL_LIB_PREFIX}testlib )
+add_test( NAME vpgl_file_formats_test_geo_camera COMMAND $<TARGET_FILE:vpgl_file_formats_test_all> test_geo_camera)
+
 add_executable( vpgl_file_formats_test_include test_include.cxx )
 target_link_libraries( vpgl_file_formats_test_include ${VXL_LIB_PREFIX}vpgl_file_formats)

--- a/core/vpgl/file_formats/tests/test_driver.cxx
+++ b/core/vpgl/file_formats/tests/test_driver.cxx
@@ -1,0 +1,11 @@
+#include "testlib/testlib_register.h"
+
+DECLARE(test_geo_camera);
+
+void
+register_tests()
+{
+  REGISTER(test_geo_camera);
+}
+
+DEFINE_MAIN;

--- a/core/vpgl/file_formats/tests/test_geo_camera.cxx
+++ b/core/vpgl/file_formats/tests/test_geo_camera.cxx
@@ -1,0 +1,75 @@
+#include "testlib/testlib_test.h"
+
+#include <iostream>
+#include <array>
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+#include "vpgl/vpgl_lvcs.h"
+#include "vpgl/file_formats/vpgl_geo_camera.h"
+
+// helper function: test camera.project(x, y) == (u, v)
+void
+_test_project(vpgl_geo_camera camera, double x, double y, double u, double v)
+{
+  double uresult, vresult, uerr, verr;
+  camera.project(x, y, 0.0, uresult, vresult);
+  std::cout << "project (" << x << "," << y << ") -> "
+            << "(" << u << "," << v << "); "
+            << "result (" << uresult << "," << vresult << ")\n";
+  uerr = std::fabs(u - uresult);
+  verr = std::fabs(v - vresult);
+  TEST_NEAR("vpgl_geo_camera.project", uerr + verr, 0.0, 1e-3);
+}
+
+static void
+test_geo_camera()
+{
+  double x, y, u, v, lx, ly, lz;
+  std::vector<std::tuple<double, double, double, double> > data;
+
+  // WGS84 geotransform
+  // https://gdal.org/user/raster_data_model.html#affine-geotransform
+  // Xgeo = GT(0) + Xpixel*GT(1) + Yline*GT(2)
+  // Ygeo = GT(3) + Xpixel*GT(4) + Yline*GT(5)
+  std::array<double, 6> geotransform = {100.0, 1e-6, 0.0, 30.0, 0.0, -1e-6};
+  std::cout << "geotransform for testing: ";
+  for (auto const& v : geotransform)
+    std::cout << v << " ";
+  std::cout << std::endl;
+
+  // WGS84 geocam with no lvcs
+  // global coordinate -> raster coordinate
+  auto cam0 = load_geo_camera_from_geotransform(geotransform);
+  std::cout << "geo_camera: WGS84 without LVCS:\n" << cam0 << std::endl;
+
+  data.clear();
+  data.push_back(std::make_tuple(100.0, 30.0, 0.0, 0.0));
+  data.push_back(std::make_tuple(100.0 + (50*1e-6), 30.0 - (50*1e-6), 50.0, 50.0));
+
+  for (auto const& item : data) {
+    std::tie(x, y, u, v) = item;
+    _test_project(cam0, x, y, u, v);
+  }
+
+  // WGS84 geocam with lvcs
+  // local coordinate -> raster coordinate
+  auto lvcs = vpgl_lvcs(30.0, 100.0, 0.0);
+  auto cam1 = load_geo_camera_from_geotransform(geotransform, -1, 0, &lvcs);
+  std::cout << "geo_camera: WGS84 with LVCS:\n" << cam1 << "\n";
+
+  data.clear();
+  data.push_back(std::make_tuple(0.0, 0.0, 0.0, 0.0));
+
+  lvcs.global_to_local(100.0 + (50*1e-6), 30.0 - (50*1e-6), 0.0,
+                       vpgl_lvcs::wgs84, lx, ly, lz);
+  data.push_back(std::make_tuple(lx, ly, 50.0, 50.0));
+
+  for (auto const& item : data) {
+    std::tie(x, y, u, v) = item;
+    _test_project(cam1, x, y, u, v);
+  }
+}
+
+TESTMAIN(test_geo_camera);

--- a/core/vpgl/file_formats/tests/test_include.cxx
+++ b/core/vpgl/file_formats/tests/test_include.cxx
@@ -1,11 +1,5 @@
 #include <vpgl/file_formats/vpgl_nitf_rational_camera.h>
-
-#include <vil/vil_config.h>
-#ifdef HAS_GEOTIFF
-#  if HAS_GEOTIFF
-#    include <vpgl/file_formats/vpgl_geo_camera.h>
-#  endif
-#endif
+#include <vpgl/file_formats/vpgl_geo_camera.h>
 
 int
 main()

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -206,6 +206,8 @@ vpgl_geo_camera::load_from_geotransform(std::array<double, 6> geotransform,
   this->utm_zone_ = utm_zone;
   this->northing_ = northing;
   this->set_lvcs(lvcs);
+
+  return true;
 }
 
 //: define a geo_camera by the image file name (filename should have format such as xxx_N35W73_S0.6x0.6_xxx.tif)

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -32,11 +32,13 @@ vpgl_geo_camera::vpgl_geo_camera()
 vpgl_geo_camera::vpgl_geo_camera(vpgl_geo_camera const & rhs)
   : vpgl_camera<double>(rhs)
   , trans_matrix_(rhs.trans_matrix_)
-  , lvcs_(new vpgl_lvcs(*(rhs.lvcs_)))
   , is_utm_(rhs.is_utm_)
   , utm_zone_(rhs.utm_zone_)
+  , northing_(rhs.northing_)
   , scale_tag_(rhs.scale_tag_)
-{}
+{
+  this->set_lvcs(rhs.lvcs_);
+}
 
 bool
 vpgl_geo_camera::init_geo_camera(vil_image_resource_sptr const & geotiff_img,
@@ -403,6 +405,7 @@ vpgl_geo_camera::lvcs_elev_origin() const
   }
   return 0.0;
 }
+
 //: transforms a given local 3d world point to image plane
 void
 vpgl_geo_camera::project(const double x, const double y, const double z, double & u, double & v) const

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -363,7 +363,7 @@ vpgl_geo_camera::local_to_global(double lx, double ly, double lz, double & gx, d
   }
 }
 bool
-vpgl_geo_camera::global_to_local(double gx, double gy, double gz, double & lx, double & ly, double & lz)
+vpgl_geo_camera::global_to_local(double gx, double gy, double gz, double & lx, double & ly, double & lz) const
 {
   if (!lvcs_)
   {
@@ -385,7 +385,7 @@ vpgl_geo_camera::global_to_local(double gx, double gy, double gz, double & lx, d
 }
 
 double
-vpgl_geo_camera::lvcs_elev_origin()
+vpgl_geo_camera::lvcs_elev_origin() const
 {
   if (!lvcs_)
     return 0.0;
@@ -438,7 +438,7 @@ vpgl_geo_camera::project(const double x, const double y, const double z, double 
 
 //: backprojects an image point into local coordinates (based on lvcs_)
 void
-vpgl_geo_camera::backproject(const double u, const double v, double & x, double & y, double & z)
+vpgl_geo_camera::backproject(const double u, const double v, double & x, double & y, double & z) const
 {
   vnl_vector<double> vec(4), res(4);
   if (scale_tag_)
@@ -643,7 +643,7 @@ vpgl_geo_camera::global_utm_to_img(const double x, const double y, int zone, dou
 
 //: returns the corresponding utm location for the given local position
 void
-vpgl_geo_camera::local_to_utm(const double x, const double y, const double z, double & e, double & n, int & utm_zone)
+vpgl_geo_camera::local_to_utm(const double x, const double y, const double z, double & e, double & n, int & utm_zone) const
 {
   double lat, lon, gz;
   lvcs_->local_to_global(x, y, z, vpgl_lvcs::wgs84, lon, lat, gz);
@@ -793,7 +793,7 @@ vpgl_geo_camera::img_to_wgs(unsigned /*i*/,
                             unsigned /*k*/,
                             double & /*lon*/,
                             double & /*lat*/,
-                            double & /*elev*/)
+                            double & /*elev*/) const
 {
   assert(!"Not yet implemented");
 }

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -702,19 +702,20 @@ vpgl_geo_camera::operator==(vpgl_geo_camera const & rhs) const
 std::ostream &
 operator<<(std::ostream & s, vpgl_geo_camera const & p)
 {
-  if (!p.is_utm_)
-    s << "geocam is using wgs_84 deg/meters" << '\n';
   if (p.lvcs_)
     s << p.trans_matrix_ << '\n' << *(p.lvcs_) << '\n';
   else
     s << p.trans_matrix_ << '\n';
-  if (p.is_utm_)
-  {
-    s << "geocam is using UTM with zone: " << p.utm_zone_ << '\n';
-    if (p.northing_)
-      s << "southern zone" << std::endl;
-    else
-      s << "northern zone" << std::endl;
+
+  if (!p.is_utm_) {
+    s << "geocam is using wgs84 deg/meters\n";
+  } else {
+    s << "geocam is using UTM with zone " << p.utm_zone_ << '\n';
+    if (p.northing_) {
+      s << "southern zone\n";
+    } else {
+      s << "northern zone\n";
+    }
   }
 
   return s;

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -82,7 +82,8 @@ class vpgl_geo_camera : public vpgl_camera<double>
   //northing=0 means North, 1 is south
   void set_utm(int utm_zone, unsigned northing) { is_utm_=true, utm_zone_=utm_zone; northing_=northing; }
 
-  void set_lvcs(vpgl_lvcs_sptr lvcs) {lvcs_ = new vpgl_lvcs(*lvcs); }
+  void set_lvcs(const vpgl_lvcs* lvcs) {lvcs_ = (lvcs) ? lvcs->clone() : nullptr; }
+  void set_lvcs(const vpgl_lvcs_sptr& lvcs) {lvcs_ = (lvcs) ? lvcs->clone() : nullptr; }
 
   void set_scale_format(bool scale_tag) { scale_tag_=scale_tag; }
 

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -88,27 +88,27 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   vpgl_lvcs_sptr const lvcs() {return lvcs_;}
 
-  double lvcs_elev_origin();
+  double lvcs_elev_origin() const;
 
     //: convert local coordinates to global coordinates in the geo_camera CS
   void local_to_global(double lx, double ly, double lz, double& gx, double& gy, double& gz) const;
 
   //: convert global coordinates in the geo_camera CS to local coordinates
-  bool global_to_local(double gx, double gy, double gz, double& lx, double& ly, double& lz);
+  bool global_to_local(double gx, double gy, double gz, double& lx, double& ly, double& lz) const;
 
   //: Implementing the generic camera interface of vpgl_camera.
   //  x,y,z are in local coordinates, u represents image column, v image row
   void project(const double x, const double y, const double z, double& u, double& v) const override;
 
   //: backprojects an image point into local coordinates (based on lvcs_)
-  void backproject(const double u, const double v, double& x, double& y, double& z);
+  void backproject(const double u, const double v, double& x, double& y, double& z) const;
 
   // adds translation to the trans matrix
   void translate(double tx, double ty, double z);
 
   //: the lidar pixel size in meters assumes square pixels
-  double pixel_spacing() { if (scale_tag_) return trans_matrix_[0][0];
-                           else return 1.0; }
+  double pixel_spacing() const { if (scale_tag_) return trans_matrix_[0][0];
+                                 else return 1.0; }
 
   bool operator ==(vpgl_geo_camera const& rhs) const;
 
@@ -156,7 +156,7 @@ class vpgl_geo_camera : public vpgl_camera<double>
                          double& u, double& v) const;
 
   //: returns the corresponding utm location for the given local position
-  void local_to_utm(const double x, const double y, const double z, double& e, double& n, int& utm_zone);
+  void local_to_utm(const double x, const double y, const double z, double& e, double& n, int& utm_zone) const;
 
   int utm_zone() const { return utm_zone_; }
   int utm_northing() const { return northing_; }
@@ -165,9 +165,9 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   //: returns the corresponding geographical coordinate (lon, lat, elev) for a given pixel position (i,j,k)
   //  Note: not yet implemented -- PVr, 16 aug 2012
-  void img_to_wgs(unsigned i, unsigned j, unsigned k, double& lon, double& lat, double& elev);
+  void img_to_wgs(unsigned i, unsigned j, unsigned k, double& lon, double& lat, double& elev) const;
 
-  vnl_matrix<double>  trans_matrix(){return trans_matrix_; }
+  vnl_matrix<double> trans_matrix() const {return trans_matrix_; }
 
   //: since vpgl_geo_camera is not templated only vpgl_camera<double>* is covariant with vpgl_camera<T>*
   vpgl_geo_camera *clone() const override { return new vpgl_geo_camera(*this); }

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -26,7 +26,10 @@
 
 #include <vpgl/vpgl_camera.h>
 
+#include <vil/vil_config.h> // defines HAS_GEOTIFF
+#if HAS_GEOTIFF
 #include <vil/vil_image_resource_sptr.h>
+#endif
 
 class vpgl_geo_camera : public vpgl_camera<double>
 {
@@ -47,6 +50,7 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   vpgl_geo_camera(vpgl_camera<double> const& rhs);
 
+#if HAS_GEOTIFF
   // Load camera from geotiff file
   bool load_from_geotiff(std::string const& file,
                          const vpgl_lvcs *lvcs=nullptr);
@@ -54,12 +58,6 @@ class vpgl_geo_camera : public vpgl_camera<double>
   //: Load camera from image resource
   bool load_from_resource(vil_image_resource_sptr const& geotiff_img,
                           const vpgl_lvcs* lvcs=nullptr);
-
-  //: Load camera from GDAL geotransform
-  bool load_from_geotransform(std::array<double, 6> geotransform,
-                              int utm_zone = -1,
-                              int northing = 0, //0 North, 1 South
-                              const vpgl_lvcs *lvcs=nullptr);
 
   //: uses lvcs to convert local x-y to global longitude and latitude
   static bool init_geo_camera(vil_image_resource_sptr const& geotiff_img,
@@ -72,6 +70,13 @@ class vpgl_geo_camera : public vpgl_camera<double>
     vpgl_lvcs_sptr lvcs = nullptr;
     return init_geo_camera(geotiff_img, lvcs, camera);
   }
+#endif
+
+  //: Load camera from GDAL geotransform
+  bool load_from_geotransform(std::array<double, 6> geotransform,
+                              int utm_zone = -1,
+                              int northing = 0, //0 North, 1 South
+                              const vpgl_lvcs *lvcs=nullptr);
 
   //: warning, use this camera cautiously, the output of img_to_global method needs to be adjusted sign wise
   //  for 'S' use -lat and for 'W' -lon
@@ -212,6 +217,7 @@ class vpgl_geo_camera : public vpgl_camera<double>
   bool scale_tag_ = false;
 };
 
+#if HAS_GEOTIFF
 //: Create a vpgl_geo_camera from a geotiff file
 vpgl_geo_camera
 load_geo_camera_from_geotiff(std::string const& file,
@@ -221,6 +227,7 @@ load_geo_camera_from_geotiff(std::string const& file,
 vpgl_geo_camera
 load_geo_camera_from_resource(vil_image_resource_sptr const& geotiff_img,
                               const vpgl_lvcs* lvcs = nullptr);
+#endif
 
 //: Create a vpgl_geo_camera from GDAL geotransform
 // https://gdal.org/user/raster_data_model.html#affine-geotransform

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -47,6 +47,10 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   vpgl_geo_camera(vpgl_camera<double> const& rhs);
 
+  //: Load camera from image resource
+  bool load_from_resource(vil_image_resource_sptr const& geotiff_img,
+                          const vpgl_lvcs* lvcs=nullptr);
+
   //: uses lvcs to convert local x-y to global longitude and latitude
   static bool init_geo_camera(vil_image_resource_sptr const& geotiff_img,
                               const vpgl_lvcs_sptr& lvcs,
@@ -197,5 +201,10 @@ class vpgl_geo_camera : public vpgl_camera<double>
   int northing_; //0 North, 1 South
   bool scale_tag_;
 };
+
+//: Create a vpgl_geo_camera from a vil_image_resource_sptr & optional LVCS
+vpgl_geo_camera
+load_geo_camera_from_resource(vil_image_resource_sptr const& geotiff_img,
+                              const vpgl_lvcs* lvcs = nullptr);
 
 #endif // vpgl_geo_camera_h_

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -195,11 +195,11 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   vnl_matrix<double> trans_matrix_;           // 4x4 matrix
   //: lvcs of world parameters
-  vpgl_lvcs_sptr lvcs_;
-  bool is_utm_;
-  int utm_zone_;
-  int northing_; //0 North, 1 South
-  bool scale_tag_;
+  vpgl_lvcs_sptr lvcs_ = nullptr;
+  bool is_utm_ = false;
+  int utm_zone_ = 0;
+  int northing_ = 0; //0 North, 1 South
+  bool scale_tag_ = false;
 };
 
 //: Create a vpgl_geo_camera from a vil_image_resource_sptr & optional LVCS

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -47,9 +47,19 @@ class vpgl_geo_camera : public vpgl_camera<double>
 
   vpgl_geo_camera(vpgl_camera<double> const& rhs);
 
+  // Load camera from geotiff file
+  bool load_from_geotiff(std::string const& file,
+                         const vpgl_lvcs *lvcs=nullptr);
+
   //: Load camera from image resource
   bool load_from_resource(vil_image_resource_sptr const& geotiff_img,
                           const vpgl_lvcs* lvcs=nullptr);
+
+  //: Load camera from GDAL geotransform
+  bool load_from_geotransform(std::array<double, 6> geotransform,
+                              int utm_zone = -1,
+                              int northing = 0, //0 North, 1 South
+                              const vpgl_lvcs *lvcs=nullptr);
 
   //: uses lvcs to convert local x-y to global longitude and latitude
   static bool init_geo_camera(vil_image_resource_sptr const& geotiff_img,
@@ -202,9 +212,22 @@ class vpgl_geo_camera : public vpgl_camera<double>
   bool scale_tag_ = false;
 };
 
+//: Create a vpgl_geo_camera from a geotiff file
+vpgl_geo_camera
+load_geo_camera_from_geotiff(std::string const& file,
+                             const vpgl_lvcs* lvcs = nullptr);
+
 //: Create a vpgl_geo_camera from a vil_image_resource_sptr & optional LVCS
 vpgl_geo_camera
 load_geo_camera_from_resource(vil_image_resource_sptr const& geotiff_img,
                               const vpgl_lvcs* lvcs = nullptr);
+
+//: Create a vpgl_geo_camera from GDAL geotransform
+// https://gdal.org/user/raster_data_model.html#affine-geotransform
+vpgl_geo_camera
+load_geo_camera_from_geotransform(std::array<double, 6> geotransform,
+                                  int utm_zone = -1,
+                                  int northing = 0, //0 North, 1 South
+                                  const vpgl_lvcs* lvcs = nullptr);
 
 #endif // vpgl_geo_camera_h_

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -85,6 +85,8 @@ class vpgl_lvcs : public vbl_ref_count
   ~vpgl_lvcs() override;
   vpgl_lvcs& operator=(const vpgl_lvcs&);
 
+  //: Create a copy on the heap via new and return pointer
+  vpgl_lvcs *clone() const { return new vpgl_lvcs(*this); }
 
   // Utility Methods-----------------------------------------------------------
   void local_to_global(const double lx, const double ly, const double lz,


### PR DESCRIPTION
Refactor `vpgl_geo_camera` to permit more flexible construction. Changes are designed to be backward compatible.  

Changes include:
- additional `vpgl_geo_camera` load functions to creste camera on the stack & heap
- make `vpgl_geo_camera` always available, with extra functionality enabled via `HAS_GEOTIFF` directive (e.g., loading from geotiff)
- improve `vpgl_geo_camera` const correctness
- `vpgl_geo_camera` unit tests
- add `vpgl_lvcs::clone` method
- make several existing `vil_geotiff_header` functions public

@decrispell 

## PR Checklist

- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✔️  Makes design changes to existing vxl/core/\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
