### PR TITLE
copy constructor didn't update pixel spacing

### DIFF
--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -43,6 +43,7 @@ vpgl_geo_camera::vpgl_geo_camera(vpgl_geo_camera const & rhs)
   , scale_tag_(rhs.scale_tag_)
 {
   this->set_lvcs(rhs.lvcs_);
+  rhs.pixel_spacing(sx_, sy_);
 }
 
 

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -132,7 +132,7 @@ class vpgl_geo_camera : public vpgl_camera<double>
   double pixel_spacing() const{return 0.5*(sx_ + sy_);}
 
   //: the lidar pixel size in meters, general case
-  void pixel_spacing(double& sx, double& sy){sx = sx_; sy = sy_;}
+  void pixel_spacing(double& sx, double& sy) const {sx = sx_; sy = sy_;}
 
   bool operator ==(vpgl_geo_camera const& rhs) const;
 


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X]  --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
-  :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
