### PR TITLE
ENH: contrib/brl bsgm_check_shadows

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_error_checking.h
+++ b/contrib/brl/bseg/bsgm/bsgm_error_checking.h
@@ -19,6 +19,16 @@
 // \author Thomas Pollard
 // \date July 24, 2018
 
+//: Invalidate disparity pixels with corresponding image intensity below
+// a shadow threshold
+template <class T>
+void bsgm_check_shadows(
+  vil_image_view<float>& disp_img,
+  const vil_image_view<T>& img,
+  float invalid_disparity,
+  unsigned short shadow_thresh,
+  const vgl_box_2d<int>& img_window = vgl_box_2d<int>());
+
 
 //: Use the OpenCV SGM uniqueness criteria to find bad disparities. This
 // is not quite the same as the left-right consistency check from the SGM


### PR DESCRIPTION
For bsgm_disparity_estimator, always check for shadows if shadow_thresh > 0 via new function bsgm_check_shadows

@decrispell

PR Checklist
❌ Makes breaking changes to the vxl/core/* API that requires semantic versioning increase
❌ Makes design changes to existing vxl/core* API that requires semantic versioning increase
✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
❌ Adds tests and baseline comparison (quantitative).
❌ Adds Documentation.