### PR TITLE
ENH: Missing dependency on build options caused build failure

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -121,6 +121,8 @@ CMAKE_DEPENDENT_OPTION( VXL_BUILD_VGUI "Build VGUI" OFF
 mark_as_advanced(VXL_BUILD_VGUI)
 if(VXL_BUILD_VGUI)
   add_subdirectory(vgui)
+else()
+  unset(VGUI_FOUND)
 endif()
 
 

--- a/core/vgl/examples/CMakeLists.txt
+++ b/core/vgl/examples/CMakeLists.txt
@@ -1,9 +1,11 @@
-include( ${VXL_CMAKE_DIR}/UseVGUI.cmake )
 
 add_executable(vgl_conic_example vgl_conic_example.cxx)
 target_link_libraries( vgl_conic_example ${VXL_LIB_PREFIX}vgl_algo )
 
-if( VGUI_FOUND )
-  add_executable(vgl_calculate_homography calculate_homography.cxx)
-  target_link_libraries( vgl_calculate_homography ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgui ${VXL_LIB_PREFIX}vnl )
+if(VXL_BUILD_VGUI)
+  include( ${VXL_CMAKE_DIR}/UseVGUI.cmake )
+  if( VGUI_FOUND )
+    add_executable(vgl_calculate_homography calculate_homography.cxx)
+    target_link_libraries( vgl_calculate_homography ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vgui ${VXL_LIB_PREFIX}vnl )
+  endif()
 endif()


### PR DESCRIPTION
Turning VXL_BUILD_GUI on, configure, then off caused a build failure due to dependancy not being properly and completely enforced.
