### PR TITLE
ENH: Use modern deprecation methods for VXL.     

### DIFF
--- a/contrib/brl/bseg/baml/tests/CMakeLists.txt
+++ b/contrib/brl/bseg/baml/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable( baml_test_all
   test_dem_appear.cxx
 )
 
-target_link_libraries( baml_test_all baml ${VXL_LIB_PREFIX}imesh ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}vsol ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vil1 ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}testlib)
+target_link_libraries( baml_test_all baml brdb ${VXL_LIB_PREFIX}imesh ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}vsol ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vpgl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vil1 ${VXL_LIB_PREFIX}vbl ${VXL_LIB_PREFIX}testlib)
 
 # add_test( NAME baml_test_appearance COMMAND $<TARGET_FILE:baml_test_all> test_appearance )
 # add_test( NAME baml_test_dem_appear COMMAND $<TARGET_FILE:baml_test_all> test_dem_appear )

--- a/contrib/brl/bseg/sdet/sdet_nms.h
+++ b/contrib/brl/bseg/sdet/sdet_nms.h
@@ -45,6 +45,7 @@
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
+#include <vcl_compiler.h>
 #include <vbl/vbl_array_2d.h>
 #include <vil/vil_image_view.h>
 #include <vgl/vgl_point_2d.h>
@@ -95,7 +96,7 @@ class sdet_nms
 
  public:
   //: default constructor is not to be used
