### PR TITLE
COMP: Removed constructor template parameters from the VNL library

### DIFF
--- a/core/vnl/algo/vnl_svd_fixed.h
+++ b/core/vnl/algo/vnl_svd_fixed.h
@@ -163,7 +163,7 @@ class vnl_svd_fixed
   bool valid_;        // false if the NETLIB call failed.
 
   // Disallow assignment.
-  vnl_svd_fixed<T,R,C>(vnl_svd_fixed<T,R,C> const &) { }
+  vnl_svd_fixed(vnl_svd_fixed<T,R,C> const &) { }
   vnl_svd_fixed<T,R,C>& operator=(vnl_svd_fixed<T,R,C> const &) { return *this; }
 };
 

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -735,7 +735,7 @@ class VNL_EXPORT vnl_matrix
 //--------------------------------------------------------------------------------
 
  protected:
-  vnl_matrix<T>( unsigned ext_num_rows, unsigned ext_num_cols,
+  vnl_matrix( unsigned ext_num_rows, unsigned ext_num_cols,
       T * continuous_external_memory_block, bool manage_own_memory )
   : num_rows{ ext_num_rows}
   , num_cols{ ext_num_cols}

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -459,7 +459,7 @@ class VNL_EXPORT vnl_vector
     set_data(datain, this->size(), LetArrayManageMemory);
   }
  protected:
-  vnl_vector<T>( size_t ext_num_elmts, T * extdata, bool manage_own_memory )
+  vnl_vector( size_t ext_num_elmts, T * extdata, bool manage_own_memory )
     : num_elmts{ ext_num_elmts }
     , data{ extdata }
     , m_LetArrayManageMemory{ manage_own_memory }


### PR DESCRIPTION
Removed template parameters from protected constructors in VNL class definitions to allow successful compilation to avoid the following error with gcc-11 C++20:

error: expected unqualified-id before ')' token