### PR TITLE
TSan issues

### DIFF
--- a/core/vgui/internals/vgui_accelerate_x11.cxx
+++ b/core/vgui/internals/vgui_accelerate_x11.cxx
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <cmath>
 #include <cstring>
+#include <cstdint>
 #include <algorithm>
 #include "vgui_accelerate_x11.h"
 
@@ -39,11 +40,11 @@ struct gl_to_hermes_format_map
 {
   GLenum gl_format;
   GLenum gl_type;
-  int32 bits_per_pixel;
-  int32 red_mask;
-  int32 green_mask;
-  int32 blue_mask;
-  int32 alpha_mask;
+  int32_t bits_per_pixel;
+  int32_t red_mask;
+  int32_t green_mask;
+  int32_t blue_mask;
+  int32_t alpha_mask;
 };
 
 // swap between little and big endian 32bit words.
@@ -153,10 +154,10 @@ vgui_accelerate_x11::vgui_glClear(GLbitfield mask)
                             x_max - x_min,
                             y_max - y_min,
                             backbuffer->bytes_per_line,
-                            (int32)(clear_color[0] * 255.0F),
-                            (int32)(clear_color[1] * 255.0F),
-                            (int32)(clear_color[2] * 255.0F),
-                            (int32)(clear_color[3] * 255.0F));
+                            (int32_t)(clear_color[0] * 255.0F),
+                            (int32_t)(clear_color[1] * 255.0F),
+                            (int32_t)(clear_color[2] * 255.0F),
+                            (int32_t)(clear_color[3] * 255.0F));
         Hermes_FormatFree(dest_format);
       }
       GLbitfield leftover = mask & ~(GL_COLOR_BUFFER_BIT);

--- a/core/vil/file_formats/vil_tiff_header.cxx
+++ b/core/vil/file_formats/vil_tiff_header.cxx
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cstdio>
 #include <ctime>
+#include <cstdint>
 #include "vil_tiff_header.h"
 #ifdef _MSC_VER
 #  include "vcl_msvc_warnings.h"
@@ -239,12 +240,12 @@ vil_tiff_header::read_header()
       std::cout << "TBC[" << i << "]=" << tile_byte_counts[i] << '\n';
   }
 #endif
-  uint32 count, f;
+  uint32_t count, f;
   char * data;
   f = TIFFGetField(tif_, 42113, &count, &data);
   if (f)
   {
-    for (uint32 i = 0; i < count; ++i)
+    for (uint32_t i = 0; i < count; ++i)
       no_data_value_.push_back(data[i]);
   }
 

--- a/core/vnl/algo/vnl_svd.hxx
+++ b/core/vnl/algo/vnl_svd.hxx
@@ -8,6 +8,7 @@
 #include <complex>
 #include <iostream>
 #include <algorithm>
+#include <atomic>
 #include "vnl_svd.h"
 
 #include <cassert>
@@ -205,8 +206,8 @@ template <class T> void vnl_svd<T>::zero_out_relative(double tol) // sqrt(machin
   zero_out_absolute(tol * std::abs(sigma_max()));
 }
 
-static bool w=false;
-inline bool vnl_svn_warned() { if (w) return true; else { w=true; return false; } }
+static std::atomic_flag w=ATOMIC_FLAG_INIT;
+inline bool vnl_svn_warned() { return std::atomic_flag_test_and_set(&w); }
 
 //: Calculate determinant as product of diagonals in W.
 template <class T>

--- a/core/vpgl/algo/vpgl_equi_rectification.cxx
+++ b/core/vpgl/algo/vpgl_equi_rectification.cxx
@@ -54,7 +54,6 @@ bool vpgl_equi_rectification::column_transform(const std::vector<vnl_vector_fixe
   AA[0][0] = Su1u1;
   AA[0][1] = AA[1][0] = Su1v1;
   AA[1][1] = Sv1v1;
-  AA[2][2] = 1.0;
   bb[0] = Su0u1;
   bb[1] = Su0v1;
   double d = fabs(vnl_det(AA));
@@ -228,7 +227,6 @@ vpgl_equi_rectification::rectify_pair(const vpgl_affine_fundamental_matrix<doubl
   AA[0][0] = Su1u1;
   AA[0][1] = AA[1][0] = Su1v1;
   AA[1][1] = Sv1v1;
-  AA[2][2] = 1.0;
   bb[0] = Su0u1;
   bb[1] = Su0v1;
   double d = fabs(vnl_det(AA));


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- <!-- [X] or :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X] or :no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
- <!-- [X] or :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
