### PR TITLE
COMP: Do not contaminate CMAKE_REQUIRED_FLAGS

### DIFF
--- a/config/cmake/config/VXLIntrospectionConfig.cmake
+++ b/config/cmake/config/VXLIntrospectionConfig.cmake
@@ -431,7 +431,9 @@ PERFORM_CMAKE_TEST_RUN(${VXL_PLFM_TEST_FILE} VXL_HAS_SSE2_HARDWARE_SUPPORT)
 # if no support right now, see if the support exists if some flags
 # are added.  This can be used to give the user some useful info.
 if(NOT VXL_HAS_SSE2_HARDWARE_SUPPORT)
-  if(CMAKE_COMPILER_IS_GNUCXX)
+  # -msse2 flags are the default on 64 bit systems,
+  # so the following is only relavant for 32 bit systems
+  if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(VXL_SSE_TEST_FLAG_BACKUP ${CMAKE_REQUIRED_FLAGS})
     set(CMAKE_REQUIRED_FLAGS " -msse2 ${VXL_SSE_TEST_FLAG_BACKUP} ")
     PERFORM_CMAKE_TEST_RUN(${VXL_PLFM_TEST_FILE} VXL_SSE2_HARDWARE_SUPPORT_POSSIBLE)


### PR DESCRIPTION
VXL contaminates the CMAKE_REQUIRED_FLAGS that may be used by other packages.  This is only relavant for compilations on i386 machines. As stated in the gcc docs the SSE instruction set is enabled by default when using an x86-64 compiler.

Long-standing problem identified in https://github.com/InsightSoftwareConsortium/ITK/pull/3852

