### PR TITLE
COMP: unary minus result mismatch warning

### DIFF
--- a/core/vnl/tests/test_matrix.cxx
+++ b/core/vnl/tests/test_matrix.cxx
@@ -349,6 +349,24 @@ test_int()
     for (unsigned int i = 0; i < vc.size(); ++i)
       TEST("vc.apply_columnwise(sum_vector)", vc.get(i), 5);
   }
+
+  { // test operator-() on unsigned values
+    unsigned int vvalues[] = {1, 2, 3, 4};
+    int out_values[] = {-1, -2, -3, -4};
+    const vnl_matrix<int> outm(2, 2, 4, out_values);
+
+    vnl_matrix<unsigned int> unsigned_m22(2, 2, 4, vvalues);
+    const vnl_matrix<int> minus_v1 = -unsigned_m22;
+    const vnl_matrix<int> minus_v2 = unsigned_m22.operator-();
+    TEST("unsigned_m22.operator-()",
+         (outm(0, 0) == minus_v1(0, 0) && outm(0, 1) == minus_v1(0, 1) && outm(1, 0) == minus_v1(1, 0) &&
+          outm(1, 1) == minus_v1(1, 1)), true);
+    TEST("unsigned_m22.operator-()",
+         (outm(0, 0) == minus_v2(0, 0) && outm(0, 1) == minus_v2(0, 1) && outm(1, 0) == minus_v2(1, 0) &&
+          outm(1, 1) == minus_v2(1, 1)), true);
+  }
+
+
 }
 
 

--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -292,6 +292,22 @@ test_int()
   TEST("m.update([4],1,1)",
        ((m3 = 4), (m.update(m3, 1, 1)), (m(0, 0) == 0 && m(0, 1) == -2 && m(1, 0) == 2 && m(1, 1) == 4)),
        true);
+
+  { // test operator-() on unsigned values
+    unsigned int vvalues[] = {1, 2, 3, 4};
+    int out_values[] = {-1, -2, -3, -4};
+    const vnl_matrix_fixed<int,2,2> outm( out_values);
+
+    vnl_matrix_fixed<unsigned int,2,2> unsigned_m22(vvalues);
+    const vnl_matrix_fixed<int,2,2> minus_v1 = -unsigned_m22;
+    const vnl_matrix_fixed<int,2,2> minus_v2 = unsigned_m22.operator-();
+    TEST("unsigned_m22.operator-()",
+         (outm(0, 0) == minus_v1(0, 0) && outm(0, 1) == minus_v1(0, 1) && outm(1, 0) == minus_v1(1, 0) &&
+          outm(1, 1) == minus_v1(1, 1)), true);
+    TEST("unsigned_m22.operator-()",
+         (outm(0, 0) == minus_v2(0, 0) && outm(0, 1) == minus_v2(0, 1) && outm(1, 0) == minus_v2(1, 0) &&
+          outm(1, 1) == minus_v2(1, 1)), true);
+  }
 }
 
 static void

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -317,6 +317,37 @@ vnl_vector_test_int()
     v = v_temp, v.roll_inplace(-5); // Positive, in range
     TEST("v.roll_inplace(-5)", (1 == v[0] && 2 == v[1] && 3 == v[2] && 0 == v[3]), true);
   }
