### PR TITLE
BUG/STYLE: contrib/brl acal single node tree

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -615,28 +615,21 @@ acal_match_graph::validate_match_trees_and_set_metric()
         temp[trit->first] = trit->second;
     }
 
-    if (temp.size() > 0)
+    // no valid match trees
+    if (temp.empty())
     {
-      match_trees_[cc] = temp;
-      std::shared_ptr<acal_match_tree> best_tree = this->largest_tree(cc);
-      if (!best_tree){
-        match_tree_metric_[cc] = 0;
-        continue;
-      }
-      match_tree_metric_[cc] = best_tree->size();
-      continue;
-    } else {//no valid match trees
       std::cout << "all match trees failed for connected component " << cc
-                << " listing cams with excessive projection error"<< std::endl;
+                << " listing cams with excessive projection error" << std::endl;
       std::vector<size_t> bad_ids;
       for (std::map<size_t, size_t>::iterator bit = bad_track_camera_ids_.begin();
            bit != bad_track_camera_ids_.end(); ++bit)
       {
         size_t nbad = bit->second;
-        if(nbad>0) bad_ids.push_back(bit->first);
-        if (nbad == 0) continue;
-        std::cout << "cam id " << bit->first << ", n_bad " << bit->second
-                  << ", n_trees " << n_trees << std::endl;
+        if (nbad > 0) {
+          bad_ids.push_back(bit->first);
+          std::cout << "cam id " << bit->first << ", n_bad " << nbad
+                    << ", n_trees " << n_trees << std::endl;
+        }
       }
 
       std::cout << "remove bad cameras from match trees and retry to find valid trees" << std::endl;
@@ -645,7 +638,7 @@ acal_match_graph::validate_match_trees_and_set_metric()
           mit != mtrees.end(); ++mit)
       {
         size_t fid = mit->first;
-        if(bad_track_camera_ids_[fid]>0) // skip entire tree if root is bad
+        if (bad_track_camera_ids_[fid] > 0) // skip entire tree if root is bad
           continue;
         std::shared_ptr<acal_match_tree> repaired(new acal_match_tree(*(mit->second), bad_ids));
         repaired_trees[mit->first] = repaired;
@@ -669,15 +662,15 @@ acal_match_graph::validate_match_trees_and_set_metric()
       }
     }
 
-    if (temp.size() > 0) {
+    if (temp.size() > 0)
+    {
       match_trees_[cc] = temp;
       std::shared_ptr<acal_match_tree> best_tree = this->largest_tree(cc);
-      if (!best_tree){
+      if (!best_tree) {
         match_tree_metric_[cc] = 0;
-        continue;
+      } else {
+        match_tree_metric_[cc] = best_tree->size();
       }
-      match_tree_metric_[cc] = best_tree->size();
-      continue;
     }
   }
 }

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -24,6 +24,7 @@ match_vertex::edge_ids() const
   return ids;
 }
 
+
 // equality operator
 bool
 match_vertex::operator==(match_vertex const& other) const
@@ -31,6 +32,7 @@ match_vertex::operator==(match_vertex const& other) const
   return this->cam_id_ == other.cam_id_ &&
          this->edge_ids() == other.edge_ids();
 }
+
 
 // streaming operator
 std::ostream&
@@ -61,6 +63,7 @@ match_edge::vertex_ids() const
   return ids;
 }
 
+
 // equality operator
 bool
 match_edge::operator==(match_edge const& other) const
@@ -69,6 +72,7 @@ match_edge::operator==(match_edge const& other) const
          this->vertex_ids() == other.vertex_ids() &&
          this->matches_ == other.matches_;
 }
+
 
 // streaming operator
 std::ostream&
@@ -90,6 +94,7 @@ acal_match_graph::acal_match_graph(
 {
   bool success = this->load_incidence_matrix(incidence_matrix);
 }
+
 
 bool
 acal_match_graph::load_incidence_matrix(
@@ -135,6 +140,7 @@ acal_match_graph::load_incidence_matrix(
   return true;
 }
 
+
 bool
 acal_match_graph::load_from_fmatches(std::string const& fmatches_path)
 {
@@ -151,11 +157,13 @@ acal_match_graph::load_from_fmatches(std::string const& fmatches_path)
   return true;
 }
 
+
 bool
 acal_match_graph::load_affine_cams(std::string const& affine_cam_path)
 {
   return acal_f_utils::read_affine_cameras(affine_cam_path, all_acams_);
 }
+
 
 void
 acal_match_graph::clear_vertex_marks()
@@ -164,6 +172,7 @@ acal_match_graph::clear_vertex_marks()
       vit != match_vertices_.end(); ++vit)
     (*vit).second->mark_ = false;
 }
