### PR TITLE
map focal plane rectification homograpies to common image space

### DIFF
--- a/core/vpgl/algo/vpgl_equi_rectification.cxx
+++ b/core/vpgl/algo/vpgl_equi_rectification.cxx
@@ -334,9 +334,11 @@ bool vpgl_equi_rectification::rectify_pair(vpgl_perspective_camera<double> const
     return false;
   }
   // update the rectificaion homographies
+  // map image points to focal plane space using K_inverse
+  // map to rectified focal plane image space
+  // map back to rectified image0 space by applying K0
   H0 = K0 * R0r * K0_inv;
-  H1 = K1 * R0r * R10 * K1_inv;
-
+  H1 = K0 * R0r * R10 * K1_inv;
   // compute offset and scale transforms
   size_t n = img_pts0.size();
 
@@ -361,7 +363,7 @@ bool vpgl_equi_rectification::rectify_pair(vpgl_perspective_camera<double> const
 
   // update the rectification homographies
   H0 = Tv0 * H0; H1 = Tv1 * H1;
-
+  
   // scale columns with an affine skew transform to minimize disparity on the pointsets img_pta0 and img_pts1
   double min_scale = 0.5;
   vnl_matrix_fixed<double, 3, 3> Usqt, Usqt_inv;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

-  :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
-  :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
-  :no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
-  :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
-  :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