+
+  { // test operator-() on unsigned values
+    unsigned int vvalues[] = {1, 2, 3, 4};
+    int out_values[] = {-1, -2, -3, -4};
+
+    vnl_vector<unsigned int> unsigned_v(4, 4, vvalues);
+    const vnl_vector<int> minus_v1 = -unsigned_v;
+    const vnl_vector<int> minus_v2 = unsigned_v.operator-();
+    TEST("unsigned_v.operator-()",
+         (out_values[0] == minus_v1[0] && out_values[1] == minus_v1[1] && out_values[2] == minus_v1[2] &&
+          out_values[3] == minus_v1[3]), true);
+    TEST("unsigned_v.operator-()",
+         (out_values[0] == minus_v2[0] && out_values[1] == minus_v2[1] && out_values[2] == minus_v2[2] &&
+          out_values[3] == minus_v2[3]), true);
+  }
+
+  { // test operator-() on unsigned values
+    unsigned int vvalues[] = {1, 2, 3, 4};
+    int out_values[] = {-1, -2, -3, -4};
+
+    vnl_vector_fixed<unsigned int,4> unsigned_v(vvalues);
+    const vnl_vector_fixed<int,4> minus_v1 = -unsigned_v;
+    const vnl_vector_fixed<int,4> minus_v2 = unsigned_v.operator-();
+    TEST("unsigned_v.operator-()",
+         (out_values[0] == minus_v1[0] && out_values[1] == minus_v1[1] && out_values[2] == minus_v1[2] &&
+          out_values[3] == minus_v1[3]), true);
+    TEST("unsigned_v.operator-()",
+         (out_values[0] == minus_v2[0] && out_values[1] == minus_v2[1] && out_values[2] == minus_v2[2] &&
+          out_values[3] == minus_v2[3]), true);
+  }
+
 }
 
 bool

--- a/core/vnl/vnl_bignum_traits.h
+++ b/core/vnl/vnl_bignum_traits.h
@@ -25,6 +25,11 @@ class VNL_EXPORT vnl_numeric_traits<vnl_bignum>
   typedef vnl_bignum double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = vnl_bignum;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
+
 };
 
 #endif // vnl_bignum_traits_h_

--- a/core/vnl/vnl_decnum_traits.h
+++ b/core/vnl/vnl_decnum_traits.h
@@ -25,6 +25,11 @@ class VNL_EXPORT vnl_numeric_traits<vnl_decnum>
   typedef vnl_decnum double_t;
   //: Name of type which results from multiplying this type with a double
   typedef vnl_decnum real_t;
+  //: Name of this type
+  using self = vnl_decnum;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
+
 };
 
 #endif // vnl_decnum_traits_h_

--- a/core/vnl/vnl_matrix.h
+++ b/core/vnl/vnl_matrix.h
@@ -284,7 +284,7 @@ class VNL_EXPORT vnl_matrix
   vnl_matrix<T>& operator*=(vnl_matrix<T> const&rhs) { return *this = (*this) * rhs; }
 
   //: Negate all elements of matrix
-  vnl_matrix<T> operator-() const;
+  vnl_matrix<typename vnl_numeric_traits<T>::signed_t> operator-() const;
 
 
   //: Add rhs to each element of lhs matrix and return result in new matrix

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -548,12 +548,12 @@ vnl_matrix<T> operator- (T const& value, vnl_matrix<T> const& m)
 // O(m*n).
 
 template <class T>
-vnl_matrix<T> vnl_matrix<T>::operator- () const
+vnl_matrix<typename vnl_numeric_traits<T>::signed_t> vnl_matrix<T>::operator- () const
 {
-  vnl_matrix<T> result(this->num_rows, this->num_cols);
+  vnl_matrix<typename vnl_numeric_traits<T>::signed_t> result(this->num_rows, this->num_cols);
   for (unsigned int i = 0; i < this->num_rows; i++)
     for (unsigned int j = 0; j < this->num_cols; j++)
-      result.data[i][j] = - this->data[i][j];
+      result(i,j) = - this->data[i][j];
   return result;
 }
 

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -223,11 +223,26 @@ class VNL_EXPORT vnl_matrix_fixed
 
   //: Access an element for reading or writing
   // There are assert style boundary checks - #define NDEBUG to turn them off.
-  T       & operator() (unsigned r, unsigned c);
+  T       & operator() (unsigned r, unsigned c)
+  {
+#if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
+    assert(r < rows());   // Check the row index is valid
+    assert(c < cols());   // Check the column index is valid
+#endif
+    return this->data_[r][c];
+  }
+
 
   //: Access an element for reading
   // There are assert style boundary checks - #define NDEBUG to turn them off.
-  T const & operator() (unsigned r, unsigned c) const;
+  T const & operator() (unsigned r, unsigned c) const
+  {
+#if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
+    assert(r < rows());   // Check the row index is valid
+    assert(c < cols());   // Check the column index is valid
+#endif
+    return this->data_[r][c];
+  }
 
   // ----------------------- Filling and copying -----------------------
 
