### PR TITLE
COMP: Avoid implicit conversion value change warning

### DIFF
--- a/v3p/netlib/sparse/spConfig.h
+++ b/v3p/netlib/sparse/spConfig.h
@@ -511,6 +511,7 @@
 
 /*! The largest possible value of longs. */
 #define  LARGEST_LONG_INTEGER    LONG_MAX
+#define LARGEST_LONG_INTEGER_AS_DOUBLE ((double)LARGEST_LONG_INTEGER - 1.0) /* VXL - needed to avoid compiler warning about value change during implicit conversion */
 
 /*! The largest possible value of ints. */
 #define  LARGEST_INTEGER    INT_MAX

--- a/v3p/netlib/sparse/spDefs.h
+++ b/v3p/netlib/sparse/spDefs.h
@@ -461,7 +461,7 @@ spcEXTERN void abort(void);
         if (( (op1) > LARGEST_SHORT_INTEGER AND (op2) != 0) OR \
             ( (op2) > LARGEST_SHORT_INTEGER AND (op1) != 0)) \
         {   double fProduct = (double)(op1) * (double)(op2); \
-            if (fProduct >= LARGEST_LONG_INTEGER) \
+            if (fProduct >= LARGEST_LONG_INTEGER_AS_DOUBLE) \
                 (product) = LARGEST_LONG_INTEGER; \
             else \
                 (product) = (long)fProduct; \

--- a/v3p/netlib/sparse/spFactor.c
+++ b/v3p/netlib/sparse/spFactor.c
@@ -956,7 +956,7 @@ double fProduct;
         if ((*pMarkowitzRow > LARGEST_SHORT_INTEGER AND *pMarkowitzCol != 0) OR
             (*pMarkowitzCol > LARGEST_SHORT_INTEGER AND *pMarkowitzRow != 0))
         {   fProduct = (double)(*pMarkowitzRow++) * (double)(*pMarkowitzCol++);
-            if (fProduct >= LARGEST_LONG_INTEGER)
+            if (fProduct >= LARGEST_LONG_INTEGER_AS_DOUBLE)
                 *pMarkowitzProduct++ = LARGEST_LONG_INTEGER;
             else
                 *pMarkowitzProduct++ = (long)fProduct;
@@ -2905,7 +2905,7 @@ double Product;
         if ((MarkoRow[Row] > LARGEST_SHORT_INTEGER AND MarkoCol[Row] != 0) OR
             (MarkoCol[Row] > LARGEST_SHORT_INTEGER AND MarkoRow[Row] != 0))
         {   Product = (double)MarkoCol[Row] * (double)MarkoRow[Row];
-            if (Product >= LARGEST_LONG_INTEGER)
+            if (Product >= LARGEST_LONG_INTEGER_AS_DOUBLE)
                 Matrix->MarkowitzProd[Row] = LARGEST_LONG_INTEGER;
             else
                 Matrix->MarkowitzProd[Row] = (long)Product;
@@ -2923,7 +2923,7 @@ double Product;
         if ((MarkoRow[Col] > LARGEST_SHORT_INTEGER AND MarkoCol[Col] != 0) OR
             (MarkoCol[Col] > LARGEST_SHORT_INTEGER AND MarkoRow[Col] != 0))
         {   Product = (double)MarkoCol[Col] * (double)MarkoRow[Col];
-            if (Product >= LARGEST_LONG_INTEGER)
+            if (Product >= LARGEST_LONG_INTEGER_AS_DOUBLE)
                 Matrix->MarkowitzProd[Col] = LARGEST_LONG_INTEGER;
             else
                 Matrix->MarkowitzProd[Col] = (long)Product;


### PR DESCRIPTION
Clang 13 identifies a value change during an implicit conversion, so
we must set the upperbound carefully.

vxl/v3p/netlib/sparse/spFactor.c:2147:13: warning:
implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
