### PR TITLE
BUG: fixed buffer overrun in logging code found by ASan

### DIFF
--- a/core/vnl/algo/vnl_levenberg_marquardt.cxx
+++ b/core/vnl/algo/vnl_levenberg_marquardt.cxx
@@ -65,7 +65,7 @@ vnl_levenberg_marquardt::~vnl_levenberg_marquardt()
 void
 vnl_levenberg_marquardt::lmdif_lsqfun(long * n,     // I   Number of residuals
                                       long * p,     // I   Number of unknowns
-                                      double * x,   // I   Solution vector, size n
+                                      double * x,   // I   Solution vector, size p
                                       double * fx,  // O   Residual vector f(x)
                                       long * iflag, // IO  0 ==> print, -1 ==> terminate
                                       void * userdata)
@@ -74,14 +74,28 @@ vnl_levenberg_marquardt::lmdif_lsqfun(long * n,     // I   Number of residuals
   vnl_least_squares_function * f = self->f_;
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
+  assert(*p > 0);
+  assert(*n > *p);
   vnl_vector_ref<double> ref_x(*p, const_cast<double *>(x));
   vnl_vector_ref<double> ref_fx(*n, fx);
 
   if (*iflag == 0)
   {
     if (self->trace)
-      std::cerr << "lmdif: iter " << self->num_iterations_ << " err [" << x[0] << ", " << x[1] << ", " << x[2] << ", "
-                << x[3] << ", " << x[4] << ", ... ] = " << ref_fx.magnitude() << '\n';
+    {
+      std::cerr << "lmdif: iter " << self->num_iterations_ << " err [" << x[0];
+      if (*p > 1)
+        std::cerr << ", " << x[1];
+      if (*p > 2)
+        std::cerr << ", " << x[2];
+      if (*p > 3)
+        std::cerr << ", " << x[3];
+      if (*p > 4)
+        std::cerr << ", " << x[4];
+      if (*p > 5)
+        std::cerr << ", ... ";
+      std::cerr << "] = " << ref_fx.magnitude() << '\n';
+    }
 
     f->trace(self->num_iterations_, ref_x, ref_fx);
     ++(self->num_iterations_);
@@ -222,7 +236,7 @@ vnl_levenberg_marquardt::minimize_without_gradient(vnl_vector<double> & x)
 void
 vnl_levenberg_marquardt::lmder_lsqfun(long * n,    // I   Number of residuals
                                       long * p,    // I   Number of unknowns
-                                      double * x,  // I   Solution vector, size n
+                                      double * x,  // I   Solution vector, size p
                                       double * fx, // O   Residual vector f(x)
                                       double * fJ, // O   m * n Jacobian f(x)
                                       long *,
@@ -233,6 +247,8 @@ vnl_levenberg_marquardt::lmder_lsqfun(long * n,    // I   Number of residuals
   vnl_least_squares_function * f = self->f_;
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
+  assert(*p > 0);
+  assert(*n > *p);
   vnl_vector_ref<double> ref_x(*p, (double *)x); // const violation!
   vnl_vector_ref<double> ref_fx(*n, fx);
   vnl_matrix_ref<double> ref_fJ(*n, *p, fJ);
@@ -240,8 +256,20 @@ vnl_levenberg_marquardt::lmder_lsqfun(long * n,    // I   Number of residuals
   if (*iflag == 0)
   {
     if (self->trace)
-      std::cerr << "lmder: iter " << self->num_iterations_ << " err [" << x[0] << ", " << x[1] << ", " << x[2] << ", "
-                << x[3] << ", " << x[4] << ", ... ] = " << ref_fx.magnitude() << '\n';
+    {
+      std::cerr << "lmder: iter " << self->num_iterations_ << " err [" << x[0];
+      if (*p > 1)
+        std::cerr << ", " << x[1];
+      if (*p > 2)
+        std::cerr << ", " << x[2];
+      if (*p > 3)
+        std::cerr << ", " << x[3];
+      if (*p > 4)
+        std::cerr << ", " << x[4];
+      if (*p > 5)
+        std::cerr << ", ... ";
+      std::cerr << "] = " << ref_fx.magnitude() << '\n';
+    }
     f->trace(self->num_iterations_, ref_x, ref_fx);
   }
   else if (*iflag == 1)


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- <!-- [X] or :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X] or :no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- <!-- [X] or :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
- <!-- [X] or :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
