### PR TITLE
COMP: Remove deprecated WriteCompilerDetectionHeader

### DIFF
--- a/vcl/CMakeLists.txt
+++ b/vcl/CMakeLists.txt
@@ -14,75 +14,6 @@ endif()
 
 project( vcl )
 
-## Dynamically create compiler detection header
-set(VCL_COMPILER_DETECTION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/vcl_compiler_detection.h")
-include(WriteCompilerDetectionHeader)
-write_compiler_detection_header(
-    FILE "${VCL_COMPILER_DETECTION_HEADER}"
-    PREFIX VXL
-    OUTPUT_FILES_VAR compiler_stub_headers
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/compilers
-    COMPILERS AppleClang Clang GNU MSVC SunPro Intel #Supported compilers as of 3.10.3
-    VERSION ${CMAKE_VERSION}
-    FEATURES
-      cxx_aggregate_default_initializers      # Aggregate default initializers, as defined in N3605.
-      cxx_alias_templates                     # Template aliases, as defined in N2258.
-      cxx_alignas                             # Alignment control alignas, as defined in N2341.
-      cxx_alignof                             # Alignment control alignof, as defined in N2341.
-      cxx_attributes                          # Generic attributes, as defined in N2761.
-      cxx_attribute_deprecated                # [[deprecated]] attribute, as defined in N3760.
-      cxx_auto_type                           # Automatic type deduction, as defined in N1984.
-      cxx_binary_literals                     # Binary literals, as defined in N3472.
-      cxx_constexpr                           # Constant expressions, as defined in N2235.
-      cxx_contextual_conversions              # Contextual conversions, as defined in N3323.
-      cxx_decltype_incomplete_return_types    # Decltype on incomplete return types, as defined in N3276.
-      cxx_decltype                            # Decltype, as defined in N2343.
-      cxx_decltype_auto                       # decltype(auto) semantics, as defined in N3638.
-      cxx_default_function_template_args      # Default template arguments for function templates, as defined in DR226
-      cxx_defaulted_functions                 # Defaulted functions, as defined in N2346.
-      cxx_defaulted_move_initializers         # Defaulted move initializers, as defined in N3053.
-      cxx_delegating_constructors             # Delegating constructors, as defined in N1986.
-      cxx_deleted_functions                   # Deleted functions, as defined in N2346.
-      cxx_digit_separators                    # Digit separators, as defined in N3781.
-      cxx_enum_forward_declarations           # Enum forward declarations, as defined in N2764.
-      cxx_explicit_conversions                # Explicit conversion operators, as defined in N2437.
-      cxx_extended_friend_declarations        # Extended friend declarations, as defined in N1791.
-      cxx_extern_templates                    # Extern templates, as defined in N1987.
-      cxx_final                               # Override control final keyword, as defined in N2928, N3206 and N3272.
-      cxx_func_identifier                     # Predefined __func__ identifier, as defined in N2340.
-      cxx_generalized_initializers            # Initializer lists, as defined in N2672.
-      cxx_generic_lambdas                     # Generic lambdas, as defined in N3649.
-      cxx_inheriting_constructors             # Inheriting constructors, as defined in N2540.
-      cxx_inline_namespaces                   # Inline namespaces, as defined in N2535.
-      cxx_lambdas                             # Lambda functions, as defined in N2927.
-      cxx_lambda_init_captures                # Initialized lambda captures, as defined in N3648.
-      cxx_local_type_template_args            # Local and unnamed types as template arguments, as defined in N2657.
-      cxx_long_long_type                      # long long type, as defined in N1811.
-      cxx_noexcept                            # Exception specifications, as defined in N3050.
-      cxx_nonstatic_member_init               # Non-static data member initialization, as defined in N2756.
-      cxx_nullptr                             # Null pointer, as defined in N2431.
-      cxx_override                            # Override control override keyword, as defined in N2928, N3206 and N3272.
-      cxx_range_for                           # Range-based for, as defined in N2930.
-      cxx_raw_string_literals                 # Raw string literals, as defined in N2442.
-      cxx_reference_qualified_functions       # Reference qualified functions, as defined in N2439.
-      cxx_relaxed_constexpr                   # Relaxed constexpr, as defined in N3652.
-      cxx_return_type_deduction               # Return type deduction on normal functions, as defined in N3386.
-      cxx_right_angle_brackets                # Right angle bracket parsing, as defined in N1757.
-      cxx_rvalue_references                   # R-value references, as defined in N2118.
-      cxx_sizeof_member                       # Size of non-static data members, as defined in N2253.
-      cxx_static_assert                       # Static assert, as defined in N1720.
-      cxx_strong_enums                        # Strongly typed enums, as defined in N2347.
-      cxx_thread_local                        # Thread-local variables, as defined in N2659.
-      cxx_trailing_return_types               # Automatic function return type, as defined in N2541.
-      cxx_unicode_literals                    # Unicode string literals, as defined in N2442.
-      cxx_uniform_initialization              # Uniform intialization, as defined in N2640.
-      cxx_unrestricted_unions                 # Unrestricted unions, as defined in N2544.
-      cxx_user_literals                       # User-defined literals, as defined in N2765.
-      cxx_variable_templates                  # Variable templates, as defined in N3651.
-      cxx_variadic_macros                     # Variadic macros, as defined in N1653.
-      cxx_variadic_templates                  # Variadic templates, as defined in N2242.
-      cxx_template_template_parameters        # Template template parameters, as defined in ISO/IEC 14882:1998.
-)
 
 #
 # Install platform-specific compiler detection files
@@ -99,10 +30,6 @@ install(FILES ${VXL_COMPILER_DETECTION_FILES}
       DESTINATION ${_compilers_destination}
       PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
       COMPONENT Development )
-install(FILES ${VCL_COMPILER_DETECTION_HEADER}
-      DESTINATION ${_compiler_detection_destination}
-      PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-      COMPONENT Development )
 
 # If VXL_INSTALL_INCLUDE_DIR is the default value
 if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")
@@ -115,6 +42,8 @@ vxl_configure_file(${CMAKE_CURRENT_LIST_DIR}/vcl_where_root_dir.h.in ${PROJECT_B
 
 include_directories(${PROJECT_BINARY_DIR})
 set( vcl_sources
+  vcl_compiler_detection.h
+
   vcl_legacy_aliases.h
   vcl_deprecated.cxx
   vcl_deprecated.h

--- a/vcl/vcl_compiler_detection.h
+++ b/vcl/vcl_compiler_detection.h
@@ -1,0 +1,322 @@
+
+// This is a generated file. Do not edit!
+
+#ifndef VXL_COMPILER_DETECTION_H
+#define VXL_COMPILER_DETECTION_H
+
+#define VXL_DEC(X) (X)
+#define VXL_HEX(X) ( \
+    ((X)>>28 & 0xF) * 10000000 + \
+    ((X)>>24 & 0xF) *  1000000 + \
+    ((X)>>20 & 0xF) *   100000 + \
+    ((X)>>16 & 0xF) *    10000 + \
+    ((X)>>12 & 0xF) *     1000 + \
+    ((X)>>8  & 0xF) *      100 + \
+    ((X)>>4  & 0xF) *       10 + \
+    ((X)     & 0xF) \
+    )
+
+#ifdef __cplusplus
+# define VXL_COMPILER_IS_Comeau 0
+# define VXL_COMPILER_IS_Intel 0
+# define VXL_COMPILER_IS_IntelLLVM 0
+# define VXL_COMPILER_IS_PathScale 0
+# define VXL_COMPILER_IS_Embarcadero 0
+# define VXL_COMPILER_IS_Borland 0
+# define VXL_COMPILER_IS_Watcom 0
+# define VXL_COMPILER_IS_OpenWatcom 0
+# define VXL_COMPILER_IS_SunPro 0
+# define VXL_COMPILER_IS_HP 0
+# define VXL_COMPILER_IS_Compaq 0
+# define VXL_COMPILER_IS_zOS 0
+# define VXL_COMPILER_IS_XLClang 0
+# define VXL_COMPILER_IS_XL 0
+# define VXL_COMPILER_IS_VisualAge 0
+# define VXL_COMPILER_IS_NVHPC 0
+# define VXL_COMPILER_IS_PGI 0
+# define VXL_COMPILER_IS_Cray 0
+# define VXL_COMPILER_IS_TI 0
+# define VXL_COMPILER_IS_FujitsuClang 0
+# define VXL_COMPILER_IS_Fujitsu 0
+# define VXL_COMPILER_IS_GHS 0
+# define VXL_COMPILER_IS_SCO 0
+# define VXL_COMPILER_IS_ARMCC 0
+# define VXL_COMPILER_IS_AppleClang 0
+# define VXL_COMPILER_IS_ARMClang 0
+# define VXL_COMPILER_IS_Clang 0
+# define VXL_COMPILER_IS_GNU 0
+# define VXL_COMPILER_IS_MSVC 0
+# define VXL_COMPILER_IS_ADSP 0
+# define VXL_COMPILER_IS_IAR 0
+# define VXL_COMPILER_IS_MIPSpro 0
+
+#if defined(__COMO__)
+# undef VXL_COMPILER_IS_Comeau
+# define VXL_COMPILER_IS_Comeau 1
+
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+# undef VXL_COMPILER_IS_Intel
+# define VXL_COMPILER_IS_Intel 1
+
+#elif (defined(__clang__) && defined(__INTEL_CLANG_COMPILER)) || defined(__INTEL_LLVM_COMPILER)
+# undef VXL_COMPILER_IS_IntelLLVM
+# define VXL_COMPILER_IS_IntelLLVM 1
+
+#elif defined(__PATHCC__)
+# undef VXL_COMPILER_IS_PathScale
+# define VXL_COMPILER_IS_PathScale 1
+
+#elif defined(__BORLANDC__) && defined(__CODEGEARC_VERSION__)
+# undef VXL_COMPILER_IS_Embarcadero
+# define VXL_COMPILER_IS_Embarcadero 1
+
+#elif defined(__BORLANDC__)
+# undef VXL_COMPILER_IS_Borland
+# define VXL_COMPILER_IS_Borland 1
+
+#elif defined(__WATCOMC__) && __WATCOMC__ < 1200
+# undef VXL_COMPILER_IS_Watcom
+# define VXL_COMPILER_IS_Watcom 1
+
+#elif defined(__WATCOMC__)
+# undef VXL_COMPILER_IS_OpenWatcom
+# define VXL_COMPILER_IS_OpenWatcom 1
+
+#elif defined(__SUNPRO_CC)
+# undef VXL_COMPILER_IS_SunPro
+# define VXL_COMPILER_IS_SunPro 1
+
+#elif defined(__HP_aCC)
+# undef VXL_COMPILER_IS_HP
+# define VXL_COMPILER_IS_HP 1
+
+#elif defined(__DECCXX)
+# undef VXL_COMPILER_IS_Compaq
+# define VXL_COMPILER_IS_Compaq 1
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__)
+# undef VXL_COMPILER_IS_zOS
+# define VXL_COMPILER_IS_zOS 1
+
+#elif defined(__ibmxl__) && defined(__clang__)
+# undef VXL_COMPILER_IS_XLClang
+# define VXL_COMPILER_IS_XLClang 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ >= 800
+# undef VXL_COMPILER_IS_XL
+# define VXL_COMPILER_IS_XL 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ < 800
+# undef VXL_COMPILER_IS_VisualAge
+# define VXL_COMPILER_IS_VisualAge 1
+
+#elif defined(__NVCOMPILER)
+# undef VXL_COMPILER_IS_NVHPC
+# define VXL_COMPILER_IS_NVHPC 1
+
+#elif defined(__PGI)
+# undef VXL_COMPILER_IS_PGI
+# define VXL_COMPILER_IS_PGI 1
+
+#elif defined(_CRAYC)
+# undef VXL_COMPILER_IS_Cray
+# define VXL_COMPILER_IS_Cray 1
+
+#elif defined(__TI_COMPILER_VERSION__)
+# undef VXL_COMPILER_IS_TI
+# define VXL_COMPILER_IS_TI 1
+
+#elif defined(__CLANG_FUJITSU)
+# undef VXL_COMPILER_IS_FujitsuClang
+# define VXL_COMPILER_IS_FujitsuClang 1
+
+#elif defined(__FUJITSU)
+# undef VXL_COMPILER_IS_Fujitsu
+# define VXL_COMPILER_IS_Fujitsu 1
+
+#elif defined(__ghs__)
+# undef VXL_COMPILER_IS_GHS
+# define VXL_COMPILER_IS_GHS 1
+
+#elif defined(__SCO_VERSION__)
+# undef VXL_COMPILER_IS_SCO
+# define VXL_COMPILER_IS_SCO 1
+
+#elif defined(__ARMCC_VERSION) && !defined(__clang__)
+# undef VXL_COMPILER_IS_ARMCC
+# define VXL_COMPILER_IS_ARMCC 1
+
+#elif defined(__clang__) && defined(__apple_build_version__)
+# undef VXL_COMPILER_IS_AppleClang
+# define VXL_COMPILER_IS_AppleClang 1
+
+#elif defined(__clang__) && defined(__ARMCOMPILER_VERSION)
+# undef VXL_COMPILER_IS_ARMClang
+# define VXL_COMPILER_IS_ARMClang 1
+
+#elif defined(__clang__)
+# undef VXL_COMPILER_IS_Clang
+# define VXL_COMPILER_IS_Clang 1
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+# undef VXL_COMPILER_IS_GNU
+# define VXL_COMPILER_IS_GNU 1
+
+#elif defined(_MSC_VER)
+# undef VXL_COMPILER_IS_MSVC
+# define VXL_COMPILER_IS_MSVC 1
+
+#elif defined(__VISUALDSPVERSION__) || defined(__ADSPBLACKFIN__) || defined(__ADSPTS__) || defined(__ADSP21000__)
+# undef VXL_COMPILER_IS_ADSP
+# define VXL_COMPILER_IS_ADSP 1
+
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__IAR_SYSTEMS_ICC)
+# undef VXL_COMPILER_IS_IAR
+# define VXL_COMPILER_IS_IAR 1
+
+
+#endif
+
+#  if VXL_COMPILER_IS_AppleClang
+
+#    include "compilers/VXL_COMPILER_INFO_AppleClang_CXX.h"
+
+#  elif VXL_COMPILER_IS_Clang
+
+#    include "compilers/VXL_COMPILER_INFO_Clang_CXX.h"
+
+#  elif VXL_COMPILER_IS_GNU
+
+#    include "compilers/VXL_COMPILER_INFO_GNU_CXX.h"
+
+#  elif VXL_COMPILER_IS_MSVC
+
+#    include "compilers/VXL_COMPILER_INFO_MSVC_CXX.h"
+
+#  elif VXL_COMPILER_IS_SunPro
+
+#    include "compilers/VXL_COMPILER_INFO_SunPro_CXX.h"
+
+#  elif VXL_COMPILER_IS_Intel
+
+#    include "compilers/VXL_COMPILER_INFO_Intel_CXX.h"
+
+#  else
+#    error Unsupported compiler
+#  endif
+
+#  if defined(VXL_COMPILER_CXX_ALIGNAS) && VXL_COMPILER_CXX_ALIGNAS
+#    define VXL_ALIGNAS(X) alignas(X)
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_ALIGNAS(X) __attribute__ ((__aligned__(X)))
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_ALIGNAS(X) __declspec(align(X))
+#  else
+#    define VXL_ALIGNAS(X)
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_ALIGNOF) && VXL_COMPILER_CXX_ALIGNOF
+#    define VXL_ALIGNOF(X) alignof(X)
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_ALIGNOF(X) __alignof__(X)
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_ALIGNOF(X) __alignof(X)
+#  endif
+
+
+#  ifndef VXL_DEPRECATED
+#    if defined(VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED) && VXL_COMPILER_CXX_ATTRIBUTE_DEPRECATED
+#      define VXL_DEPRECATED [[deprecated]]
+#      define VXL_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#    elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang
+#      define VXL_DEPRECATED __attribute__((__deprecated__))
+#      define VXL_DEPRECATED_MSG(MSG) __attribute__((__deprecated__(MSG)))
+#    elif VXL_COMPILER_IS_MSVC
+#      define VXL_DEPRECATED __declspec(deprecated)
+#      define VXL_DEPRECATED_MSG(MSG) __declspec(deprecated(MSG))
+#    else
+#      define VXL_DEPRECATED
+#      define VXL_DEPRECATED_MSG(MSG)
+#    endif
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_CONSTEXPR) && VXL_COMPILER_CXX_CONSTEXPR
+#    define VXL_CONSTEXPR constexpr
+#  else
+#    define VXL_CONSTEXPR 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_DELETED_FUNCTIONS) && VXL_COMPILER_CXX_DELETED_FUNCTIONS
+#    define VXL_DELETED_FUNCTION = delete
+#  else
+#    define VXL_DELETED_FUNCTION 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_EXTERN_TEMPLATES) && VXL_COMPILER_CXX_EXTERN_TEMPLATES
+#    define VXL_EXTERN_TEMPLATE extern
+#  else
+#    define VXL_EXTERN_TEMPLATE 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_FINAL) && VXL_COMPILER_CXX_FINAL
+#    define VXL_FINAL final
+#  else
+#    define VXL_FINAL 
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_NOEXCEPT) && VXL_COMPILER_CXX_NOEXCEPT
+#    define VXL_NOEXCEPT noexcept
+#    define VXL_NOEXCEPT_EXPR(X) noexcept(X)
+#  else
+#    define VXL_NOEXCEPT
+#    define VXL_NOEXCEPT_EXPR(X)
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_NULLPTR) && VXL_COMPILER_CXX_NULLPTR
+#    define VXL_NULLPTR nullptr
+#  elif VXL_COMPILER_IS_GNU
+#    define VXL_NULLPTR __null
+#  else
+#    define VXL_NULLPTR 0
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_OVERRIDE) && VXL_COMPILER_CXX_OVERRIDE
+#    define VXL_OVERRIDE override
+#  else
+#    define VXL_OVERRIDE 
+#  endif
+
+#  if defined(VXL_COMPILER_CXX_STATIC_ASSERT) && VXL_COMPILER_CXX_STATIC_ASSERT
+#    define VXL_STATIC_ASSERT(X) static_assert(X, #X)
+#    define VXL_STATIC_ASSERT_MSG(X, MSG) static_assert(X, MSG)
+#  else
+#    define VXL_STATIC_ASSERT_JOIN(X, Y) VXL_STATIC_ASSERT_JOIN_IMPL(X, Y)
+#    define VXL_STATIC_ASSERT_JOIN_IMPL(X, Y) X##Y
+template<bool> struct VXLStaticAssert;
+template<> struct VXLStaticAssert<true>{};
+#    define VXL_STATIC_ASSERT(X) enum { VXL_STATIC_ASSERT_JOIN(VXLStaticAssertEnum, __LINE__) = sizeof(VXLStaticAssert<X>) }
+#    define VXL_STATIC_ASSERT_MSG(X, MSG) enum { VXL_STATIC_ASSERT_JOIN(VXLStaticAssertEnum, __LINE__) = sizeof(VXLStaticAssert<X>) }
+#  endif
+
+
+#  if defined(VXL_COMPILER_CXX_THREAD_LOCAL) && VXL_COMPILER_CXX_THREAD_LOCAL
+#    define VXL_THREAD_LOCAL thread_local
+#  elif VXL_COMPILER_IS_GNU || VXL_COMPILER_IS_Clang || VXL_COMPILER_IS_AppleClang
+#    define VXL_THREAD_LOCAL __thread
+#  elif VXL_COMPILER_IS_MSVC
+#    define VXL_THREAD_LOCAL __declspec(thread)
+#  else
+// VXL_THREAD_LOCAL not defined for this configuration.
+#  endif
+
+#endif
+
+#endif


### PR DESCRIPTION
The cmake WriteCompilerDetectionHeader mechanism
is deprecated in cmake.

See cmake --help-policy CMP0120
