### PR TITLE
Large disparity

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_error_checking.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_error_checking.hxx
@@ -399,7 +399,7 @@ void bsgm_compute_invalid_map(
     img_stop_x = target_window.max_x();
     img_stop_y = target_window.max_y();
   }
-
+  
   // the x coordinate of the left-most possible reference pixel mapped to from the target
   int img_ref_start_x = std::max(0, img_start_x + min_disparity);
 
@@ -418,12 +418,13 @@ void bsgm_compute_invalid_map(
 
     // Fill in the left border
     for (int invalid_x = 0, img_x = img_start_x; invalid_x < w; invalid_x++, img_x++) {
-      if (img_tar(img_x, img_y) == border_val)
-        invalid_tar(invalid_x, invalid_y) = true;
+        if (img_tar(img_x, img_y) == border_val) {
+            invalid_tar(invalid_x, invalid_y) = true;
+       }
       else
         break;
     } //x
-
+    
     // Fill in the right border
     for (int invalid_x = w - 1, img_x = img_stop_x - 1; invalid_x >= 0; invalid_x--, img_x--) {
       if (img_tar(img_x, img_y) == border_val)
@@ -432,7 +433,13 @@ void bsgm_compute_invalid_map(
         break;
     } //x
   } //y
-
+#if 0 // for debug
+  vil_image_view<vxl_byte> tar_vis(w, h);
+  for (int y = 0; y < h; y++)
+      for (int x = 0; x < w; x++)
+          tar_vis(x, y) = invalid_tar(x, y) ? 255 : 0;
+  vil_save( vis, "D:/tests/WorldCup/AOI4/debug/invalid.png" );
+#endif
   // Find the border in the reference image
   for (int invalid_y = 0, img_y = img_start_y; invalid_y < h; invalid_y++, img_y++) {
 
@@ -448,7 +455,7 @@ void bsgm_compute_invalid_map(
     // Mask any pixels in the target image which map into the left border
     for (int invalid_x = 0; invalid_x < std::min(w, lb_invalid); invalid_x++)
       invalid_tar(invalid_x, invalid_y) = true;
-
+   
     // Find the right border
     int rb_ref = img_ref_stop_x - 1;
     for ( ; rb_ref >= img_ref_start_x; rb_ref--)
@@ -457,17 +464,17 @@ void bsgm_compute_invalid_map(
 
     int rb_target = rb_ref - max_disparity;
     int rb_invalid = rb_target - img_start_x;
-
+    
     // Mask any pixels in the target image which map into the right border
     for (int invalid_x = w - 1; invalid_x > std::max(0, rb_invalid); invalid_x--)
       invalid_tar(invalid_x, invalid_y) = true;
+    
   } //y
-
-  //vil_image_view<vxl_byte> vis( w_, h_ );
-  //for( int y = 0; y < h_; y++ )
-  //  for( int x = 0; x < w_; x++ )
-  //    vis(x,y) = invalid_tar(x,y) ? 255 : 0;
-  //vil_save( vis, "D:/results/sattel/invalid.png" );
+  
+  vil_image_view<vxl_byte> vis( w, h );
+  for( int y = 0; y < h; y++ )
+    for( int x = 0; x < w; x++ )
+      vis(x,y) = invalid_tar(x,y) ? 255 : 0;
 }
 
 //: Fill in disparity pixels flagged as errors via multi-directional

--- a/contrib/brl/bseg/bsgm/bsgm_multiscale_disparity_estimator.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_multiscale_disparity_estimator.cxx
@@ -105,5 +105,35 @@ bsgm_multiscale_disparity_estimator::~bsgm_multiscale_disparity_estimator()
   delete fine_de_;
 }
 
-
+vil_image_view<float> bsgm_multiscale_disparity_estimator::fill_1x1_holes(vil_image_view<float> const& img) {
+    float large_spike_tol = 10.0f;
+    size_t ni = img.ni(), nj = img.nj();
+    vil_image_view<float> ret(img);
+    // ignore borders
+    for(int j = 1; j<(nj-1); ++j)
+        for (int i = 1; i < (ni - 1); ++i) {
+            float sum = 0.0f, ns = 0.0f;
+            for (int rj = -1; rj <= 1; ++rj)
+                for (int ri = -1; ri <= 1; ++ri)
+            {
+                if (ri == 0&&rj ==0) continue;
+                float v = img(i + ri, j + rj);
+                if (std::isnan(v))
+                    continue; 
+                sum += v; ns += 1.0f;
+            }
+            if (ns < 8.0) {
+                continue;
+            }
+            sum /= ns;
+            float v = img(i, j);
+            if (std::isnan(v)) {
+                ret(i, j) = sum;
+                continue;
+            }
+            if (fabs(v - sum) > large_spike_tol)
+                ret(i, j) = sum;
+       }
+    return ret;
+}
 //----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

:no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
 :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X]  --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
 :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
:no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
