### PR TITLE
ENH: contrib/brl - surface_type

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
@@ -52,8 +52,13 @@ bpgl_surface_type::read(std::string const& directory)
 bool
 bpgl_surface_type::write(std::string const& directory) const
 {
+  if ((type_images_.size() == 0) || (ni_ == 0) || (nj_ == 0)) {
+    std::cerr << "surface type images are not initalized or empty" << std::endl;
+    return false;
+  }
+
   if (!vul_file::is_directory(directory)) {
-    std::cerr << "type data directory not accessable "
+    std::cerr << "surface type data directory not accessable "
               << directory << std::endl;
     return false;
   }

--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
@@ -183,6 +183,7 @@ class bpgl_surface_type
   bool write(std::string const& path) const;
 
   //: accessors
+  size_t ntypes() const {return type_images_.size();}
   size_t ni() const {return ni_;}
   size_t nj() const {return nj_;}
   domain domain_id() const {return domain_;}

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
@@ -347,11 +347,8 @@ class bsgm_prob_pairwise_dsm
   const vil_image_view<float>& prob_confidence() const { return prob_heightmap_prob_; }
   const vil_image_view<float>& radial_std_dev_image() const {return radial_std_dev_image_; }
 
-  const bpgl_surface_type & rect_target_stype() const  { return rect_space_target_; }
-  const bpgl_surface_type & dsm_grid_stype() const { return dsm_grid_space_; }
-  bool save_dsm_grid_stype(std::string const& stype_dir){
-    return dsm_grid_space_.write(stype_dir);
-  }
+  const bpgl_surface_type & rect_target_stype() const  { return rect_target_stype_; }
+  const bpgl_surface_type & dsm_grid_stype() const { return dsm_grid_stype_; }
 
   // PROCESS-----
 
@@ -485,7 +482,11 @@ class bsgm_prob_pairwise_dsm
 
   //: apply a color map to the probability values and
   //  output a color point cloud as ascii
-  bool save_prob_ptset_color(std::string const& path) const;
+  void save_prob_ptset_color(std::string const& path) const;
+
+  //: save surface type data
+  void save_rect_target_stype(std::string const& path) const;
+  void save_dsm_grid_stype(std::string const& path) const;
 
  protected:
 
@@ -545,8 +546,8 @@ class bsgm_prob_pairwise_dsm
   vgl_vector_2d<float> sun_dir_1_;
 
   // define surface type probability layers
-  bpgl_surface_type rect_space_target_;
-  bpgl_surface_type dsm_grid_space_;
+  bpgl_surface_type rect_target_stype_;
+  bpgl_surface_type dsm_grid_stype_;
 
   // associate target_image pix_ij to triangulated 3-d pointset index
   std::map<size_t, std::pair<size_t, size_t> > pt_index_to_pix_;

--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
@@ -415,10 +415,10 @@ bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_prob(bool compute_prob_height
 {
   // check number of points
   if (ptset_fwd_.size() == 0) {
-    std::runtime_error("ptset_fwd_ is empty");
+    throw std::runtime_error("ptset_fwd_ is empty");
   }
   if (ptset_rev_.size() == 0) {
-    std::runtime_error("ptset_rev_ is empty");
+    throw std::runtime_error("ptset_rev_ is empty");
   }
 
   // overall pointset probability is related to how rapidly z changes with disparity
@@ -465,7 +465,7 @@ bool bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_prob(bool compute_prob_height
   // check size
   n = prob_ptset_.size();
   if (n == 0) {
-    std::runtime_error("prob_ptset_ is empty");
+    throw std::runtime_error("prob_ptset_ is empty");
   }
 
   // convert pointset to images
@@ -521,7 +521,7 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::compute_xyz_prob(bool compute_prob_he
   }
   size_t n = prob_ptset_.size();
   if (n == 0) {
-    std::runtime_error("prob_ptset_ is empty");
+    throw std::runtime_error("prob_ptset_ is empty");
   }
 
   // convert pointset to images
@@ -708,7 +708,7 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::set_shadow_context_data(){
   //  |                    /---------\                    |
   //  | image space     long cast shadow                  |
   //  =====================================================
-  std::runtime_error("shadow dp weighting not implemented for the perspective camera");
+  throw std::runtime_error("shadow dp weighting not implemented for the perspective camera");
 }
 
 


### PR DESCRIPTION
contrib/brl minor refactoring of `bpgl_surface_type` and `bsgm_prob_pairwise_dsm`

- add missing `throw` statements to some runtime_errors
- parameter/method naming consistency
- new accessors
- save functions throw errors

@decrispell 

## PR Checklist

- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✔️  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