-  sdet_nms() VXL_DELETED_FUNCTION;
+  sdet_nms() = delete;
 
   //: Constructor from a parameter block, gradient magnitudes given as an image and gradients given as component images
   sdet_nms(const sdet_nms_params& nsp,

--- a/core/vgl/algo/tests/test_h_matrix_2d.cxx
+++ b/core/vgl/algo/tests/test_h_matrix_2d.cxx
@@ -78,7 +78,7 @@ test_transform_types()
   pp = h(p);
   vgl_homg_point_2d<double> tasp(2.35711, 7.46975, 1.5);
   TEST_NEAR("aspect ratio", length(pp - tasp), 0.0, 1e-05);
-  vnl_matrix<double> M(2, 3);
+  vnl_matrix_fixed<double,2,3> M;
   M[0][0] = 0.707107;
   M[0][1] = -0.707107;
   M[0][2] = 1.1;

--- a/core/vgl/algo/vgl_h_matrix_1d.hxx
+++ b/core/vgl/algo/vgl_h_matrix_1d.hxx
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <fstream>
 #include "vgl_h_matrix_1d.h"
+#include <vcl_compiler.h>
 #include <vgl/vgl_homg_point_1d.h>
 #include <vnl/vnl_inverse.h>
 #include <vnl/vnl_vector_fixed.h>
@@ -14,7 +15,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cassert>
-# include <vcl_deprecated.h>
+# include <vcl_compiler.h>
 
 //--------------------------------------------------------------------------------
 template <class T>
@@ -132,12 +133,14 @@ void vgl_h_matrix_1d<T>::get(vnl_matrix_fixed<T,2,2>* H) const
   *H = t12_matrix_;
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 void vgl_h_matrix_1d<T>::get(vnl_matrix<T>* H) const
 {
-  VXL_DEPRECATED_MACRO("vgl_h_matrix_1d<T>::get(vnl_matrix<T>*) const");
   *H = t12_matrix_.as_ref(); // size 2x2
 }
+#endif
 
 template <class T>
 vgl_h_matrix_1d<T>&

--- a/core/vgl/algo/vgl_h_matrix_2d.hxx
+++ b/core/vgl/algo/vgl_h_matrix_2d.hxx
@@ -14,7 +14,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cassert>
-#include <vcl_deprecated.h>
+#include <vcl_compiler.h>
 
 template <class T>
 vgl_h_matrix_2d<T>::vgl_h_matrix_2d(std::istream& s)
@@ -202,12 +202,14 @@ void vgl_h_matrix_2d<T>::get(vnl_matrix_fixed<T,3,3>* H) const
   *H = t12_matrix_;
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 void vgl_h_matrix_2d<T>::get(vnl_matrix<T>* H) const
 {
-  VXL_DEPRECATED_MACRO("vgl_h_matrix_2d<T>::get(vnl_matrix<T>*) const");
   *H = t12_matrix_.as_ref(); // size 3x3
 }
+#endif
 
 template <class T>
 vgl_h_matrix_2d<T>&
@@ -442,11 +444,12 @@ vgl_h_matrix_2d<T>::set_affine(vnl_matrix_fixed<T,2,3> const& M23)
   return *this;
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 vgl_h_matrix_2d<T>&
 vgl_h_matrix_2d<T>::set_affine(vnl_matrix<T> const& M23)
 {
-  VXL_DEPRECATED_MACRO("vgl_h_matrix_2d<T>::set_affine(vnl_matrix<T> const&)");
   assert (M23.rows()==2 && M23.columns()==3);
   for (unsigned r = 0; r<2; ++r)
     for (unsigned c = 0; c<3; ++c)
@@ -454,6 +457,7 @@ vgl_h_matrix_2d<T>::set_affine(vnl_matrix<T> const& M23)
   t12_matrix_[2][0] = T(0); t12_matrix_[2][1] = T(0);  t12_matrix_[2][2] = T(1);
   return *this;
 }
+#endif
 
 template <class T>
 vgl_h_matrix_2d<T>

--- a/core/vgl/algo/vgl_h_matrix_3d.hxx
+++ b/core/vgl/algo/vgl_h_matrix_3d.hxx
@@ -18,7 +18,7 @@
 #include <vnl/vnl_vector_fixed.h>
 #include <vnl/vnl_quaternion.h>
 #include <vnl/algo/vnl_svd.h>
-# include <vcl_deprecated.h>
+# include <vcl_compiler.h>
 
 template <class T>
 vgl_h_matrix_3d<T>::vgl_h_matrix_3d(std::vector<vgl_homg_point_3d<T> > const& points1,
@@ -216,12 +216,14 @@ void vgl_h_matrix_3d<T>::get (vnl_matrix_fixed<T,4,4>* H) const
   *H = t12_matrix_;
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 void vgl_h_matrix_3d<T>::get (vnl_matrix<T>* H) const
 {
-  VXL_DEPRECATED_MACRO("vgl_h_matrix_3d<T>::get(vnl_matrix<T>*) const");
   *H = t12_matrix_.as_ref(); // size 4x4
 }
+#endif
 
 template <class T>
 vgl_h_matrix_3d<T>

--- a/core/vgl/vgl_homg.cxx
+++ b/core/vgl/vgl_homg.cxx
@@ -1,6 +1,6 @@
 // This is core/vgl/vgl_homg.cxx
 
-#ifndef VXL_LEGACY_REMOVE
+#if !VXL_LEGACY_FUTURE_REMOVE
 #  include "vgl_homg.h"
 // template <> float vgl_homg<float>::infinity = 3.4028234663852886e+38f;
 template <>

--- a/core/vgl/vgl_vector_3d.hxx
+++ b/core/vgl/vgl_vector_3d.hxx
@@ -14,7 +14,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cassert>
-#include <vcl_deprecated.h>
+#include <vcl_compiler.h>
 
 template <class T>
 double vgl_vector_3d<T>::length() const
@@ -22,14 +22,16 @@ double vgl_vector_3d<T>::length() const
   return std::sqrt( 0.0+sqr_length() );
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 //: The one-parameter family of unit vectors that are orthogonal to *this, v(s).
 // The parameterization is such that 0<=s<1, v(0)==v(1)
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 vgl_vector_3d<T> vgl_vector_3d<T>::orthogonal_vectors(double s) const
 {
-  VXL_DEPRECATED_MACRO("vgl_vector_3d<T>::orthogonal_vectors(double s)");
   return ::orthogonal_vectors(*this, s);
 }
+#endif
 
 template<class T>
 double angle(vgl_vector_3d<T> const& a, vgl_vector_3d<T> const& b)

--- a/core/vnl/io/tests/CMakeLists.txt
+++ b/core/vnl/io/tests/CMakeLists.txt
@@ -1,11 +1,13 @@
 # This is core/vnl/io/tests/CMakeLists.txt
+if(NOT VXL_LEGACY_FUTURE_REMOVE)
+  set(_LEGACY_CODE_SRCS golden_test_vnl_io.cxx)
+endif()
 
 add_executable( vnl_io_test_all
   # Driver source
   test_driver.cxx
 
   # The tests
-  golden_test_vnl_io.cxx
   test_bignum_io.cxx
   test_diag_matrix_io.cxx
   test_matrix_fixed_io.cxx
@@ -18,6 +20,9 @@ add_executable( vnl_io_test_all
   test_sym_matrix_io.cxx
   test_vector_fixed_io.cxx
   test_vector_io.cxx
+
+  # Legacy code tests
+  ${_LEGACY_CODE_SRCS}
 )
 
 target_link_libraries( vnl_io_test_all ${VXL_LIB_PREFIX}vnl_io ${VXL_LIB_PREFIX}vsl ${VXL_LIB_PREFIX}testlib ${VXL_LIB_PREFIX}vpl )
@@ -34,7 +39,10 @@ add_test( NAME vnl_io_test_sparse_matrix_io COMMAND $<TARGET_FILE:vnl_io_test_al
 add_test( NAME vnl_io_test_sym_matrix_io COMMAND $<TARGET_FILE:vnl_io_test_all> test_sym_matrix_io           )
 add_test( NAME vnl_io_test_vector_fixed_io COMMAND $<TARGET_FILE:vnl_io_test_all> test_vector_fixed_io         )
 add_test( NAME vnl_io_test_vector_io COMMAND $<TARGET_FILE:vnl_io_test_all> test_vector_io               )
-add_test( NAME vnl_io_golden_test_vnl_io COMMAND $<TARGET_FILE:vnl_io_test_all> golden_test_vnl_io           )
+if(NOT VXL_LEGACY_FUTURE_REMOVE)
+  # This test requires deprecated file reading capabilities.
+  add_test( NAME vnl_io_golden_test_vnl_io COMMAND $<TARGET_FILE:vnl_io_test_all> golden_test_vnl_io           )
+endif()
 
 add_executable( vnl_io_test_include test_include.cxx )
 target_link_libraries( vnl_io_test_include ${VXL_LIB_PREFIX}vnl_io )

--- a/core/vnl/io/tests/test_driver.cxx
+++ b/core/vnl/io/tests/test_driver.cxx
@@ -1,3 +1,4 @@
+#include <vcl_compiler.h>
 #include "testlib/testlib_register.h"
 
 DECLARE(test_bignum_io);
@@ -12,7 +13,9 @@ DECLARE(test_sparse_matrix_io);
 DECLARE(test_sym_matrix_io);
 DECLARE(test_vector_fixed_io);
 DECLARE(test_vector_io);
+#if !VXL_LEGACY_FUTURE_REMOVE
 DECLARE(golden_test_vnl_io);
+#endif
 
 void
 register_tests()
@@ -29,7 +32,9 @@ register_tests()
   REGISTER(test_sym_matrix_io);
   REGISTER(test_vector_fixed_io);
   REGISTER(test_vector_io);
+#if !VXL_LEGACY_FUTURE_REMOVE
   REGISTER(golden_test_vnl_io);
+#endif
 }
 
 DEFINE_MAIN;

--- a/core/vnl/io/vnl_io_matrix.hxx
+++ b/core/vnl/io/vnl_io_matrix.hxx
@@ -38,12 +38,16 @@ void vsl_b_read(vsl_b_istream &is, vnl_matrix<T> & p)
   switch (v)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     vsl_b_read(is, m);
     vsl_b_read(is, n);
     p.set_size(m, n);
     // Calling begin() on empty matrix causes segfault
     if (m*n>0)
       vsl_b_read_block_old(is, p.begin(), p.size());
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
     break;
 
    case 2:

--- a/core/vnl/io/vnl_io_matrix_fixed.hxx
+++ b/core/vnl/io/vnl_io_matrix_fixed.hxx
@@ -38,6 +38,7 @@ void vsl_b_read(vsl_b_istream &is, vnl_matrix_fixed<T,m,n> & p)
   switch (v)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     vsl_b_read(is, stream_m);
     vsl_b_read(is, stream_n);
     if ( stream_n != n || stream_m != m ) {
@@ -50,6 +51,9 @@ void vsl_b_read(vsl_b_istream &is, vnl_matrix_fixed<T,m,n> & p)
     if (m*n>0)
       vsl_b_read_block_old(is, p.begin(), p.size());
     break;
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
 
    case 2:
     vsl_b_read(is, stream_m);

--- a/core/vnl/io/vnl_io_sym_matrix.hxx
+++ b/core/vnl/io/vnl_io_sym_matrix.hxx
@@ -37,13 +37,16 @@ void vsl_b_read(vsl_b_istream &is, vnl_sym_matrix<T> & p)
   switch (v)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     vsl_b_read(is, n);
     p.set_size(n);
     // Calling begin() on empty matrix causes segfault
     if (n>0)
       vsl_b_read_block_old(is, p.data_block(), p.size());
     break;
-
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
    case 2:
     vsl_b_read(is, n);
     p.set_size(n);

--- a/core/vnl/io/vnl_io_vector.hxx
+++ b/core/vnl/io/vnl_io_vector.hxx
@@ -34,10 +34,14 @@ void vsl_b_read(vsl_b_istream &is, vnl_vector<T> & p)
   switch (ver)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     vsl_b_read(is, n);
     p.set_size(n);
     if (n)
       vsl_b_read_block_old(is, p.data_block(), n);
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
     break;
 
    case 2:

--- a/core/vnl/io/vnl_io_vector_fixed.hxx
+++ b/core/vnl/io/vnl_io_vector_fixed.hxx
@@ -34,6 +34,7 @@ void vsl_b_read(vsl_b_istream &is, vnl_vector_fixed<T,n> & p)
   switch (ver)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     vsl_b_read(is, stream_n);
     if ( n == stream_n ) {
       vsl_b_read_block_old(is, p.begin(), n);
@@ -44,6 +45,9 @@ void vsl_b_read(vsl_b_istream &is, vnl_vector_fixed<T,n> & p)
       return;
     }
     break;
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
 
    case 2:
     vsl_b_read(is, stream_n);

--- a/core/vpgl/algo/vpgl_invmap_cost_function.cxx
+++ b/core/vpgl/algo/vpgl_invmap_cost_function.cxx
@@ -6,7 +6,7 @@
 #ifdef _MSC_VER
 #  include "vcl_msvc_warnings.h"
 #endif
-#include <vcl_deprecated.h>
+#include <vcl_compiler.h>
 
 vpgl_invmap_cost_function::vpgl_invmap_cost_function(vnl_vector_fixed<double, 2> const & image_point,
                                                      vnl_vector_fixed<double, 4> const & plane,
@@ -77,10 +77,11 @@ vpgl_invmap_cost_function::set_params(vnl_vector_fixed<double, 3> const & xyz, v
   }
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 void
 vpgl_invmap_cost_function::set_params(vnl_vector_fixed<double, 3> const & xyz, vnl_vector<double> & x)
 {
-  VXL_DEPRECATED_MACRO("vpgl_invmap_cost_function::set_params(, vnl_vector<double>&)");
   switch (pp_)
   {
     case X_Y: {
@@ -105,6 +106,7 @@ vpgl_invmap_cost_function::set_params(vnl_vector_fixed<double, 3> const & xyz, v
     }
   }
 }
+#endif
 
 void
 vpgl_invmap_cost_function::point_3d(vnl_vector_fixed<double, 2> const & x, vnl_vector_fixed<double, 3> & xyz)
@@ -139,10 +141,11 @@ vpgl_invmap_cost_function::point_3d(vnl_vector_fixed<double, 2> const & x, vnl_v
   }
 }
 
+#if !VXL_LEGACY_FUTURE_REMOVE
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL")
 void
 vpgl_invmap_cost_function::point_3d(vnl_vector<double> const & x, vnl_vector_fixed<double, 3> & xyz)
 {
-  VXL_DEPRECATED_MACRO("vpgl_invmap_cost_function::point_3d(vnl_vector<double>,)");
   // Switch on plane parameterization
   switch (pp_)
   {
@@ -172,3 +175,4 @@ vpgl_invmap_cost_function::point_3d(vnl_vector<double> const & x, vnl_vector_fix
     }
   }
 }
+#endif

--- a/core/vsl/vsl_b_read_block_old.h
+++ b/core/vsl/vsl_b_read_block_old.h
@@ -1,6 +1,8 @@
 // This is core/vsl/vsl_b_read_block_old.h
 #ifndef vsl_b_read_block_old_h_
 #define vsl_b_read_block_old_h_
+
+#if !VXL_LEGACY_FUTURE_REMOVE
 //:
 // \file
 // \brief Backwards compatibility support only.
@@ -24,7 +26,7 @@
 // backwards compatibility. If any of the functions are actually used, a
 // deprecation warning will be sent to cerr.
 
-#include <vcl_deprecated.h>
+#include <vcl_compiler.h>
 
 // The next declaration should be kept with its non-specialist definition.
 // It was this mistake that lead to the full replacement of vsl_b_read_block
@@ -35,9 +37,9 @@
 // then just #include "vsl_binary_explicit_io.h"
 // \deprecated in favour of vsl_block_binary_read
 template <class T>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, T* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   while (nelems--)
     vsl_b_read(is, *(begin++));
 }
@@ -48,9 +50,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, T* begin, std::size_t nelems
 // This function is very speed efficient.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, double* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   is.is().read((char*) begin, (unsigned long)(nelems*sizeof(double)));
   vsl_swap_bytes((char *)begin, sizeof(double), nelems);
 }
@@ -61,9 +63,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, double* begin, std::size_t n
 // This function is very speed efficient.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, float* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   is.is().read((char*) begin, (unsigned long)(nelems*sizeof(float)));
   vsl_swap_bytes((char *)begin, sizeof(float), nelems);
 }
@@ -76,9 +78,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, float* begin, std::size_t ne
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, int* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   if (!is) return;
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
@@ -107,9 +109,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, int* begin, std::size_t nele
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned int* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
   if (nbytes)
@@ -138,9 +140,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned int* begin, std::si
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, short* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
   if (nbytes)
@@ -169,9 +171,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, short* begin, std::size_t ne
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned short* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
   if (nbytes)
@@ -200,9 +202,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned short* begin, std::
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, long* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
   if (nbytes)
@@ -231,9 +233,9 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, long* begin, std::size_t nel
 // size of the block being read.
 // \deprecated in favour of vsl_block_binary_read
 template <>
+VXL_DEPRECATED_MSG("Will be removed in future versions of VXL, prefer vsl_block_binary_read")
 inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned long* begin, std::size_t nelems)
 {
-  VXL_DEPRECATED_MACRO( "vsl_b_read_block_old()" );
   std::size_t nbytes;
   vsl_b_read(is, nbytes);
   if (nbytes)
@@ -251,5 +253,7 @@ inline void vsl_b_read_block_old(vsl_b_istream &is, unsigned long* begin, std::s
     }
   }
 }
