### PR TITLE
Fix CMP0120: The WriteCompilerDetectionHeader module is removed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.10.2)
 if(CMAKE_VERSION VERSION_LESS 3.12.0)
   cmake_policy(VERSION ${CMAKE_VERSION})
 else()
-  cmake_policy(VERSION 3.10.2...3.13.2)
+  cmake_policy(VERSION 3.10.2...3.20.3)
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -55,12 +55,11 @@ foreach(p
     ## Only policies introduced after the cmake_minimum_required
     ## version need to explicitly be set to NEW.
 
-    ##----- Policies Introduced by CMake 3.12
-    CMP0075  #: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
-    ##----- Policies Introduced by CMake 3.10
-    CMP0071  #: Let AUTOMOC and AUTOUIC process GENERATED files.
     CMP0070  #: Define file(GENERATE) behavior for relative paths.
+    CMP0071  #: Let AUTOMOC and AUTOUIC process GENERATED files.
+    CMP0075  #: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
     CMP0083  #: Add PIE options when linking executable.
+    CMP0120  #: The WriteCompilerDetectionHeader module is removed.
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -14,96 +14,6 @@ endif()
 
 project( vcl )
 
-## Dynamically create compiler detection header
-set(VCL_COMPILER_DETECTION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/vcl_compiler_detection.h")
-include(WriteCompilerDetectionHeader)
-write_compiler_detection_header(
-    FILE "${VCL_COMPILER_DETECTION_HEADER}"
-    PREFIX VXL
-    OUTPUT_FILES_VAR compiler_stub_headers
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/compilers
-    COMPILERS AppleClang Clang GNU MSVC SunPro Intel #Supported compilers as of 3.10.3
-    VERSION ${CMAKE_VERSION}
-    FEATURES
-      cxx_aggregate_default_initializers      # Aggregate default initializers, as defined in N3605.
-      cxx_alias_templates                     # Template aliases, as defined in N2258.
-      cxx_alignas                             # Alignment control alignas, as defined in N2341.
-      cxx_alignof                             # Alignment control alignof, as defined in N2341.
-      cxx_attributes                          # Generic attributes, as defined in N2761.
-      cxx_attribute_deprecated                # [[deprecated]] attribute, as defined in N3760.
-      cxx_auto_type                           # Automatic type deduction, as defined in N1984.
-      cxx_binary_literals                     # Binary literals, as defined in N3472.
-      cxx_constexpr                           # Constant expressions, as defined in N2235.
-      cxx_contextual_conversions              # Contextual conversions, as defined in N3323.
-      cxx_decltype_incomplete_return_types    # Decltype on incomplete return types, as defined in N3276.
-      cxx_decltype                            # Decltype, as defined in N2343.
-      cxx_decltype_auto                       # decltype(auto) semantics, as defined in N3638.
-      cxx_default_function_template_args      # Default template arguments for function templates, as defined in DR226
-      cxx_defaulted_functions                 # Defaulted functions, as defined in N2346.
-      cxx_defaulted_move_initializers         # Defaulted move initializers, as defined in N3053.
-      cxx_delegating_constructors             # Delegating constructors, as defined in N1986.
-      cxx_deleted_functions                   # Deleted functions, as defined in N2346.
-      cxx_digit_separators                    # Digit separators, as defined in N3781.
-      cxx_enum_forward_declarations           # Enum forward declarations, as defined in N2764.
-      cxx_explicit_conversions                # Explicit conversion operators, as defined in N2437.
-      cxx_extended_friend_declarations        # Extended friend declarations, as defined in N1791.
-      cxx_extern_templates                    # Extern templates, as defined in N1987.
-      cxx_final                               # Override control final keyword, as defined in N2928, N3206 and N3272.
-      cxx_func_identifier                     # Predefined __func__ identifier, as defined in N2340.
-      cxx_generalized_initializers            # Initializer lists, as defined in N2672.
-      cxx_generic_lambdas                     # Generic lambdas, as defined in N3649.
-      cxx_inheriting_constructors             # Inheriting constructors, as defined in N2540.
-      cxx_inline_namespaces                   # Inline namespaces, as defined in N2535.
-      cxx_lambdas                             # Lambda functions, as defined in N2927.
-      cxx_lambda_init_captures                # Initialized lambda captures, as defined in N3648.
-      cxx_local_type_template_args            # Local and unnamed types as template arguments, as defined in N2657.
-      cxx_long_long_type                      # long long type, as defined in N1811.
-      cxx_noexcept                            # Exception specifications, as defined in N3050.
-      cxx_nonstatic_member_init               # Non-static data member initialization, as defined in N2756.
-      cxx_nullptr                             # Null pointer, as defined in N2431.
-      cxx_override                            # Override control override keyword, as defined in N2928, N3206 and N3272.
-      cxx_range_for                           # Range-based for, as defined in N2930.
-      cxx_raw_string_literals                 # Raw string literals, as defined in N2442.
-      cxx_reference_qualified_functions       # Reference qualified functions, as defined in N2439.
-      cxx_relaxed_constexpr                   # Relaxed constexpr, as defined in N3652.
-      cxx_return_type_deduction               # Return type deduction on normal functions, as defined in N3386.
-      cxx_right_angle_brackets                # Right angle bracket parsing, as defined in N1757.
-      cxx_rvalue_references                   # R-value references, as defined in N2118.
-      cxx_sizeof_member                       # Size of non-static data members, as defined in N2253.
-      cxx_static_assert                       # Static assert, as defined in N1720.
-      cxx_strong_enums                        # Strongly typed enums, as defined in N2347.
-      cxx_thread_local                        # Thread-local variables, as defined in N2659.
-      cxx_trailing_return_types               # Automatic function return type, as defined in N2541.
-      cxx_unicode_literals                    # Unicode string literals, as defined in N2442.
-      cxx_uniform_initialization              # Uniform intialization, as defined in N2640.
-      cxx_unrestricted_unions                 # Unrestricted unions, as defined in N2544.
-      cxx_user_literals                       # User-defined literals, as defined in N2765.
-      cxx_variable_templates                  # Variable templates, as defined in N3651.
-      cxx_variadic_macros                     # Variadic macros, as defined in N1653.
-      cxx_variadic_templates                  # Variadic templates, as defined in N2242.
-      cxx_template_template_parameters        # Template template parameters, as defined in ISO/IEC 14882:1998.
-)
-
-#
-# Install platform-specific compiler detection files
-#
-if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
-  set(_compilers_destination ${VXL_INSTALL_INCLUDE_DIR}/vcl/compilers)
-  set(_compiler_detection_destination ${VXL_INSTALL_INCLUDE_DIR}/vcl)
-else()
-  set(_compilers_destination ${VXL_INSTALL_INCLUDE_DIR}/compilers)
-  set(_compiler_detection_destination ${VXL_INSTALL_INCLUDE_DIR})
-endif()
-file(GLOB VXL_COMPILER_DETECTION_FILES ${CMAKE_CURRENT_BINARY_DIR}/compilers/*)
-install(FILES ${VXL_COMPILER_DETECTION_FILES}
-      DESTINATION ${_compilers_destination}
-      PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-      COMPONENT Development )
-install(FILES ${VCL_COMPILER_DETECTION_HEADER}
-      DESTINATION ${_compiler_detection_destination}
-      PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-      COMPONENT Development )
-
 # If VXL_INSTALL_INCLUDE_DIR is the default value
 if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
   set(_config_destination ${VXL_INSTALL_INCLUDE_DIR}/vcl)
@@ -184,6 +94,15 @@ set( vcl_sources
   internal/vcl_atomic_count_sync.h
   internal/vcl_atomic_count_win32.h
   internal/vcl_interlocked.h
+  
+  # Compiler specific files produced by WriteCompilerDetectionHeader
+  vcl_compiler_detection.h
+  compilers/VXL_COMPILER_INFO_AppleClang_CXX.h
+  compilers/VXL_COMPILER_INFO_Clang_CXX.h
+  compilers/VXL_COMPILER_INFO_GNU_CXX.h
+  compilers/VXL_COMPILER_INFO_Intel_CXX.h
+  compilers/VXL_COMPILER_INFO_MSVC_CXX.h
+  compilers/VXL_COMPILER_INFO_SunPro_CXX.h
 )
 
 

--- a/vcl/compilers/VXL_COMPILER_INFO_AppleClang_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_AppleClang_CXX.h
@@ -1,0 +1,360 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 400)
+#      error Unsupported compiler version
+#    endif
+
+# define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__clang_major__)
+# define VXL_COMPILER_VERSION_MINOR VXL_DEC(__clang_minor__)
+# define VXL_COMPILER_VERSION_PATCH VXL_DEC(__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define VXL_SIMULATE_VERSION_MAJOR VXL_DEC(_MSC_VER / 100)
+#  define VXL_SIMULATE_VERSION_MINOR VXL_DEC(_MSC_VER % 100)
+# endif
+# define VXL_COMPILER_VERSION_TWEAK VXL_DEC(__apple_build_version__)
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_aggregate_nsdmi)
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_alias_templates)
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_alignas)
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_alignas)
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_attributes)
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_auto_type)
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_binary_literals)
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_constexpr)
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_contextual_conversions)
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_decltype_incomplete_return_types)
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_decltype)
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_default_function_template_args)
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_defaulted_functions)
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_defaulted_functions)
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_delegating_constructors)
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_deleted_functions)
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_explicit_conversions)
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_override_control)
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_generalized_initializers)
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_inheriting_constructors)
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_lambdas)
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_init_captures)
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_local_type_template_args)
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_noexcept)
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_nonstatic_member_init)
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_nullptr)
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_override_control)
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_range_for)
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_raw_string_literals)
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_reference_qualified_functions)
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_relaxed_constexpr)
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_return_type_deduction)
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_rvalue_references)
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_static_assert)
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_strong_enums)
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_thread_local)
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_trailing_return)
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_unicode_literals)
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_generalized_initializers)
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_unrestricted_unions)
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_user_literals)
+#      define VXL_COMPILER_CXX_USER_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_USER_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_variable_templates)
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_variadic_templates)
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __cplusplus >= 199711L
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/compilers/VXL_COMPILER_INFO_Clang_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_Clang_CXX.h
@@ -1,0 +1,359 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 301)
+#      error Unsupported compiler version
+#    endif
+
+# define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__clang_major__)
+# define VXL_COMPILER_VERSION_MINOR VXL_DEC(__clang_minor__)
+# define VXL_COMPILER_VERSION_PATCH VXL_DEC(__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define VXL_SIMULATE_VERSION_MAJOR VXL_DEC(_MSC_VER / 100)
+#  define VXL_SIMULATE_VERSION_MINOR VXL_DEC(_MSC_VER % 100)
+# endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_aggregate_nsdmi)
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_alias_templates)
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_alignas)
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_alignas)
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_attributes)
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_auto_type)
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_binary_literals)
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_constexpr)
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_contextual_conversions)
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_decltype_incomplete_return_types)
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_decltype)
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_default_function_template_args)
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_defaulted_functions)
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_defaulted_functions)
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_delegating_constructors)
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_deleted_functions)
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_explicit_conversions)
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_override_control)
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_generalized_initializers)
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_inheriting_constructors)
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_lambdas)
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_init_captures)
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_local_type_template_args)
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_noexcept)
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_nonstatic_member_init)
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_nullptr)
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_override_control)
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_range_for)
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_raw_string_literals)
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_reference_qualified_functions)
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_relaxed_constexpr)
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_return_type_deduction)
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_rvalue_references)
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_static_assert)
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_strong_enums)
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_thread_local)
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_trailing_return)
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_unicode_literals)
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_generalized_initializers)
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_unrestricted_unions)
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_user_literals)
+#      define VXL_COMPILER_CXX_USER_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_USER_LITERALS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_variable_templates)
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_variadic_templates)
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __cplusplus >= 199711L
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/compilers/VXL_COMPILER_INFO_GNU_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_GNU_CXX.h
@@ -1,0 +1,362 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !((__GNUC__ * 100 + __GNUC_MINOR__) >= 404)
+#      error Unsupported compiler version
+#    endif
+
+# if defined(__GNUC__)
+#  define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__GNUC__)
+# else
+#  define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define VXL_COMPILER_VERSION_MINOR VXL_DEC(__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define VXL_COMPILER_VERSION_PATCH VXL_DEC(__GNUC_PATCHLEVEL__)
+# endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 500 && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+#    endif
+
+#    if ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40801) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 405 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 405 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 405 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 405 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40801) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 500 && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 407 && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_USER_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_USER_LITERALS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 500 && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && __cplusplus
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/compilers/VXL_COMPILER_INFO_Intel_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_Intel_CXX.h
@@ -1,0 +1,388 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !(__INTEL_COMPILER >= 1210)
+#      error Unsupported compiler version
+#    endif
+
+  /* __INTEL_COMPILER = VRP prior to 2021, and then VVVV for 2021 and later,
+     except that a few beta releases use the old format with V=2021.  */
+# if __INTEL_COMPILER < 2021 || __INTEL_COMPILER == 202110 || __INTEL_COMPILER == 202111
+#  define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__INTEL_COMPILER/100)
+#  define VXL_COMPILER_VERSION_MINOR VXL_DEC(__INTEL_COMPILER/10 % 10)
+#  if defined(__INTEL_COMPILER_UPDATE)
+#   define VXL_COMPILER_VERSION_PATCH VXL_DEC(__INTEL_COMPILER_UPDATE)
+#  else
+#   define VXL_COMPILER_VERSION_PATCH VXL_DEC(__INTEL_COMPILER   % 10)
+#  endif
+# else
+#  define VXL_COMPILER_VERSION_MAJOR VXL_DEC(__INTEL_COMPILER)
+#  define VXL_COMPILER_VERSION_MINOR VXL_DEC(__INTEL_COMPILER_UPDATE)
+   /* The third version component from --version is an update index,
+      but no macro is provided for it.  */
+#  define VXL_COMPILER_VERSION_PATCH VXL_DEC(0)
+# endif
+# if defined(__INTEL_COMPILER_BUILD_DATE)
+   /* __INTEL_COMPILER_BUILD_DATE = YYYYMMDD */
+#  define VXL_COMPILER_VERSION_TWEAK VXL_DEC(__INTEL_COMPILER_BUILD_DATE)
+# endif
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define VXL_SIMULATE_VERSION_MAJOR VXL_DEC(_MSC_VER / 100)
+#  define VXL_SIMULATE_VERSION_MINOR VXL_DEC(_MSC_VER % 100)
+# endif
+# if defined(__GNUC__)
+#  define VXL_SIMULATE_VERSION_MAJOR VXL_DEC(__GNUC__)
+# elif defined(__GNUG__)
+#  define VXL_SIMULATE_VERSION_MAJOR VXL_DEC(__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define VXL_SIMULATE_VERSION_MINOR VXL_DEC(__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define VXL_SIMULATE_VERSION_PATCH VXL_DEC(__GNUC_PATCHLEVEL__)
+# endif
+
+#    if __INTEL_COMPILER >= 1600 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if (__cpp_attributes >= 200809 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if __cpp_binary_literals >= 201304 || __INTEL_COMPILER >= 1210
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if __cpp_constexpr >= 200704 || __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1600 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+#    endif
+
+#    if ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__)) && (__INTEL_COMPILER > 1400 || (__INTEL_COMPILER == 1400 && __INTEL_COMPILER_UPDATE >= 2)) && !defined(_MSC_VER)
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+#    endif
+
+#    if __cpp_decltype >= 200707 || __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if __cpp_decltype_auto >= 201304 || __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1600 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1300 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if __cpp_generic_lambdas >= 201304
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if (__cpp_lambdas >= 200907 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if (__cpp_init_captures >= 201304 || __INTEL_COMPILER >= 1500) && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1300 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if __cpp_raw_strings >= 200710 || __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    if __cpp_constexpr >= 201304 || (__INTEL_COMPILER >= 1700 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) ) && !defined(_MSC_VER))
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+#    endif
+
+#    if __cpp_return_type_deduction >= 201304 || __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201300L) || ((__cplusplus == 201103L) && !defined(__INTEL_CXX11_MODE__)) || ((((__INTEL_COMPILER == 1500) && (__INTEL_COMPILER_UPDATE == 1))) && defined(__GXX_EXPERIMENTAL_CXX0X__) && !defined(__INTEL_CXX11_MODE__) ) || (defined(__INTEL_CXX11_MODE__) && defined(__cpp_aggregate_nsdmi)) )
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if (__cpp_rvalue_references >= 200610 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if (__cpp_static_assert >= 200410 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if __cpp_unicode_literals >= 200710 || (__INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__)) && (!defined(_MSC_VER) || __INTEL_COMPILER >= 1600))
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1300 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    if __cpp_user_defined_literals >= 200809 || (__INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__)) && (!defined(_MSC_VER) || __INTEL_COMPILER >= 1600))
+#      define VXL_COMPILER_CXX_USER_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_USER_LITERALS 0
+#    endif
+
+#    if __cpp_variable_templates >= 201304
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if (__cpp_variadic_templates >= 200704 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1210 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/compilers/VXL_COMPILER_INFO_MSVC_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_MSVC_CXX.h
@@ -1,0 +1,366 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !(_MSC_VER >= 1600)
+#      error Unsupported compiler version
+#    endif
+
+  /* _MSC_VER = VVRR */
+# define VXL_COMPILER_VERSION_MAJOR VXL_DEC(_MSC_VER / 100)
+# define VXL_COMPILER_VERSION_MINOR VXL_DEC(_MSC_VER % 100)
+# if defined(_MSC_FULL_VER)
+#  if _MSC_VER >= 1400
+    /* _MSC_FULL_VER = VVRRPPPPP */
+#   define VXL_COMPILER_VERSION_PATCH VXL_DEC(_MSC_FULL_VER % 100000)
+#  else
+    /* _MSC_FULL_VER = VVRRPPPP */
+#   define VXL_COMPILER_VERSION_PATCH VXL_DEC(_MSC_FULL_VER % 10000)
+#  endif
+# endif
+# if defined(_MSC_BUILD)
+#  define VXL_COMPILER_VERSION_TWEAK VXL_DEC(_MSC_BUILD)
+# endif
+
+#    if _MSC_FULL_VER >= 190024406
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+#    endif
+
+#    if _MSC_VER >= 1911
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if _MSC_VER >= 1700
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if _MSC_VER >= 1700
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if _MSC_FULL_VER >= 180030723
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if _MSC_VER >= 1700
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    if _MSC_VER >= 1911
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if _MSC_VER >= 1700
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define VXL_COMPILER_CXX_USER_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_USER_LITERALS 0
+#    endif
+
+#    if _MSC_FULL_VER >= 190023918
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/compilers/VXL_COMPILER_INFO_SunPro_CXX.h
+++ b/vcl/compilers/VXL_COMPILER_INFO_SunPro_CXX.h
@@ -1,0 +1,342 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#  error This file may only be included from vcl_compiler_detection.h
+#endif
+
+#    if !(__SUNPRO_CC >= 0x5130)
+#      error Unsupported compiler version
+#    endif
+
+# if __SUNPRO_CC >= 0x5100
+   /* __SUNPRO_CC = 0xVRRP */
+#  define VXL_COMPILER_VERSION_MAJOR VXL_HEX(__SUNPRO_CC>>12)
+#  define VXL_COMPILER_VERSION_MINOR VXL_HEX(__SUNPRO_CC>>4 & 0xFF)
+#  define VXL_COMPILER_VERSION_PATCH VXL_HEX(__SUNPRO_CC    & 0xF)
+# else
+   /* __SUNPRO_CC = 0xVRP */
+#  define VXL_COMPILER_VERSION_MAJOR VXL_HEX(__SUNPRO_CC>>8)
+#  define VXL_COMPILER_VERSION_MINOR VXL_HEX(__SUNPRO_CC>>4 & 0xF)
+#  define VXL_COMPILER_VERSION_PATCH VXL_HEX(__SUNPRO_CC    & 0xF)
+# endif
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_AGGREGATE_DEFAULT_INITIALIZERS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_ALIAS_TEMPLATES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ALIGNOF 1
+#    else
+#      define VXL_COMPILER_CXX_ALIGNOF 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ATTRIBUTES 1
+#    else
+#      define VXL_COMPILER_CXX_ATTRIBUTES 0
+#    endif
+
+#    define VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_AUTO_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_AUTO_TYPE 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5140) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_BINARY_LITERALS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define VXL_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    define VXL_COMPILER_CXX_CONTEXTUAL_CONVERSIONS 0
+
+#    define VXL_COMPILER_CXX_DECLTYPE_INCOMPLETE_RETURN_TYPES 0
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 1
+#    else
+#      define VXL_COMPILER_CXX_DECLTYPE_AUTO 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULT_FUNCTION_TEMPLATE_ARGS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_FUNCTIONS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_DEFAULTED_MOVE_INITIALIZERS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_DELEGATING_CONSTRUCTORS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_DELETED_FUNCTIONS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 1
+#    else
+#      define VXL_COMPILER_CXX_DIGIT_SEPARATORS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_ENUM_FORWARD_DECLARATIONS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXPLICIT_CONVERSIONS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 1
+#    else
+#      define VXL_COMPILER_CXX_EXTENDED_FRIEND_DECLARATIONS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_EXTERN_TEMPLATES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_FINAL 1
+#    else
+#      define VXL_COMPILER_CXX_FINAL 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 1
+#    else
+#      define VXL_COMPILER_CXX_FUNC_IDENTIFIER 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_GENERIC_LAMBDAS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 1
+#    else
+#      define VXL_COMPILER_CXX_INHERITING_CONSTRUCTORS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 1
+#    else
+#      define VXL_COMPILER_CXX_INLINE_NAMESPACES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_LAMBDAS 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDAS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 1
+#    else
+#      define VXL_COMPILER_CXX_LAMBDA_INIT_CAPTURES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 1
+#    else
+#      define VXL_COMPILER_CXX_LOCAL_TYPE_TEMPLATE_ARGS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 1
+#    else
+#      define VXL_COMPILER_CXX_LONG_LONG_TYPE 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define VXL_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 1
+#    else
+#      define VXL_COMPILER_CXX_NONSTATIC_MEMBER_INIT 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_NULLPTR 1
+#    else
+#      define VXL_COMPILER_CXX_NULLPTR 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_OVERRIDE 1
+#    else
+#      define VXL_COMPILER_CXX_OVERRIDE 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RANGE_FOR 1
+#    else
+#      define VXL_COMPILER_CXX_RANGE_FOR 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_RAW_STRING_LITERALS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5140) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 1
+#    else
+#      define VXL_COMPILER_CXX_REFERENCE_QUALIFIED_FUNCTIONS 0
+#    endif
+
+#    define VXL_COMPILER_CXX_RELAXED_CONSTEXPR 0
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 1
+#    else
+#      define VXL_COMPILER_CXX_RETURN_TYPE_DEDUCTION 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 1
+#    else
+#      define VXL_COMPILER_CXX_RIGHT_ANGLE_BRACKETS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define VXL_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 1
+#    else
+#      define VXL_COMPILER_CXX_SIZEOF_MEMBER 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define VXL_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 1
+#    else
+#      define VXL_COMPILER_CXX_STRONG_ENUMS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define VXL_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 1
+#    else
+#      define VXL_COMPILER_CXX_TRAILING_RETURN_TYPES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 1
+#    else
+#      define VXL_COMPILER_CXX_UNICODE_LITERALS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 1
+#    else
+#      define VXL_COMPILER_CXX_UNIFORM_INITIALIZATION 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 1
+#    else
+#      define VXL_COMPILER_CXX_UNRESTRICTED_UNIONS 0
+#    endif
+
+#    define VXL_COMPILER_CXX_USER_LITERALS 0
+
+#    if (__SUNPRO_CC >= 0x5150) && __cplusplus >= 201402L
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIABLE_TEMPLATES 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_MACROS 0
+#    endif
+
+#    if (__SUNPRO_CC >= 0x5130) && __cplusplus >= 201103L
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define VXL_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if __SUNPRO_CC >= 0x5130 && __cplusplus
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 1
+#    else
+#      define VXL_COMPILER_CXX_TEMPLATE_TEMPLATE_PARAMETERS 0
+#    endif
+

--- a/vcl/vcl_compiler.h.in
+++ b/vcl/vcl_compiler.h.in
@@ -3,15 +3,12 @@
 
 //:
 // \file
-// This file is generated from vcl_compiler_detection.h.in
+// This file is generated from vcl_compiler.h.in
 // This file has mostly been replaced with
 // CMake supported features in the auto-generated
 // vcl_compiler_detection.h that should be included
 // independently where needed
 //
-
-//----------------------------------------------------------------------
-// syntax-like things.
 
 /* The version of the CXX compiler used when VXL was built */
 #define VXL_COMPILED_CXX_STANDARD_VERSION @VXL_COMPILED_CXX_STANDARD_VERSION@

--- a/vcl/vcl_compiler_detection.h
+++ b/vcl/vcl_compiler_detection.h
@@ -1,0 +1,314 @@
+#ifndef VXL_COMPILER_DETECTION_H
+#define VXL_COMPILER_DETECTION_H
+
+#define VXL_DEC(X) (X)
+#define VXL_HEX(X) ( \
+    ((X)>>28 & 0xF) * 10000000 + \
+    ((X)>>24 & 0xF) *  1000000 + \
+    ((X)>>20 & 0xF) *   100000 + \
+    ((X)>>16 & 0xF) *    10000 + \
+    ((X)>>12 & 0xF) *     1000 + \
+    ((X)>>8  & 0xF) *      100 + \
+    ((X)>>4  & 0xF) *       10 + \
+    ((X)     & 0xF) \
+    )
+
+#ifdef __cplusplus
+# define VXL_COMPILER_IS_Comeau 0
+# define VXL_COMPILER_IS_Intel 0
+# define VXL_COMPILER_IS_IntelLLVM 0
+# define VXL_COMPILER_IS_PathScale 0
+# define VXL_COMPILER_IS_Embarcadero 0
+# define VXL_COMPILER_IS_Borland 0
+# define VXL_COMPILER_IS_Watcom 0
+# define VXL_COMPILER_IS_OpenWatcom 0
+# define VXL_COMPILER_IS_SunPro 0
+# define VXL_COMPILER_IS_HP 0
+# define VXL_COMPILER_IS_Compaq 0
+# define VXL_COMPILER_IS_zOS 0
+# define VXL_COMPILER_IS_XLClang 0
+# define VXL_COMPILER_IS_XL 0
+# define VXL_COMPILER_IS_VisualAge 0
+# define VXL_COMPILER_IS_NVHPC 0
+# define VXL_COMPILER_IS_PGI 0
+# define VXL_COMPILER_IS_Cray 0
+# define VXL_COMPILER_IS_TI 0
+# define VXL_COMPILER_IS_Fujitsu 0
+# define VXL_COMPILER_IS_GHS 0
+# define VXL_COMPILER_IS_SCO 0
+# define VXL_COMPILER_IS_ARMCC 0
+# define VXL_COMPILER_IS_AppleClang 0
+# define VXL_COMPILER_IS_ARMClang 0
+# define VXL_COMPILER_IS_Clang 0
+# define VXL_COMPILER_IS_GNU 0
+# define VXL_COMPILER_IS_MSVC 0
+# define VXL_COMPILER_IS_ADSP 0
+# define VXL_COMPILER_IS_IAR 0
+# define VXL_COMPILER_IS_MIPSpro 0
+
+#if defined(__COMO__)
+# undef VXL_COMPILER_IS_Comeau
+# define VXL_COMPILER_IS_Comeau 1
+
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+# undef VXL_COMPILER_IS_Intel
+# define VXL_COMPILER_IS_Intel 1
+
+#elif (defined(__clang__) && defined(__INTEL_CLANG_COMPILER)) || defined(__INTEL_LLVM_COMPILER)
+# undef VXL_COMPILER_IS_IntelLLVM
+# define VXL_COMPILER_IS_IntelLLVM 1
+
+#elif defined(__PATHCC__)
+# undef VXL_COMPILER_IS_PathScale
+# define VXL_COMPILER_IS_PathScale 1
+
+#elif defined(__BORLANDC__) && defined(__CODEGEARC_VERSION__)
+# undef VXL_COMPILER_IS_Embarcadero
+# define VXL_COMPILER_IS_Embarcadero 1
+
+#elif defined(__BORLANDC__)
+# undef VXL_COMPILER_IS_Borland
+# define VXL_COMPILER_IS_Borland 1
+
+#elif defined(__WATCOMC__) && __WATCOMC__ < 1200
+# undef VXL_COMPILER_IS_Watcom
+# define VXL_COMPILER_IS_Watcom 1
+
+#elif defined(__WATCOMC__)
+# undef VXL_COMPILER_IS_OpenWatcom
+# define VXL_COMPILER_IS_OpenWatcom 1
+
+#elif defined(__SUNPRO_CC)
+# undef VXL_COMPILER_IS_SunPro
+# define VXL_COMPILER_IS_SunPro 1
+
+#elif defined(__HP_aCC)
+# undef VXL_COMPILER_IS_HP
+# define VXL_COMPILER_IS_HP 1
+
+#elif defined(__DECCXX)
+# undef VXL_COMPILER_IS_Compaq
+# define VXL_COMPILER_IS_Compaq 1
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__)
+# undef VXL_COMPILER_IS_zOS
+# define VXL_COMPILER_IS_zOS 1
+
+#elif defined(__ibmxl__) && defined(__clang__)
+# undef VXL_COMPILER_IS_XLClang
+# define VXL_COMPILER_IS_XLClang 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ >= 800
+# undef VXL_COMPILER_IS_XL
+# define VXL_COMPILER_IS_XL 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ < 800
+# undef VXL_COMPILER_IS_VisualAge
+# define VXL_COMPILER_IS_VisualAge 1
+
+#elif defined(__NVCOMPILER)
+# undef VXL_COMPILER_IS_NVHPC
+# define VXL_COMPILER_IS_NVHPC 1
+
+#elif defined(__PGI)
+# undef VXL_COMPILER_IS_PGI
+# define VXL_COMPILER_IS_PGI 1
+
+#elif defined(_CRAYC)
+# undef VXL_COMPILER_IS_Cray
+# define VXL_COMPILER_IS_Cray 1
+
+#elif defined(__TI_COMPILER_VERSION__)
+# undef VXL_COMPILER_IS_TI
+# define VXL_COMPILER_IS_TI 1
+
+#elif defined(__FUJITSU) || defined(__FCC_VERSION) || defined(__fcc_version)
+# undef VXL_COMPILER_IS_Fujitsu
+# define VXL_COMPILER_IS_Fujitsu 1
+
+#elif defined(__ghs__)
+# undef VXL_COMPILER_IS_GHS
+# define VXL_COMPILER_IS_GHS 1
+
+#elif defined(__SCO_VERSION__)
+# undef VXL_COMPILER_IS_SCO
+# define VXL_COMPILER_IS_SCO 1
+
+#elif defined(__ARMCC_VERSION) && !defined(__clang__)
+# undef VXL_COMPILER_IS_ARMCC
+# define VXL_COMPILER_IS_ARMCC 1
+
+#elif defined(__clang__) && defined(__apple_build_version__)
+# undef VXL_COMPILER_IS_AppleClang
+# define VXL_COMPILER_IS_AppleClang 1
+
+#elif defined(__clang__) && defined(__ARMCOMPILER_VERSION)
+# undef VXL_COMPILER_IS_ARMClang
+# define VXL_COMPILER_IS_ARMClang 1
+
+#elif defined(__clang__)
+# undef VXL_COMPILER_IS_Clang
+# define VXL_COMPILER_IS_Clang 1
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+# undef VXL_COMPILER_IS_GNU
+# define VXL_COMPILER_IS_GNU 1
+
+#elif defined(_MSC_VER)
+# undef VXL_COMPILER_IS_MSVC
+# define VXL_COMPILER_IS_MSVC 1
+
+#elif defined(__VISUALDSPVERSION__) || defined(__ADSPBLACKFIN__) || defined(__ADSPTS__) || defined(__ADSP21000__)
+# undef VXL_COMPILER_IS_ADSP
+# define VXL_COMPILER_IS_ADSP 1
+
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__IAR_SYSTEMS_ICC)
+# undef VXL_COMPILER_IS_IAR
+# define VXL_COMPILER_IS_IAR 1
+
+
+#endif
+
+#  if VXL_COMPILER_IS_AppleClang
+
+#    include "compilers/VXL_COMPILER_INFO_AppleClang_CXX.h"
+
+#  elif VXL_COMPILER_IS_Clang
+
+#    include "compilers/VXL_COMPILER_INFO_Clang_CXX.h"
+
+#  elif VXL_COMPILER_IS_GNU
+
+#    include "compilers/VXL_COMPILER_INFO_GNU_CXX.h"
+
+#  elif VXL_COMPILER_IS_MSVC
+
+#    include "compilers/VXL_COMPILER_INFO_MSVC_CXX.h"
+
+#  elif VXL_COMPILER_IS_SunPro
+
+#    include "compilers/VXL_COMPILER_INFO_SunPro_CXX.h"
+
+#  elif VXL_COMPILER_IS_Intel
+
+#    include "compilers/VXL_COMPILER_INFO_Intel_CXX.h"
+
+#  else
+#    error Unsupported compiler
+#  endif
+
+#  if defined(VXL_COMPILER_CXX_ALIGNAS) && VXL_COMPILER_CXX_ALIGNAS
+#    define VXL_ALIGNAS(X) alignas(X)
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_ALIGNAS(X) __attribute__ ((__aligned__(X)))
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_ALIGNAS(X) __declspec(align(X))
+#  else
+#    define VXL_ALIGNAS(X)
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_ALIGNOF) && VXL_COMPILER_CXX_ALIGNOF
+#    define VXL_ALIGNOF(X) alignof(X)
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_ALIGNOF(X) __alignof__(X)
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_ALIGNOF(X) __alignof(X)
+#  endif
+
+
+#  ifndef VXL_DEPRECATED
+#    if defined(VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED) && VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED
+#      define VXL_DEPRECATED [[deprecated]]
+#      define VXL_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#    elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang
+#      define VXL_DEPRECATED __attribute__((__deprecated__))
+#      define VXL_DEPRECATED_MSG(MSG) __attribute__((__deprecated__(MSG)))
+#    elif VXL_COMPILER_IS_MSVC
+#      define VXL_DEPRECATED __declspec(deprecated)
+#      define VXL_DEPRECATED_MSG(MSG) __declspec(deprecated(MSG))
+#    else
+#      define VXL_DEPRECATED
+#      define VXL_DEPRECATED_MSG(MSG)
+#    endif
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_CONSTEXPR) && VXL_COMPILER_CXX_CONSTEXPR
+#    define VXL_CONSTEXPR constexpr
+#  else
+#    define VXL_CONSTEXPR 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_DELETED_FUNCTIONS) && VXL_COMPILER_CXX_DELETED_FUNCTIONS
+#    define VXL_DELETED_FUNCTION = delete
+#  else
+#    define VXL_DELETED_FUNCTION 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_EXTERN_TEMPLATES) && VXL_COMPILER_CXX_EXTERN_TEMPLATES
+#    define VXL_EXTERN_TEMPLATE extern
+#  else
+#    define VXL_EXTERN_TEMPLATE 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_FINAL) && VXL_COMPILER_CXX_FINAL
+#    define VXL_FINAL final
+#  else
+#    define VXL_FINAL 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_NOEXCEPT) && VXL_COMPILER_CXX_NOEXCEPT
+#    define VXL_NOEXCEPT noexcept
+#    define VXL_NOEXCEPT_EXPR(X) noexcept(X)
+#  else
+#    define VXL_NOEXCEPT
+#    define VXL_NOEXCEPT_EXPR(X)
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_NULLPTR) && VXL_COMPILER_CXX_NULLPTR
+#    define VXL_NULLPTR nullptr
+#  elif VXL_COMPILER_IS_GNU
+#    define VXL_NULLPTR __null
+#  else
+#    define VXL_NULLPTR 0
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_OVERRIDE) && VXL_COMPILER_CXX_OVERRIDE
+#    define VXL_OVERRIDE override
+#  else
+#    define VXL_OVERRIDE 
+#  endif
+
+#  if defined(VXL_COMPILER_CXX_STATIC_ASSERT) && VXL_COMPILER_CXX_STATIC_ASSERT
+#    define VXL_STATIC_ASSERT(X) static_assert(X, #X)
+#    define VXL_STATIC_ASSERT_MSG(X, MSG) static_assert(X, MSG)
+#  else
+#    define VXL_STATIC_ASSERT_JOIN(X, Y) VXL_STATIC_ASSERT_JOIN_IMPL(X, Y)
+#    define VXL_STATIC_ASSERT_JOIN_IMPL(X, Y) X##Y
+template<bool> struct VXLStaticAssert;
+template<> struct VXLStaticAssert<true>{};
+#    define VXL_STATIC_ASSERT(X) enum { VXL_STATIC_ASSERT_JOIN(VXLStaticAssertEnum, __LINE__) = sizeof(VXLStaticAssert<X>) }
+#    define VXL_STATIC_ASSERT_MSG(X, MSG) enum { VXL_STATIC_ASSERT_JOIN(VXLStaticAssertEnum, __LINE__) = sizeof(VXLStaticAssert<X>) }
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_THREAD_LOCAL) && VXL_COMPILER_CXX_THREAD_LOCAL
+#    define VXL_THREAD_LOCAL thread_local
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_THREAD_LOCAL __thread
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_THREAD_LOCAL __declspec(thread)
+#  else
+// VXL_THREAD_LOCAL not defined for this configuration.
+#  endif
+
+#endif
+
+#endif


### PR DESCRIPTION
This is a follow-up to #833. We should be able to revert https://github.com/InsightSoftwareConsortium/ITK/pull/2464 once this is merged.

## PR Checklist
- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.

