### PR TITLE
COMP Add extensions to that newer cmake is happy

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/tests/CMakeLists.txt
+++ b/contrib/brl/bbas/bvgl/algo/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable( bvgl_algo_test_all
   test_2d_geo_index.cxx
   test_biarc.cxx
   test_eulerspiral.cxx
-  test_register
+  test_register.cxx
 )
 
 target_link_libraries( bvgl_algo_test_all bvgl_algo ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}vnl_algo bnl ${VXL_LIB_PREFIX}testlib )


### PR DESCRIPTION
I wasn't able to configure on cmake 3.22.1 without this change

## PR Checklist

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.