### PR TITLE
STYLE: CMakeLists.txt use ON/OFF vs True/NO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/config/cmake/config/VXLIntrospectionConfig.cma
 #-------------------------------------------------------------------
 # This block should come after VXLIntrospectionConfig.cmake has been executed.
 if(VCL_HAS_LFS OR WIN32)
-  option( VXL_USE_LFS "Should VXL use Large File Support?" NO)
+  option( VXL_USE_LFS "Should VXL use Large File Support?" OFF)
   mark_as_advanced( VXL_USE_LFS )
 endif()
 
@@ -261,13 +261,13 @@ if(VXL_USE_LFS)
   if(WIN32)
     # TODO: MS Version Support
     #  message( SEND_ERROR "Sorry - Large File Support is not quite working on Win32 yet. Turning VXL_USE_LFS off")
-    #  set(VXL_USE_LFS "NO" CACHE BOOL "Should VXL use Large File Support?" FORCE)
+    #  set(VXL_USE_LFS OFF CACHE BOOL "Should VXL use Large File Support?" FORCE)
   else()
     if(VCL_HAS_LFS)
       add_definitions( -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE)
     else()
       message( SEND_ERROR "This platform does not have Large File Support - turning VXL_USE_LFS off")
-      set(VXL_USE_LFS "NO" CACHE BOOL "Should VXL use Large File Support?" FORCE)
+      set(VXL_USE_LFS OFF CACHE BOOL "Should VXL use Large File Support?" FORCE)
     endif()
   endif()
 endif()
@@ -294,7 +294,7 @@ mark_as_advanced(VXL_BUILD_NONDEPRECATED_ONLY)
 CMAKE_DEPENDENT_OPTION(VXL_BUILD_CORE_PROBABILITY "Build VXL's probability libraries (Experimental)" ON
                        "VXL_BUILD_CORE_NUMERICS;NOT VXL_BUILD_CORE_NUMERICS_ONLY" OFF)
 
-option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" True)
+option(VXL_USE_GEOTIFF "Use the GEOTIFF Library if available" ON)
 mark_as_advanced(VXL_USE_GEOTIFF)
 
 # Build the core vxl + support libraries


### PR DESCRIPTION
Most of this file uses ON/OFF for OPTION and CACHE BOOL settings already, with one "True" and three "NO"s. In CMake logically ON, YES, TRUE, 1 are equivalent, but NO is visually similar to ON with opposite meaning. Many CMake editors won't syntax highlight True, and CMake-gui will change OPTION or CACHE BOOL values to ON/OFF, creating unnecessary changes to CMakeCache.txt.

(Sorry the note about commit message formats came up after I'd already committed, not sure how to fix it using this git web UI, feel free to modify in any way!)