@@ -353,10 +368,12 @@ class VNL_EXPORT vnl_matrix_fixed
   }
 
   //: Negate all elements of matrix
-  vnl_matrix_fixed operator- () const
+  vnl_matrix_fixed<typename vnl_numeric_traits<T>::signed_t, num_rows,num_cols> operator- () const
   {
-    vnl_matrix_fixed r;
-    self::sub( T(0), data_block(), r.data_block() );
+    vnl_matrix_fixed<typename vnl_numeric_traits<T>::signed_t, num_rows,num_cols> r;
+    for(int i=0; i<num_rows; ++i)
+      for(int j=0; j<num_cols; ++j)
+        r(i,j) = -(*this)(i,j);
     return r;
   }
 

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -34,27 +34,9 @@ vnl_matrix_fixed<T, num_rows, num_cols>::operator=(const vnl_matrix<T>& rhs)
 	return *this;
 }
 
-template<class T, unsigned nrows, unsigned ncols>
-T       &
-vnl_matrix_fixed<T, nrows, ncols>::operator() (unsigned r, unsigned c)
-{
-#if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
-	assert(r < rows());   // Check the row index is valid
-	assert(c < cols());   // Check the column index is valid
-#endif
-	return this->data_[r][c];
-}
 
-template<class T, unsigned nrows, unsigned ncols>
-T const &
-vnl_matrix_fixed<T, nrows, ncols>::operator() (unsigned r, unsigned c) const
-{
-#if VNL_CONFIG_CHECK_BOUNDS  && (!defined NDEBUG)
-	assert(r < rows());   // Check the row index is valid
-	assert(c < cols());   // Check the column index is valid
-#endif
-	return this->data_[r][c];
-}
+
+
 
 template<class T, unsigned nrows, unsigned ncols>
 void

--- a/core/vnl/vnl_numeric_traits.h
+++ b/core/vnl/vnl_numeric_traits.h
@@ -24,6 +24,7 @@
 //-----------------------------------------------------------------------------
 
 #include <complex>
+#include <type_traits>
 #include <vxl_config.h> // for type vxl_uint_64
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
@@ -63,6 +64,9 @@ class VNL_EXPORT vnl_numeric_traits
 
   //: Name of type which results from multiplying this type with a double
   typedef vnl_numeric_traits_not_a_valid_type real_t;
+
+  //: Name of type which results from using a unary operator-()
+  typedef vnl_numeric_traits_not_a_valid_type signed_t;
 };
 #endif
 
@@ -83,6 +87,10 @@ class VNL_EXPORT vnl_numeric_traits<bool>
   typedef unsigned int double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = bool;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template <>
@@ -114,6 +122,10 @@ class VNL_EXPORT vnl_numeric_traits<char>
   typedef short double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = char;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -135,6 +147,10 @@ class VNL_EXPORT vnl_numeric_traits<unsigned char>
   typedef unsigned short double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = unsigned char;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -156,6 +172,10 @@ class VNL_EXPORT vnl_numeric_traits<signed char>
   typedef signed short double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = signed char;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -177,6 +197,10 @@ class VNL_EXPORT vnl_numeric_traits<short>
   typedef int double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = short;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -198,6 +222,10 @@ class VNL_EXPORT vnl_numeric_traits<unsigned short>
   typedef unsigned int double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = unsigned short;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -219,6 +247,10 @@ class VNL_EXPORT vnl_numeric_traits<int>
   typedef long double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = int;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -240,6 +272,10 @@ class VNL_EXPORT vnl_numeric_traits<unsigned int>
   typedef unsigned long double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = unsigned int;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -261,6 +297,10 @@ class VNL_EXPORT vnl_numeric_traits<long>
   typedef vxl_sint_64 double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = long;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -283,6 +323,10 @@ class VNL_EXPORT vnl_numeric_traits<unsigned long>
   typedef vxl_uint_64 double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = unsigned long;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -306,6 +350,10 @@ class VNL_EXPORT vnl_numeric_traits<long long>
   typedef long long double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = long long;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -327,6 +375,10 @@ class VNL_EXPORT vnl_numeric_traits<unsigned long long>
   typedef unsigned long long double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = unsigned long long;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = std::make_signed<self>::type;
 };
 
 template<>
