### PR TITLE
BUG: /MP and #warning

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -86,7 +86,11 @@ function( vxl_add_library )
     add_library(${vxl_add_LIBRARY_NAME} ${vxl_add_LIBRARY_SOURCES} )
 
     # This enables object-level build parallelism in VNL libraries for MSVC
-    if(MSVC AND NOT vxl_add_DISABLE_MSVC_MP) 
+    # - disabled for MSVC simulators such as clang-cl
+    #     https://github.com/vxl/vxl/issues/863
+    #     https://gitlab.kitware.com/cmake/cmake/-/issues/19724
+    # - disabled for DISABLE_MSVC_MP
+    if(MSVC AND NOT "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC" AND NOT vxl_add_DISABLE_MSVC_MP)
       target_compile_definitions(${vxl_add_LIBRARY_NAME} PRIVATE " /MP ")
     endif()
 

--- a/v3p/geotiff/CMakeLists.txt
+++ b/v3p/geotiff/CMakeLists.txt
@@ -46,7 +46,11 @@ if (${VXL_USE_GEOTIFF})
       )
 
 
-    vxl_add_library(LIBRARY_NAME geotiff LIBRARY_SOURCES ${geotiff_sources} )
+    vxl_add_library(
+        LIBRARY_NAME geotiff
+        LIBRARY_SOURCES ${geotiff_sources}
+        DISABLE_MSVC_MP
+    )
     target_link_libraries(geotiff ${TIFF_LIBRARIES})
 
     #endif()

--- a/v3p/netlib/CMakeLists.txt
+++ b/v3p/netlib/CMakeLists.txt
@@ -437,8 +437,12 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 # Create a netlib library with mangled symbols.
-vxl_add_library(LIBRARY_NAME ${VXL_LIB_PREFIX}v3p_netlib
-  LIBRARY_SOURCES ${v3p_netlib_sources})
+vxl_add_library(
+    LIBRARY_NAME ${VXL_LIB_PREFIX}v3p_netlib
+    LIBRARY_SOURCES ${v3p_netlib_sources}
+    DISABLE_MSVC_MP
+)
+
 if(UNIX)
   target_link_libraries(${VXL_LIB_PREFIX}v3p_netlib m)
 endif()

--- a/v3p/tiff/CMakeLists.txt
+++ b/v3p/tiff/CMakeLists.txt
@@ -165,7 +165,11 @@ if(NOT VXL_USING_NATIVE_TIFF)
       )
     endif()
   endif()
-  vxl_add_library(LIBRARY_NAME tiff LIBRARY_SOURCES ${tiff_sources} )
+  vxl_add_library(
+      LIBRARY_NAME tiff
+      LIBRARY_SOURCES ${tiff_sources}
+      DISABLE_MSVC_MP
+  )
   target_link_libraries( tiff ${ZLIB_LIBRARIES} ${JPEG_LIBRARIES})
 
   if( BUILD_TESTING)

--- a/vcl/vcl_deprecated.h
+++ b/vcl/vcl_deprecated.h
@@ -53,7 +53,12 @@
   #define VXL_DEPRECATED_MACRO(f) /* suppress deprecation warning */
 #endif
 
+#ifdef _MSC_VER
+#pragma message ( "warning: vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants." )
+#else
 #warning "vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants."
+#endif
+
 #else
 #error "vcl_deprecated.h, and it's associated VXL_WARN_DEPRECATED functions should be replaced with vcl_compiler.h and VXL_DEPRECATED_MSG variants."
 #endif


### PR DESCRIPTION
- Disable /MP for several additional v3p libraries, eliminating warnings on MSVC compilers as per #832 
- Implement suggestion to disable /MP for clang-cl compilers from #863 
- `#warning` -> `#pragma message` for MSVC, bug introduced in #899 


@hjmjohnson 

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

