### PR TITLE
BUG: vil_math::isnan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.3.1.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.3.2.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 


### PR DESCRIPTION
`vil_math::isisinf`, `vil_math::isnan`, `vil_math::isfinite`, `vil_math::isnormal` copied from vnl_math, handling a variety of corner cases (e.g., MSVC does not properly implement C++11 conformance for integral types).

Fixes issue #843, @dzenanz, @hjmjohnson 

## PR Checklist
- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✔️  Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌  Adds tests and baseline comparison (quantitative).
- ❌  Adds Documentation.

