### PR TITLE
ENH: vpgl_utm force_utm_zone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.4.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.5.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vpgl/tests/CMakeLists.txt
+++ b/core/vpgl/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable( vpgl_test_all
   test_local_rational_camera.cxx
   test_generic_camera.cxx
   test_lvcs.cxx
+  test_utm.cxx
   test_tri_focal_tensor.cxx
   test_affine_fundamental_matrix.cxx
   test_affine_tri_focal_tensor.cxx
@@ -34,6 +35,7 @@ add_test( NAME vpgl_test_rational_camera COMMAND $<TARGET_FILE:vpgl_test_all> te
 add_test( NAME vpgl_test_local_rational_camera COMMAND $<TARGET_FILE:vpgl_test_all> test_local_rational_camera)
 add_test( NAME vpgl_test_generic_camera COMMAND $<TARGET_FILE:vpgl_test_all> test_generic_camera)
 add_test( NAME vpgl_test_lvcs COMMAND $<TARGET_FILE:vpgl_test_all> test_lvcs)
+add_test( NAME vpgl_test_utm COMMAND $<TARGET_FILE:vpgl_test_all> test_utm)
 add_test( NAME vpgl_test_tri_focal_tensor COMMAND $<TARGET_FILE:vpgl_test_all> test_tri_focal_tensor)
 add_test( NAME vpgl_test_affine_fundamental_matrix COMMAND $<TARGET_FILE:vpgl_test_all> test_affine_fundamental_matrix)
 add_test( NAME vpgl_test_affine_tri_focal_tensor COMMAND $<TARGET_FILE:vpgl_test_all> test_affine_tri_focal_tensor)

--- a/core/vpgl/tests/test_driver.cxx
+++ b/core/vpgl/tests/test_driver.cxx
@@ -13,6 +13,7 @@ DECLARE(test_rational_camera);
 DECLARE(test_local_rational_camera);
 DECLARE(test_generic_camera);
 DECLARE(test_lvcs);
+DECLARE(test_utm);
 DECLARE(test_tri_focal_tensor);
 DECLARE(test_affine_tri_focal_tensor);
 DECLARE(test_affine_fundamental_matrix);
@@ -33,6 +34,7 @@ register_tests()
   REGISTER(test_local_rational_camera);
   REGISTER(test_generic_camera);
   REGISTER(test_lvcs);
+  REGISTER(test_utm);
   REGISTER(test_tri_focal_tensor);
   REGISTER(test_affine_tri_focal_tensor);
   REGISTER(test_affine_fundamental_matrix);

--- a/core/vpgl/tests/test_lvcs.cxx
+++ b/core/vpgl/tests/test_lvcs.cxx
@@ -6,50 +6,6 @@
 static void
 test_lvcs()
 {
-  // first check utm projection
-  // pt 1 near border: 11 S 237346.15 m E 4199542.50 m N   , wgs84 (from google earth):  lat 37.905526(degrees) 37
-  // (degrees)54'19.89"N lon -119.987431(degrees) 119(degrees)59'14.75"W
-  //   pt1 from http://www.ngs.noaa.gov/cgi-bin/utm_getut.prl     11 S  237346.006 m E   4199541.877 m N
-  // pt 2 near border: 10 S 763653.66 m E 4199428.45 m N   , wgs84 (from google earth):  lat 37.904211(degrees)
-  // 37(degrees)54'15.16"N lon -120.001263(degrees) 120(degrees) 0'4.55"W pt 3 mid        : 11 S 495039.78 m E
-  // 4314876.95 m N   , wgs84 (from google earth):  lat 38.982859(degrees)  38(degrees)58'58.29"N lon
-  // -117.057278(degrees) 117(degrees) 3'26.20"W pt 3 mid from http://www.ngs.noaa.gov/cgi-bin/utm_getut.prl 4314875.917
-  // 495039.020   11
-
-  double lat1, lon1, lat2, lon2, lat3, lon3;
-  lat1 = 37.905526;
-  lon1 = -119.987431;
-  lat2 = 37.904211;
-  lon2 = -120.001263;
-  lat3 = 38.982859;
-  lon3 = -117.057278;
-  vpgl_utm u;
-  double x1, y1;
-  int zone1;
-  double x2, y2;
-  int zone2;
-  double x3, y3;
-  int zone3;
-  u.transform(lat1, lon1, x1, y1, zone1);
-  TEST("wgs84 to utm, pt1 zone", zone1, 11);
-  TEST_NEAR("wgs84 to utm, pt1 x", x1, 237346.15, 1);
-  TEST_NEAR("wgs84 to utm, pt1 y", y1, 4199542.5, 1);
-
-  TEST_NEAR("wgs84 to utm (noaa), pt1 x", x1, 237346.006, 1);
-  TEST_NEAR("wgs84 to utm (noaa), pt1 y", y1, 4199541.877, 1);
-
-  u.transform(lat2, lon2, x2, y2, zone2);
-  TEST("wgs84 to utm, pt2 zone", zone2, 10);
-  TEST_NEAR("wgs84 to utm, pt2 x", x2, 763653.66, 1);
-  TEST_NEAR("wgs84 to utm, pt2 y", y2, 4199428.45, 1);
-
-  u.transform(lat3, lon3, x3, y3, zone3);
-  TEST("wgs84 to utm, pt3 zone", zone3, 11);
-  TEST_NEAR("wgs84 to utm, pt3 x", x3, 495039.78, 1);
-  TEST_NEAR("wgs84 to utm, pt3 y", y3, 4314876.95, 1);
-
-  TEST_NEAR("wgs84 to utm (noaa), pt3 x", x3, 495039.78, 1);
-  TEST_NEAR("wgs84 to utm (noaa), pt3 y", y3, 4314876.95, 1);
 }
 
 TESTMAIN(test_lvcs);

--- a/core/vpgl/tests/test_lvcs.cxx
+++ b/core/vpgl/tests/test_lvcs.cxx
@@ -1,11 +1,103 @@
+#include <iostream>
 #include "testlib/testlib_test.h"
-
 #include "vpgl/vpgl_lvcs.h"
-#include "vpgl/vpgl_utm.h"
+
 
 static void
 test_lvcs()
 {
+  // origin in WGS84 & UTM
+  double orig_lat = 38.982859, orig_lon = -117.057278, orig_elev = 1670;
+  double orig_easting = 495039.001, orig_northing = 4314875.991;
+  int orig_utm_zone = 11;
+  bool orig_south_flag = 0;
+
+  // results
+  double x, y, z;
+  int utm_zone;
+
+
+  // ----- WGS84 lvcs -----
+  std::cout << "\nTest WGS84 LVCS\n";
+  vpgl_lvcs lvcs_wgs84(orig_lat, orig_lon, orig_elev, vpgl_lvcs::wgs84,
+                       vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+
+  // origin
+  std::cout << "origin\n";
+  lvcs_wgs84.get_origin(y, x, z);
+
+  TEST_NEAR("longitude", x, orig_lon, 1e-6);
+  TEST_NEAR("latitude", y, orig_lat, 1e-6);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+
+  // local origin as (0,0,0)
+  std::cout << "global_to_local(origin, WGS84)\n";
+  lvcs_wgs84.global_to_local(orig_lon, orig_lat, orig_elev, vpgl_lvcs::wgs84,
+                             x, y, z);
+
+  TEST_NEAR("local_x", x, 0.0, 1e-3);
+  TEST_NEAR("local_y", y, 0.0, 1e-3);
+  TEST_NEAR("local_z", z, 0.0, 1e-3);
+
+  // local origin -> WGS84
+  std::cout << "global_to_local(origin, WGS84)\n";
+  lvcs_wgs84.local_to_global(0.0, 0.0, 0.0,
+                             vpgl_lvcs::wgs84, x, y, z);
+
+  TEST_NEAR("longitude", x, orig_lon, 1e-6);
+  TEST_NEAR("latitude", y, orig_lat, 1e-6);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+
+
+  // ----- UTM lvcs -----
+  std::cout << "\nTest UTM LVCS\n";
+  vpgl_lvcs lvcs_utm(orig_lat, orig_lon, orig_elev, vpgl_lvcs::utm,
+                     vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+
+  // origin in UTM
+  std::cout << "origin\n";
+  lvcs_utm.get_utm_origin(x, y, z, utm_zone);
+
+  TEST_NEAR("easting", x, orig_easting, 1e-3);
+  TEST_NEAR("northing", y, orig_northing, 1e-3);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST("utm_zone", utm_zone, orig_utm_zone);
+
+  // origin in WGS84
+  std::cout << "WGS84 origin\n";
+  lvcs_utm.get_origin(y, x, z);
+
+  TEST_NEAR("longitude", x, orig_lon, 1e-6);
+  TEST_NEAR("latitude", y, orig_lat, 1e-6);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+
+  // local origin as (0,0,0)
+  std::cout << "global_to_local(origin, UTM)\n";
+  lvcs_utm.global_to_local(orig_easting, orig_northing, orig_elev, vpgl_lvcs::utm,
+                           x, y, z);
+
+  TEST_NEAR("local_x", x, 0.0, 1e-3);
+  TEST_NEAR("local_y", y, 0.0, 1e-3);
+  TEST_NEAR("local_z", z, 0.0, 1e-3);
+
+  // local origin -> UTM
+  std::cout << "local_to_global(origin, UTM)\n";
+  lvcs_utm.local_to_global(0.0, 0.0, 0.0,
+                           vpgl_lvcs::utm, x, y, z);
+
+  TEST_NEAR("easting", x, orig_easting, 1e-3);
+  TEST_NEAR("northing", y, orig_northing, 1e-3);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+
+  // local origin -> WGS84
+  std::cout << "local_to_global(origin, WGS84)l\n";
+  lvcs_utm.local_to_global(0.0, 0.0, 0.0,
+                           vpgl_lvcs::wgs84, x, y, z);
+
+  TEST_NEAR("longitude", x, orig_lon, 1e-6);
+  TEST_NEAR("latitude", y, orig_lat, 1e-6);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+
 }
 
 TESTMAIN(test_lvcs);

--- a/core/vpgl/tests/test_utm.cxx
+++ b/core/vpgl/tests/test_utm.cxx
@@ -1,0 +1,76 @@
+#include <iostream>
+#include "testlib/testlib_test.h"
+#include "vpgl/vpgl_utm.h"
+
+
+void
+test_utm_convert(double lat, double lon, double easting, double northing,
+                 int utm_zone, bool south_flag,
+                 int force_utm_zone=-1, int force_south_flag=-1)
+{
+  // report
+  std::cout << "\n"
+            << "(lat, lon) = (" << lat << ", " << lon << ")\n"
+            << "(easting, northing, utm_zone, south_flag) = ("
+            << easting << ", " << northing << ", "
+            << utm_zone << ", " << south_flag << ")\n"
+            << "force_utm_zone = " << force_utm_zone << "\n"
+            << "force_south_flag = " << force_south_flag << "\n\n";
+
+  // UTM conversion object
+  vpgl_utm u;
+
+
+  // UTM result tolerance in meters
+  double utm_tol = 1e-3;
+
+  // WGS84 to UTM
+  double easting_result, northing_result;
+  int utm_zone_result;
+  bool south_flag_result;
+  u.transform(lat, lon, easting_result, northing_result,
+              utm_zone_result, south_flag_result,
+              force_utm_zone, force_south_flag);
+
+  std::cout << "WGS84 -> UTM\n";
+  TEST_NEAR("easting", easting_result, easting, utm_tol);
+  TEST_NEAR("northing", northing_result, northing, utm_tol);
+  TEST("utm_zone", utm_zone_result, utm_zone);
+  TEST("south_flag", south_flag_result, south_flag);
+
+
+  // WGS84 result tolerance in degrees
+  double wgs84_tol = 1e-6;
+
+  // UTM to WGS84
+  double lat_result, lon_result;
+  u.transform(utm_zone, easting, northing, lat_result, lon_result, south_flag);
+
+  std::cout << "UTM -> WGS84\n";
+  TEST_NEAR("latitude", lat_result, lat, wgs84_tol);
+  TEST_NEAR("longitude", lon_result, lon, wgs84_tol);
+
+}
+
+
+static void
+test_utm()
+{
+  // expected conversions obtained from https://www.ngs.noaa.gov/NCAT/
+  test_utm_convert(39.224086,  -98.542151, 539520.675, 4341743.979, 14, 0);
+  test_utm_convert(37.905526, -119.987431, 237345.970, 4199541.989, 11, 0);
+  test_utm_convert(37.904211, -120.001263, 763652.971, 4199427.978, 10, 0);
+  test_utm_convert(38.982859, -117.057278, 495039.001, 4314875.991, 11, 0);
+
+  // WGS84 -> UTM with forced utm_zone & south_flag
+  // The WGS84 point (lat = 0, lon = 72) is both on the equator and on the
+  // border between UTM zones 18 & 19.  Determine the UTM coordinate
+  // with various forcing selections.
+  double lat = 0.001, lon = -72.0001;
+  test_utm_convert(lat, lon, 833967.414, 110.683, 18, 0);  // default 18-north
+  test_utm_convert(lat, lon, 166010.300, 110.683, 19, 0, 19);  // force 19-north
+  test_utm_convert(lat, lon, 833967.414, 10e6 + 110.683, 18, 1, -1, 1);  // force 18-south
+  test_utm_convert(lat, lon, 166010.300, 10e6 + 110.683, 19, 1, 19, 1);  // force 19-south
+}
+
+TESTMAIN(test_utm);

--- a/core/vpgl/vpgl_utm.cxx
+++ b/core/vpgl/vpgl_utm.cxx
@@ -314,17 +314,37 @@ vpgl_utm::transform(int utm_zone,
 void
 vpgl_utm::transform(double lat, double lon, double & x, double & y, int & utm_zone) const
 {
+  bool south_flag;
+  this->transform(lat, lon, x, y, utm_zone, south_flag, -1, -1);
+}
+
+// This WGS84 -> UTM conversion provides the ability to force a specific
+// UTM zone and/or south_flag as input, allowing points near UTM borders
+// and the equator to be transformed in an adjacent UTM system.
+void
+vpgl_utm::transform(double lat, double lon,
+                    double& x, double& y, int& utm_zone, bool& south_flag,
+                    int force_utm_zone, int force_south_flag) const
+{
+  // UTM zone
+  if (force_utm_zone >= 0) {
+    utm_zone = force_utm_zone;
+  } else {
+    utm_zone = int((lon + 180) / 6.0) + 1;
+  }
+
+  // UTM north vs. south
+  if (force_south_flag >= 0) {
+    south_flag = force_south_flag;
+  } else {
+    south_flag = lat < 0;
+  }
+
   // double D2R = vnl_math::pi_over_180;
-  utm_zone = int((lon + 180) / 6.0) + 1;
   double e = std::sqrt(1.0 - b_ * b_ / (a_ * a_));
-  // This value must eventually set by user. lon_zone stands for
-  // longitudinal zone, and it must be between 1 and 60.
-  int south_flag;
+
   double utm_central_meridian = 0;
-
   utm_central_meridian = (6 * utm_zone) - 183;
-
-  south_flag = lat < 0;
 
   double lon_center = adjust_lon2(utm_central_meridian * D2R);
   double lat_center = 0.0;

--- a/core/vpgl/vpgl_utm.h
+++ b/core/vpgl/vpgl_utm.h
@@ -29,6 +29,7 @@ class vpgl_utm
   ~vpgl_utm();
   void SetSpheroidA(double a) { a_ = a; }
   void SetSpheroidB(double b) { b_ = b; }
+
   //UTM to LatLon
   void transform(int utm_zone, double x, double y, double z,
                  double& lat, double& lon , double& elev,
@@ -39,9 +40,14 @@ class vpgl_utm
                  double& lat, double& lon,
                  bool south_flag = false,
                  double utm_central_meridian = 0) const;
+
   //: LatLon to UTM
   void transform(double lat, double lon,
                  double& x, double& y, int& utm_zone) const;
+
+  void transform(double lat, double lon,
+                 double& x, double& y, int& utm_zone, bool& south_flag,
+                 int force_utm_zone=-1, int force_south_flag=-1) const;
 
  private:
    double a_{6378137}, b_{6356752.3142};


### PR DESCRIPTION
New function in `vpgl_utm` allowing users to calculate a WGS84->UTM conversion in a specific UTM zone.  This is useful when points are near a UTM zone boundary - conversion to a user specified zone ensures all UTM coordinates are relative to the same coordinate system.

Update related unit tests

- move UTM tests from `test_lvcs` to new `test_utm`
- add UTM tests for new forcing capabilities
- add basic LVCS tests in WGS84 and UTM coordinate systems

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✔️ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