+
 
 std::vector<std::shared_ptr<match_vertex> >
 acal_match_graph::adjacent_verts(std::shared_ptr<match_vertex> const& v)
@@ -181,6 +190,7 @@ acal_match_graph::adjacent_verts(std::shared_ptr<match_vertex> const& v)
   return ret;
 }
 
+
 void
 acal_match_graph::visit(
     std::shared_ptr<match_vertex>& v,
@@ -197,6 +207,7 @@ acal_match_graph::visit(
   }
 }
 
+
 void
 acal_match_graph::find_connected_components()
 {
@@ -211,6 +222,7 @@ acal_match_graph::find_connected_components()
       conn_comps_.push_back(comp);
   }
 }
+
 
 void
 acal_match_graph::set_intersect_match_edge(
@@ -325,6 +337,7 @@ acal_match_graph::set_intersect_match_edge(
   focus_corrs = inter_focus_corrs;
 }
 
+
 bool
 acal_match_graph::find_joint_tracks(
     std::shared_ptr<match_vertex> const& focus_vert,
@@ -383,6 +396,7 @@ acal_match_graph::find_joint_tracks(
   return true;
 }
 
+
 void
 acal_match_graph::compute_focus_tracks()
 {
@@ -427,6 +441,7 @@ acal_match_graph::compute_focus_tracks()
     focus_tracks_[c] = c_tracks;
   }
 }
+
 
 void
 acal_match_graph::compute_match_trees()
@@ -496,34 +511,42 @@ acal_match_graph::compute_match_trees()
   } // end conn-comp
 }
 
+
 bool
 acal_match_graph::valid_tree(std::shared_ptr<acal_match_tree> const& mtree)
 {
   if (mtree->size() == 0)
     return false;
+
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks = mtree->tracks();
   std::map<size_t, std::map<size_t, vgl_point_2d<double> > > proj_tracks;
   std::map<size_t, vpgl_affine_camera<double> > tree_acams;
   std::vector<size_t> tree_cam_ids = mtree->cam_ids();
+
   for (std::vector<size_t>::iterator cit = tree_cam_ids.begin();
-      cit != tree_cam_ids.end(); ++cit) {
+       cit != tree_cam_ids.end(); ++cit)
+  {
     if (all_acams_.count(*cit) == 0) {
       std::cout << "affine camera " << *cit << " not in match graph - fatal" << std::endl;
       return false;
     }
     tree_acams[*cit] = all_acams_[*cit];
   }
+
   std::map<size_t, vgl_point_3d<double> > inter_pts;
   if (! acal_f_utils::intersect_tracks_with_3d(tree_acams, tracks, inter_pts, proj_tracks))
     return false;
+
   double max_proj_error = 0.0;
   size_t max_track = -1, max_cam_id = -1;
   for (std::map<size_t, std::map<size_t, vgl_point_2d<double> > >::iterator pit = proj_tracks.begin();
-      pit != proj_tracks.end(); ++pit) {
+       pit != proj_tracks.end(); ++pit)
+  {
     size_t tidx = pit->first; //track index
     std::map<size_t, vgl_point_2d<double> > temp = pit->second;
     for (std::map<size_t, vgl_point_2d<double> >::iterator cit = temp.begin();
-        cit != temp.end(); ++cit) {
+         cit != temp.end(); ++cit)
+    {
       size_t cam_id = cit->first;
       vgl_point_2d<double>& pt      = tracks[tidx][cam_id];
       vgl_point_2d<double>& proj_pt = cit->second;
@@ -535,6 +558,7 @@ acal_match_graph::valid_tree(std::shared_ptr<acal_match_tree> const& mtree)
       }
     }
   }
+
   //std::cout << max_proj_error << ' ';
   if (max_proj_error > params_.max_uncal_proj_error_) {
     //std::cout << max_proj_error << " error exceeds limit for cam " << max_cam_id << " on track " << max_track << std::endl;
@@ -544,7 +568,10 @@ acal_match_graph::valid_tree(std::shared_ptr<acal_match_tree> const& mtree)
   return true;
 }
 
