### PR TITLE
ENH: vpgl_utm utm2utm conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 3.5.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 3.6.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vpgl/tests/test_utm.cxx
+++ b/core/vpgl/tests/test_utm.cxx
@@ -53,6 +53,47 @@ test_utm_convert(double lat, double lon, double easting, double northing,
 }
 
 
+void
+test_utm2utm(int utm_zone_a, bool south_flag_a,
+             double easting_a, double northing_a,
+             int utm_zone_b, bool south_flag_b,
+             double easting_b, double northing_b)
+{
+  // report
+  std::cout << "\n"
+            << "UTM->UTM (easting, northing, utm_zone, south_flag)\n"
+            << "A = (" << easting_a << ", " << northing_a << ", "
+                   << utm_zone_a << ", " << south_flag_a << ")\n"
+            << "B = (" << easting_b << ", " << northing_b << ", "
+                   << utm_zone_b << ", " << south_flag_b << ")\n";
+
+  // UTM conversion object
+  vpgl_utm u;
+
+  // UTM result tolerance in meters
+  double utm_tol = 5e-3;  // 0.5 cm
+
+  // results
+  double easting_result, northing_result;
+
+  // A->B
+  u.utm2utm(utm_zone_a, south_flag_a, easting_a, northing_a,
+            utm_zone_b, south_flag_b, easting_result, northing_result);
+
+  std::cout << "A -> B\n";
+  TEST_NEAR("easting", easting_result, easting_b, utm_tol);
+  TEST_NEAR("northing", northing_result, northing_b, utm_tol);
+
+  // B->A
+  u.utm2utm(utm_zone_b, south_flag_b, easting_b, northing_b,
+            utm_zone_a, south_flag_a, easting_result, northing_result);
+
+  std::cout << "B -> A\n";
+  TEST_NEAR("easting", easting_result, easting_a, utm_tol);
+  TEST_NEAR("northing", northing_result, northing_a, utm_tol);
+
+}
+
 static void
 test_utm()
 {
@@ -71,6 +112,13 @@ test_utm()
   test_utm_convert(lat, lon, 166010.300, 110.683, 19, 0, 19);  // force 19-north
   test_utm_convert(lat, lon, 833967.414, 10e6 + 110.683, 18, 1, -1, 1);  // force 18-south
   test_utm_convert(lat, lon, 166010.300, 10e6 + 110.683, 19, 1, 19, 1);  // force 19-south
+
+  // UTM to UTM
+  test_utm2utm(18, 0, 833967.414, 110.683,  18, 0, 833967.414, 110.683); // default 18-north
+  test_utm2utm(18, 0, 833967.414, 110.683,  19, 0, 166010.300, 110.683);  // force 19-north
+  test_utm2utm(18, 0, 833967.414, 110.683,  18, 1, 833967.414, 10e6 + 110.683);  // force 19-north
+  test_utm2utm(18, 0, 833967.414, 110.683,  19, 1, 166010.300, 10e6 + 110.683);  // force 19-north
+
 }
 
 TESTMAIN(test_utm);

--- a/core/vpgl/vpgl_utm.cxx
+++ b/core/vpgl/vpgl_utm.cxx
@@ -381,3 +381,31 @@ vpgl_utm::transform(double lat, double lon,
                                          (als / 30.0) * (61.0 - (58.0 * t) + sqr(t) + (600.0 * c) - 330.0 * esp2))))) +
       false_northing2;
 }
+
+// Convert between UTM systems.  Useful for converting from one
+// UTM coordiante system (utm_zone_in and south_flag_in) to an
+// adjacent UTM coordinate system (utm_zone_out and south_flag_out)
+// Conversion is performed by passing the point through WGS84 coordinates.
+void
+vpgl_utm::utm2utm(double utm_zone_in, bool south_flag_in,
+                  double x_in, double y_in,
+                  double utm_zone_out, bool south_flag_out,
+                  double& x_out, double& y_out) const
+{
+  // test for necessary conversion
+  if (utm_zone_in == utm_zone_out && south_flag_in == south_flag_out)
+  {
+    x_out = x_in;
+    y_out = y_in;
+    return;
+  }
+
+  // convert from utm_in to WGS84
+  double lon, lat;
+  this->transform(utm_zone_in, x_in, y_in, lat, lon, south_flag_in);
+
+  // convert from WGS84 to utm_out
+  int uz; bool sf;
+  this->transform(lat, lon, x_out, y_out, uz, sf,
+                  utm_zone_out, south_flag_out);
+}

--- a/core/vpgl/vpgl_utm.h
+++ b/core/vpgl/vpgl_utm.h
@@ -49,6 +49,12 @@ class vpgl_utm
                  double& x, double& y, int& utm_zone, bool& south_flag,
                  int force_utm_zone=-1, int force_south_flag=-1) const;
 
+  //: Conversion between different UTM zones
+  void utm2utm(double utm_zone_in, bool south_flag_in,
+               double x_in, double y_in,
+               double utm_zone_out, bool south_flag_out,
+               double& x_out, double& y_out) const;
+
  private:
    double a_{6378137}, b_{6356752.3142};
 };


### PR DESCRIPTION
Convert between UTM systems.  Useful for converting from one UTM coordiante system (utm_zone_in and south_flag_in) to an 
adjacent UTM coordinate system (utm_zone_out and south_flag_out). Conversion is performed by passing the point through WGS84 coordinates.  Includes tests.

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✔️ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✔️  Adds tests and baseline comparison (quantitative).
- ❌> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
