### PR TITLE
COMP: Fix VNL compile warning about VXL_WARN_DEPRECATED

### DIFF
--- a/vcl/tests/test_include.cxx
+++ b/vcl/tests/test_include.cxx
@@ -52,6 +52,6 @@
 #endif
 
 #include <vcl_where_root_dir.h>
-#include <vcl_deprecated.h>
+// #include <vcl_deprecated.h> // This causes compile warnings
 
 int main() { return 0; }

--- a/vcl/vcl_deprecated.cxx
+++ b/vcl/vcl_deprecated.cxx
@@ -1,8 +1,6 @@
 // This is vcl/vcl_deprecated.cxx
 #include <iostream>
 #include <cstdlib>
-#include "vcl_deprecated.h"
-
 
 
 #ifdef VXL_WARN_DEPRECATED_ABORT


### PR DESCRIPTION
Raised in ITK nightly dashboard, e.g.:
https://open.cdash.org/viewBuildError.php?type=1&buildid=8350827


