### PR TITLE
DOC: Change version minor number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.4.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.5.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 


### PR DESCRIPTION
VXL minor revision updated to 3.5 in order to allow identification
when vnl_math::abs learned how to consistently process complex numbers,
and the standard types supported by std::abs were preferred over
custom implementations.

## PR Checklist

 [X] Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
 [X] Makes design changes to existing vxl/core\* API that requires semantic versioning increase
