### PR TITLE
BUG: Recent assert in debug was too strict

### DIFF
--- a/core/vnl/algo/vnl_levenberg_marquardt.cxx
+++ b/core/vnl/algo/vnl_levenberg_marquardt.cxx
@@ -75,7 +75,7 @@ vnl_levenberg_marquardt::lmdif_lsqfun(long * n,     // I   Number of residuals
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
   assert(*p > 0);
-  assert(*n > *p);
+  assert(*n >= *p);
   vnl_vector_ref<double> ref_x(*p, const_cast<double *>(x));
   vnl_vector_ref<double> ref_fx(*n, fx);
 
@@ -248,7 +248,7 @@ vnl_levenberg_marquardt::lmder_lsqfun(long * n,    // I   Number of residuals
   assert(*p == (int)f->get_number_of_unknowns());
   assert(*n == (int)f->get_number_of_residuals());
   assert(*p > 0);
-  assert(*n > *p);
+  assert(*n >= *p);
   vnl_vector_ref<double> ref_x(*p, (double *)x); // const violation!
   vnl_vector_ref<double> ref_fx(*n, fx);
   vnl_matrix_ref<double> ref_fJ(*n, *p, fJ);


### PR DESCRIPTION
In debug builds, the historical test case would
always fail due to '*n==2' and '*p==2' that did
not pass the 'assert(*n >= *p)' strict condition
added in commit 334e913af16bc9356135da32a45c9980f164cab1.