-void acal_match_graph::print_bad_camera_ids(){
+
+void
+acal_match_graph::print_bad_camera_ids()
+{
   std::cout << "cameras that have excessive projection error in a track" << std::endl;
   for(std::map<size_t, size_t>::iterator bit = bad_track_camera_ids_.begin();
       bit != bad_track_camera_ids_.end(); ++bit) {
@@ -554,13 +581,16 @@ void acal_match_graph::print_bad_camera_ids(){
   }
 }
 
+
 void
 acal_match_graph::validate_match_trees_and_set_metric()
 {
   size_t ncc = conn_comps_.size();
   match_tree_metric_.clear();
   match_tree_metric_.resize(ncc, 0);
-  for (size_t cc = 0; cc<ncc; ++cc) {
+
+  for (size_t cc = 0; cc<ncc; ++cc)
+  {
     std::map<size_t, std::shared_ptr<acal_match_tree> >& mtrees = match_trees_[cc];
     std::map<size_t, std::shared_ptr<acal_match_tree> > temp, repaired_trees;
     size_t  n_trees = mtrees.size();
@@ -568,19 +598,25 @@ acal_match_graph::validate_match_trees_and_set_metric()
       std::cout << "no match trees for connected component " << cc << std::endl;
       continue;
     }
+
     // initialize bad camera map
     for (std::map<size_t, std::shared_ptr<acal_match_tree> >::iterator trit = mtrees.begin();
-         trit != mtrees.end(); ++trit) {
+         trit != mtrees.end(); ++trit)
+    {
       std::vector<size_t> cam_ids =  trit->second->cam_ids();
       for(size_t i = 0; i<cam_ids.size(); ++i)
         bad_track_camera_ids_[cam_ids[i]] = 0;//initialize bad in track count to 0
     }
+
     for (std::map<size_t, std::shared_ptr<acal_match_tree> >::iterator trit = mtrees.begin();
-         trit != mtrees.end(); ++trit) {
+         trit != mtrees.end(); ++trit)
+    {
       if (valid_tree(trit->second))//updates bad track camera count
         temp[trit->first] = trit->second;
     }
-    if(temp.size() > 0){
+
+    if (temp.size() > 0)
+    {
       match_trees_[cc] = temp;
       std::shared_ptr<acal_match_tree> best_tree = this->largest_tree(cc);
       if (!best_tree){
@@ -589,41 +625,51 @@ acal_match_graph::validate_match_trees_and_set_metric()
       }
       match_tree_metric_[cc] = best_tree->size();
       continue;
-    }else{//no valid match trees
-      std::cout << "all match trees failed for connected component " << cc << " listing cams with excessive projection error"<< std::endl;
+    } else {//no valid match trees
+      std::cout << "all match trees failed for connected component " << cc
+                << " listing cams with excessive projection error"<< std::endl;
       std::vector<size_t> bad_ids;
       for (std::map<size_t, size_t>::iterator bit = bad_track_camera_ids_.begin();
-        bit != bad_track_camera_ids_.end(); ++bit) {
+           bit != bad_track_camera_ids_.end(); ++bit)
+      {
         size_t nbad = bit->second;
         if(nbad>0) bad_ids.push_back(bit->first);
         if (nbad == 0) continue;
-        std::cout << "cam id " << bit->first << " n_bad / n_trees " << bit->second << " / " << n_trees << std::endl;
+        std::cout << "cam id " << bit->first << ", n_bad " << bit->second
+                  << ", n_trees " << n_trees << std::endl;
       }
+
       std::cout << "remove bad cameras from match trees and retry to find valid trees" << std::endl;
       std::map<size_t, std::shared_ptr<acal_match_tree> > repaired_trees;
       for(std::map<size_t, std::shared_ptr<acal_match_tree> >::iterator mit = mtrees.begin();
-          mit != mtrees.end(); ++mit){
+          mit != mtrees.end(); ++mit)
+      {
         size_t fid = mit->first;
         if(bad_track_camera_ids_[fid]>0) // skip entire tree if root is bad
-          continue;       
+          continue;
         std::shared_ptr<acal_match_tree> repaired(new acal_match_tree(*(mit->second), bad_ids));
         repaired_trees[mit->first] = repaired;
       }
+
       // initialize bad camera map
       bad_track_camera_ids_.clear();
       for (std::map<size_t, std::shared_ptr<acal_match_tree> >::iterator trit = repaired_trees.begin();
-           trit != repaired_trees.end(); ++trit) {
+           trit != repaired_trees.end(); ++trit)
+      {
         std::vector<size_t> cam_ids =  trit->second->cam_ids();
         for(size_t i = 0; i<cam_ids.size(); ++i)
           bad_track_camera_ids_[cam_ids[i]] = 0;//initialize bad in track count to 0
       }
+
       for (std::map<size_t, std::shared_ptr<acal_match_tree> >::iterator trit = repaired_trees.begin();
-         trit != repaired_trees.end(); ++trit) {
+           trit != repaired_trees.end(); ++trit)
+      {
         if (valid_tree(trit->second))//updates bad track camera count
           temp[trit->first] = trit->second;
       }
     }
-    if(temp.size() > 0){
+
+    if (temp.size() > 0) {
       match_trees_[cc] = temp;
       std::shared_ptr<acal_match_tree> best_tree = this->largest_tree(cc);
       if (!best_tree){
@@ -937,7 +983,8 @@ acal_match_graph::trees(size_t conn_comp_index)
 // requires special handling to compare dereferenced shared_ptr content
 // std::equal pattern from https://stackoverflow.com/a/8473603
 template<typename T>
-bool is_equal(std::vector<T> const& lhs, std::vector<T> const& rhs)
+bool
+is_equal(std::vector<T> const& lhs, std::vector<T> const& rhs)
 {
   auto pred = [] (decltype(*lhs.begin()) a, decltype(a) b)
                  { return is_equal(a, b); };
@@ -947,7 +994,8 @@ bool is_equal(std::vector<T> const& lhs, std::vector<T> const& rhs)
 }
 
 template<typename K, typename T>
-bool is_equal(std::map<K, T> const& lhs, std::map<K, T> const& rhs)
+bool
+is_equal(std::map<K, T> const& lhs, std::map<K, T> const& rhs)
 {
   auto pred = [] (decltype(*lhs.begin()) a, decltype(a) b)
                  { return a.first == b.first && is_equal(a.second, b.second); };
@@ -957,7 +1005,8 @@ bool is_equal(std::map<K, T> const& lhs, std::map<K, T> const& rhs)
 }
 
 template<typename T>
-bool is_equal(std::shared_ptr<T> const& lhs, std::shared_ptr<T> const& rhs)
+bool
+is_equal(std::shared_ptr<T> const& lhs, std::shared_ptr<T> const& rhs)
 {
   return *lhs == *rhs;
 }

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -515,7 +515,8 @@ acal_match_graph::compute_match_trees()
 bool
 acal_match_graph::valid_tree(std::shared_ptr<acal_match_tree> const& mtree)
 {
-  if (mtree->size() == 0)
+  // valid trees must have at least 2 nodes
+  if (mtree->size() < 2)
     return false;
 
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks = mtree->tracks();

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
@@ -77,8 +77,10 @@ operator<<(std::ostream& os, acal_match_node const& node)
 // --------------------
 
 // make a deep copy of a subtree
-void acal_match_tree::copy_subtree(std::shared_ptr<acal_match_node> const& node_from, std::shared_ptr<acal_match_node>& node_to){
-
+void
+acal_match_tree::copy_subtree(std::shared_ptr<acal_match_node> const& node_from,
+                              std::shared_ptr<acal_match_node>& node_to)
+{
   // don't copy the "from" parent pointer since copied subtree context is not specified
   // just set the camera id
   node_to->cam_id_ = node_from->cam_id_;
@@ -87,24 +89,27 @@ void acal_match_tree::copy_subtree(std::shared_ptr<acal_match_node> const& node_
   if(nc == 0) return; // nothing more to do node is a leaf
 
   // copy the data for the children
-  for (size_t c = 0; c<nc ; ++c) 
+  for (size_t c = 0; c<nc ; ++c)
     node_to->add_child(node_from->children_[c]->cam_id_, node_from->self_to_child_matches_[c]);
 
   //recursively copy the child subtrees
   for(size_t c = 0; c<nc; ++c)
     copy_subtree(node_from->children_[c], node_to->children_[c]);
-  
+
 }
-  
+
+
 // copy constructor
 acal_match_tree::acal_match_tree(acal_match_tree const& mt){
   copy_subtree(mt.root_, this->root_);
   this->update_tree_size();
 }
 
-// delete a leaf node of the tree
-bool acal_match_tree::delete_leaf(std::shared_ptr<acal_match_node>& leaf_node){
 
+// delete a leaf node of the tree
+bool
+acal_match_tree::delete_leaf(std::shared_ptr<acal_match_node>& leaf_node)
+{
   if(leaf_node->children_.size() != 0)//not a leaf node
     return false;
 
@@ -138,12 +143,14 @@ bool acal_match_tree::delete_leaf(std::shared_ptr<acal_match_node>& leaf_node){
   return false;
 }
 
-std::shared_ptr<acal_match_node>  acal_match_tree::find_leaf_node(std::shared_ptr<acal_match_node>& node){
 
+std::shared_ptr<acal_match_node>
+acal_match_tree::find_leaf_node(std::shared_ptr<acal_match_node>& node)
+{
   size_t nc = node->children_.size();
   if(nc == 0) // node is a leaf
     return node;
- 
+
   for(size_t c = 0; c<nc; ++c)
     return find_leaf_node(node->children_[c]);
 
@@ -151,9 +158,11 @@ std::shared_ptr<acal_match_node>  acal_match_tree::find_leaf_node(std::shared_pt
   return std::shared_ptr<acal_match_node>();
 }
 
-// delete a subtree with node as root including self
-bool acal_match_tree::delete_subtree(std::shared_ptr<acal_match_node>& subtree_root){
 
+// delete a subtree with node as root including self
+bool
+acal_match_tree::delete_subtree(std::shared_ptr<acal_match_node>& subtree_root)
+{
   // ::find_leaf_node operates depth first so the entire subtree will
   // eventually be deleted as leaf nodes are removed
   while(subtree_root->children_.size() > 0){
@@ -174,10 +183,13 @@ bool acal_match_tree::delete_subtree(std::shared_ptr<acal_match_node>& subtree_r
 
   return true;
 }
+
+
 // Each node to remove only appears once (at most) in a match tree
 // If the tree root is the node to be removed the cam_id becomes invalid, i.e.,  size_t(-1)
-acal_match_tree::acal_match_tree(acal_match_tree const& tree , std::vector<size_t> nodes_to_remove){
-
+acal_match_tree::acal_match_tree(acal_match_tree const& tree,
+                                 std::vector<size_t> nodes_to_remove)
+{
   //make a deep copy of the input tree
   *this = tree;
   size_t n = nodes_to_remove.size();
@@ -189,7 +201,7 @@ acal_match_tree::acal_match_tree(acal_match_tree const& tree , std::vector<size_
     std::shared_ptr<acal_match_node> found = this->find(this->root_, cam_id);
     if(!found)// node not in tree - or already removed so ok
       continue;
-    size_t found_id = found->cam_id_; 
+    size_t found_id = found->cam_id_;
     if(!delete_subtree(found)){
       std::cout << "Failed to remove subtree with root id " << cam_id << std::endl;
       continue;
@@ -201,6 +213,7 @@ acal_match_tree::acal_match_tree(acal_match_tree const& tree , std::vector<size_
   this->update_tree_size();
   //should now have a valid tree with the nodes to remove gone
 }
+
 
 std::shared_ptr<acal_match_node>
 acal_match_tree::find(std::shared_ptr<acal_match_node> const& node, size_t cam_id)
@@ -412,7 +425,7 @@ acal_match_tree::save_tree_dot_format(std::string const& path) const
 
 
 void
-acal_match_tree::n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n) 
+acal_match_tree::n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n)
 {
   size_t nc = node->size();
   if (nc == 0) {
@@ -427,34 +440,39 @@ acal_match_tree::n_nodes(std::shared_ptr<acal_match_node> const& node, size_t& n
 
 
 void
-acal_match_tree::collect_correspondences (
+acal_match_tree::collect_correspondences(
     std::shared_ptr<acal_match_node>& node,
-    std::map<size_t, std::vector<vgl_point_2d<double> > >& node_corrs) 
+    std::map<size_t, std::vector<vgl_point_2d<double> > >& node_corrs)
 {
   std::vector<vgl_point_2d<double> > temp;
-  size_t nc = node->size();// number of children
-  if(nc == 0) {
+  size_t nc = node->size(); // number of children
+
+  if (nc == 0) {
     // node is leaf, so use second half of match_pair (corr2_) with respect to parent
     std::shared_ptr<acal_match_node> parent = node->parent();
 
     // get parent's child index for node
     size_t cindx;
-    if(parent->child_index(node,  cindx))
+    if (parent->child_index(node,  cindx))
     {
       // retrieve the match pairs
       std::vector<acal_match_pair> & mpairs =  parent->self_to_child_matches_[cindx];
       size_t n = mpairs.size();
-      if(n == 0){
-        std::cout << "node " << node->cam_id_ << " has no correspondences - shouldn't happen" << std::endl;
+      if (n == 0) {
+        std::cout << "node " << node->cam_id_
+                  << " has no correspondences - shouldn't happen" << std::endl;
         return;
       }
+
       // extract the corr2_.pt_ half of the match pair and assign to leaf
       for(size_t i = 0; i<n; ++i)
         temp.push_back(mpairs[i].corr2_.pt_);
       node_corrs[node->cam_id_] = temp;
       return;
+
     } else {
-      std::cout << "can't find " << node->cam_id_ << "child in parent " << parent->cam_id_ << std::endl;
+      std::cout << "can't find " << node->cam_id_ << "child in parent "
+                << parent->cam_id_ << std::endl;
       return;
     }
   }
@@ -462,23 +480,27 @@ acal_match_tree::collect_correspondences (
   // not a leaf, so just pick any child to retrive match pairs to extract corr1_ to assign to node
   std::vector<acal_match_pair> & mpairs =  node->self_to_child_matches_[0];
   size_t n = mpairs.size();
-  if(n == 0){
+  if (n == 0) {
     std::cout << "node " << node->cam_id_ << " has no correspondences - shouldn't happen" << std::endl;
     return;
   }
 
   // extract corr1_ points
-  for(size_t i = 0; i<n; ++i)
+  for (size_t i = 0; i<n; ++i) {
     temp.push_back(mpairs[i].corr1_.pt_);
+  }
 
   node_corrs[node->cam_id_] = temp;
-  for(size_t c = 0; c<nc; ++c)
+  for (size_t c = 0; c<nc; ++c) {
     collect_correspondences(node->children_[c], node_corrs);
+  }
+
   return;
 }
 
+
 std::vector< std::map<size_t, vgl_point_2d<double> > >
-acal_match_tree::tracks() 
+acal_match_tree::tracks()
 {
   std::vector< std::map<size_t, vgl_point_2d<double> > > ret;
 

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.cxx
@@ -448,6 +448,14 @@ acal_match_tree::collect_correspondences(
   size_t nc = node->size(); // number of children
 
   if (nc == 0) {
+
+    // node has no children or parent
+    if (!node->has_parent()) {
+      std::cout << "singleton node " << node->cam_id_
+                << " (no children or parent)" << std::endl;
+      return;
+    }
+
     // node is leaf, so use second half of match_pair (corr2_) with respect to parent
     std::shared_ptr<acal_match_node> parent = node->parent();
 
@@ -506,6 +514,9 @@ acal_match_tree::tracks()
 
   std::map<size_t, std::vector<vgl_point_2d<double> > > tree_corrs;
   this->collect_correspondences(root_, tree_corrs);
+  if (tree_corrs.empty()) {
+    return ret;
+  }
 
   size_t nt = tree_corrs.begin()->second.size();
   for(size_t t = 0; t<nt; ++t){

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree.h
@@ -95,7 +95,7 @@ std::ostream& operator<<(std::ostream& os, acal_match_node const& node);
 class acal_match_tree
 {
  public:
-  //: default constructor  
+  //: default constructor
   acal_match_tree() = default;
 
   //: initalizing constructor
@@ -104,7 +104,7 @@ class acal_match_tree
   }
   //: copy constructor
   acal_match_tree(acal_match_tree const& mt);
-  
+
   //: construct a new tree with the specified nodes removed
   acal_match_tree(acal_match_tree const& tree, std::vector<size_t> nodes_to_remove);
 
@@ -152,7 +152,7 @@ class acal_match_tree
 
   //: collect correspondences recursively
   static void collect_correspondences(std::shared_ptr<acal_match_node>& node, std::map<size_t, std::vector<vgl_point_2d<double> > >& corrs);
-  
+
   //: reorganize correspondences in track format
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks() ;
 


### PR DESCRIPTION
BUG: fix `acal_match_graph::validate_match_trees_and_set_metric` for trees with only a single node (parent discovery for a single-node tree resulted in a segfault)

STYLE: general formatting in `acal_match_graph` and `acal_match_tree`

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