@@ -349,6 +401,10 @@ class VNL_EXPORT vnl_numeric_traits<float>
   typedef double double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = float;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>
@@ -370,6 +426,10 @@ class VNL_EXPORT vnl_numeric_traits<double>
   typedef long double double_t;
   //: Name of type which results from multiplying this type with a double
   typedef double real_t;
+  //: Name of this type
+  using self = double;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>
@@ -391,6 +451,10 @@ class VNL_EXPORT vnl_numeric_traits<long double>
   typedef long double double_t; // ahem
   //: Name of type which results from multiplying this type with a double
   typedef long double real_t;
+  //: Name of this type
+  using self = long double;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>
@@ -413,6 +477,10 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<float> >
   typedef std::complex<vnl_numeric_traits<float>::double_t> double_t;
   //: Name of type which results from multiplying this type with a double
   typedef std::complex<float> real_t;
+  //: Name of this type
+  using self = std::complex<float>;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>
@@ -435,6 +503,10 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<double> >
   typedef std::complex<vnl_numeric_traits<double>::double_t> double_t;
   //: Name of type which results from multiplying this type with a double
   typedef std::complex<double> real_t;
+  //: Name of this type
+  using self = std::complex<double>;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>
@@ -457,6 +529,10 @@ class VNL_EXPORT vnl_numeric_traits< std::complex<long double> >
   typedef std::complex<vnl_numeric_traits<long double>::double_t> double_t;
   //: Name of type which results from multiplying this type with a double
   typedef std::complex<long double> real_t;
+  //: Name of this type
+  using self = std::complex<long double>;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template<>

--- a/core/vnl/vnl_polynomial.h
+++ b/core/vnl/vnl_polynomial.h
@@ -38,6 +38,8 @@
 #endif
 #include <cassert>
 #include "vnl/vnl_export.h"
+#include "vnl/vnl_rational_traits.h"
+#include "vnl/vnl_decnum_traits.h"
 
 //: Evaluation of polynomials.
 //  vnl_polynomial<T> represents a univariate polynomial with
@@ -88,7 +90,7 @@ class VNL_EXPORT vnl_polynomial
   bool operator==(vnl_polynomial<T> const& p) const { return p.coefficients() == coeffs_; }
 
   //: Returns negative of this polynomial
-  vnl_polynomial<T> operator-() const;
+  vnl_polynomial<typename vnl_numeric_traits<T>::signed_t> operator-() const;
 
   //: Returns polynomial which is sum of this with polynomial f
   vnl_polynomial<T> operator+(vnl_polynomial<T> const& f) const;

--- a/core/vnl/vnl_polynomial.hxx
+++ b/core/vnl/vnl_polynomial.hxx
@@ -34,7 +34,7 @@ T vnl_polynomial<T>::evaluate(T const& x) const
 
 //: Returns negative of this polynomial
 template <class T>
-vnl_polynomial<T> vnl_polynomial<T>::operator-() const
+vnl_polynomial<typename vnl_numeric_traits<T>::signed_t> vnl_polynomial<T>::operator-() const
 {
   std::vector<T> neg = coeffs_;
   typename std::vector<T>::iterator i = neg.begin();

--- a/core/vnl/vnl_rational_traits.h
+++ b/core/vnl/vnl_rational_traits.h
@@ -32,6 +32,10 @@ class vnl_numeric_traits<vnl_rational>
   //  This must be a built-in type: do not set this to vnl_rational, since
   //  that would require std::sqrt(vnl_rational) etc., which is not allowed.
   typedef double real_t;
+  //: Name of this type
+  using self = vnl_rational;
+  //: Name of type which results from using a unary operator-()
+  using signed_t = self;
 };
 
 template <>

--- a/core/vnl/vnl_sparse_matrix.h
+++ b/core/vnl/vnl_sparse_matrix.h
@@ -216,7 +216,7 @@ class VNL_EXPORT vnl_sparse_matrix
   { return !operator==(rhs); }
 
   //: Unary minus
