### PR TITLE
COMP: apply /MP only to CXX

### DIFF
--- a/config/cmake/config/vxl_utils.cmake
+++ b/config/cmake/config/vxl_utils.cmake
@@ -89,9 +89,11 @@ function( vxl_add_library )
     # - disabled for MSVC simulators such as clang-cl
     #     https://github.com/vxl/vxl/issues/863
     #     https://gitlab.kitware.com/cmake/cmake/-/issues/19724
+    # - disabled for COMPILE_LANGUAGE!=CXX (via generator expression)
     # - disabled for DISABLE_MSVC_MP
     if(MSVC AND NOT "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC" AND NOT vxl_add_DISABLE_MSVC_MP)
-      target_compile_options(${vxl_add_LIBRARY_NAME} PRIVATE " /MP ")
+      target_compile_options(${vxl_add_LIBRARY_NAME} PRIVATE
+          $<$<COMPILE_LANGUAGE:CXX>:/MP> )
     endif()
 
     set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES ${vxl_add_LIBRARY_NAME})


### PR DESCRIPTION
PR #901 introduced a new error for some Windows environments where `/MP` broke the build.

Fixed in `vxl_utils.cmake` by adding `/MP` only for CXX files, using a cmake generator function.

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
