### PR TITLE
COMP: Removed constructor template parameters from the VNL library

### DIFF
--- a/core/vnl/algo/vnl_svd_fixed.h
+++ b/core/vnl/algo/vnl_svd_fixed.h
@@ -163,7 +163,7 @@ class vnl_svd_fixed
   bool valid_;        // false if the NETLIB call failed.
 
   // Disallow assignment.
-  vnl_svd_fixed<T,R,C>(vnl_svd_fixed<T,R,C> const &) { }
+  vnl_svd_fixed(vnl_svd_fixed<T,R,C> const &) { }
   vnl_svd_fixed<T,R,C>& operator=(vnl_svd_fixed<T,R,C> const &) { return *this; }
 };
 

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -735,7 +735,7 @@ class VNL_EXPORT vnl_matrix
 //--------------------------------------------------------------------------------
 
  protected:
-  vnl_matrix<T>( unsigned ext_num_rows, unsigned ext_num_cols,
+  vnl_matrix( unsigned ext_num_rows, unsigned ext_num_cols,
       T * continuous_external_memory_block, bool manage_own_memory )
   : num_rows{ ext_num_rows}
   , num_cols{ ext_num_cols}

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -459,7 +459,7 @@ class VNL_EXPORT vnl_vector
     set_data(datain, this->size(), LetArrayManageMemory);
   }
  protected:
-  vnl_vector<T>( size_t ext_num_elmts, T * extdata, bool manage_own_memory )
+  vnl_vector( size_t ext_num_elmts, T * extdata, bool manage_own_memory )
     : num_elmts{ ext_num_elmts }
     , data{ extdata }
     , m_LetArrayManageMemory{ manage_own_memory }


### PR DESCRIPTION
Removed template parameters from protected constructors in VNL class definitions to allow successful compilation to avoid the following error with gcc-11 C++20:

error: expected unqualified-id before ')' token

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- <!-- [X] or :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X] or :no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
- <!-- [X] or :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
