### PR TITLE
Limit a test to occur only when long is 64 bit

### DIFF
--- a/core/vnl/tests/test_rational.cxx
+++ b/core/vnl/tests/test_rational.cxx
@@ -260,7 +260,7 @@ test_frac()
   TEST_NEAR("large division with overflow", p, double(r) / double(s), 1e-12);
 }
 
-#if VXL_INT_64_IS_LONG || VXL_INT_64_IS_LONGLONG
+#if VXL_INT_64_IS_LONG
 static void
 test_long_64()
 {


### PR DESCRIPTION
On OpenBSD 7 on PowerPC:

warning: implicit conversion from 'long long' to 'long' changes value from 1234321234321 to 1665620369 [-Wconstant-conversion]

From the surrounding code and comments, it seems to me this code is only supposed to be used when long is 64 bit.  It's 32 bit on OpenBSD PowerPC.