+
+#endif
 
 #endif // vsl_b_read_block_old_h_

--- a/core/vsl/vsl_vector_io.hxx
+++ b/core/vsl/vsl_vector_io.hxx
@@ -69,18 +69,26 @@ void vsl_b_read(vsl_b_istream& is, std::vector<T>& v)
   switch (ver)
   {
    case 1:
+#if !VXL_LEGACY_FUTURE_REMOVE
     if (n!=0)
     {
       vsl_b_read_block_old(is, &v.front(), n);
     }
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
     break;
    case 2:
     if (n!=0)
     {
       if (vsl_is_char(v.front())) // signed char or unsigned char
       {
+#if !VXL_LEGACY_FUTURE_REMOVE
         vsl_block_binary_read_confirm_specialisation(is, false);
         vsl_b_read_block_old(is, &v.front(), n);
+#else
+    std::cerr << "I/O ERROR: Old version 1 file formats are no longer supported since deprecation of required function vsl_b_read_block_old in 2006\n";
+#endif
       }
       else
         vsl_block_binary_read(is, &v.front(), n);

--- a/vcl/vcl_deprecated.h
+++ b/vcl/vcl_deprecated.h
@@ -1,6 +1,7 @@
 #ifndef vcl_deprecated_h_
 #define vcl_deprecated_h_
 
+#if !VXL_LEGACY_FUTURE_REMOVE
 //:
 // \file
 // \brief  Defines macros used for marking deprecated functions
@@ -50,6 +51,11 @@
   #endif
 #else
   #define VXL_DEPRECATED_MACRO(f) /* suppress deprecation warning */
+#endif
+
+#warning "vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants."
+#else
+#error "vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants."
 #endif
 
 #endif


### PR DESCRIPTION
There were two deprecation methods defined within VXL.
Prefer to use the compiler supported methods rather than
the circa 2003 manually developed macros.