-  vnl_sparse_matrix<T> operator-() const;
+  vnl_sparse_matrix<typename vnl_numeric_traits<T>::signed_t> operator-() const;
 
   //: addition
   vnl_sparse_matrix<T> operator+(vnl_sparse_matrix<T> const& rhs) const;

--- a/core/vnl/vnl_sparse_matrix.hxx
+++ b/core/vnl/vnl_sparse_matrix.hxx
@@ -728,7 +728,7 @@ bool vnl_sparse_matrix<T>::operator==(vnl_sparse_matrix<T> const& rhs) const
 
 //: Unary minus
 template <class T>
-vnl_sparse_matrix<T> vnl_sparse_matrix<T>::operator-() const
+vnl_sparse_matrix<typename vnl_numeric_traits<T>::signed_t> vnl_sparse_matrix<T>::operator-() const
 {
   // The matrix to be returned:
   vnl_sparse_matrix<T> result(rows(), columns());

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -34,6 +34,7 @@
 # undef ERROR_CHECKING
 #endif
 #include "vnl_sse.h"
+#include "vnl_numeric_traits.h"
 #include <algorithm>
 
 template <class T> class vnl_vector;
@@ -202,7 +203,7 @@ class VNL_EXPORT vnl_vector
 
   //: Unary minus operator
   // Return new vector = -1*(*this)
-  vnl_vector<T> operator-() const;
+  vnl_vector<typename vnl_numeric_traits<T>::signed_t> operator-() const;
 
   vnl_vector<T> operator+(T v) const {
     vnl_vector<T> result(this->size());

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -431,11 +431,12 @@ vnl_vector<T>& vnl_vector<T>::post_multiply (vnl_matrix<T> const& m)
 //: Creates new vector containing the negation of THIS vector. O(n).
 
 template<class T>
-vnl_vector<T> vnl_vector<T>::operator- () const
+vnl_vector< typename vnl_numeric_traits<T>::signed_t> vnl_vector<T>::operator- () const
 {
-  vnl_vector<T> result(this->num_elmts);
-  for (size_t i = 0; i < this->num_elmts; i++)
-    result.data[i] = - this->data[i];           // negate element
+  vnl_vector<typename vnl_numeric_traits<T>::signed_t> result(this->num_elmts);
+  for (size_t i = 0; i < this->num_elmts; i++) {
+    result(i) = -this->data[i];           // negate element
+  }
   return result;
 }
 

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -352,10 +352,13 @@ class VNL_EXPORT vnl_vector_fixed
   }
 
   //:
-  vnl_vector_fixed<T,n> operator-() const
+  vnl_vector_fixed<typename vnl_numeric_traits<T>::signed_t,n> operator-() const
   {
-    vnl_vector_fixed<T,n> result;
-    self::sub( (T)0, data_, result.data_ );
+    vnl_vector_fixed<typename vnl_numeric_traits<T>::signed_t,n> result;
+    for(size_t i=0; i< n; ++i)
+    {
+      result[i] = -data_[i];
+    }
     return result;
   }
 

--- a/core/vnl/vnl_vector_fixed_ref.h
+++ b/core/vnl/vnl_vector_fixed_ref.h
@@ -133,8 +133,8 @@ class VNL_EXPORT vnl_vector_fixed_ref_const
   vnl_vector_fixed<T,n> apply(T (*f)(const T&)) const;
 
   //:
-  vnl_vector_fixed<T,n> operator-() const {
-    vnl_vector_fixed<T,n> result;
+  vnl_vector_fixed<typename vnl_numeric_traits<T>::signed_t,n> operator-() const {
+    vnl_vector_fixed<typename vnl_numeric_traits<T>::signed_t,n> result;
     sub( (T)0, data_, result.data_block() );
     return result;
   }


### PR DESCRIPTION
Resolves #881

The vnl_vector unary minus operator applied to
unsigned type and having a result of unsigned type (it should be signed).

vnl_vector<unsigned short> a(3) { 1, 1, 1 } ;
vnl_vector<short> b = -a;

vnl_vector<short> known= {-1, -1, 1 };

add test to demonstrate incorrect behavior of operator- When operator-() is used on an unsigned vector type, the results are wrong.
