### PR TITLE
ENH: vpgl_lvcs::set_utm

### DIFF
--- a/core/vpgl/tests/test_lvcs.cxx
+++ b/core/vpgl/tests/test_lvcs.cxx
@@ -15,6 +15,7 @@ test_lvcs()
   // results
   double x, y, z;
   int utm_zone;
+  bool south_flag;
 
 
   // ----- WGS84 lvcs -----
@@ -62,6 +63,14 @@ test_lvcs()
   TEST_NEAR("northing", y, orig_northing, 1e-3);
   TEST_NEAR("elevation", z, orig_elev, 1e-3);
   TEST("utm_zone", utm_zone, orig_utm_zone);
+
+  // origin in UTM with south_flag
+  lvcs_utm.get_utm_origin(x, y, z, utm_zone, south_flag);
+  TEST_NEAR("easting", x, orig_easting, 1e-3);
+  TEST_NEAR("northing", y, orig_northing, 1e-3);
+  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST("utm_zone", utm_zone, orig_utm_zone);
+  TEST("south_flag", south_flag, orig_south_flag);
 
   // origin in WGS84
   std::cout << "WGS84 origin\n";

--- a/core/vpgl/tests/test_lvcs.cxx
+++ b/core/vpgl/tests/test_lvcs.cxx
@@ -1,6 +1,76 @@
 #include <iostream>
+#include <iomanip>
 #include "testlib/testlib_test.h"
 #include "vpgl/vpgl_lvcs.h"
+
+void
+test_lvcs_force(double lat, double lon, double elev,
+                double easting, double northing,
+                int utm_zone, bool south_flag,
+                double meter_tol, double degree_tol)
+{
+  // report
+  std::cout << "\nTest UTM LVCS with zone/hemisphere\n"
+            << "(lat, lon) = (" << lat << ", " << lon << ")\n"
+            << "(easting, northing, utm_zone, south_flag) = ("
+            << easting << ", " << northing << ", "
+            << utm_zone << ", " << south_flag << ")\n";
+
+  // results
+  double x, y, z;
+  int utm_zone_result;
+  bool south_flag_result;
+
+  // LVCS
+  vpgl_lvcs lvcs(lat, lon, elev, vpgl_lvcs::utm,
+                 vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+
+  // force UTM zone
+  lvcs.set_utm(utm_zone, south_flag);
+
+  // test UTM zone
+  std::cout << "get_utm()\n";
+  lvcs.get_utm(utm_zone_result, south_flag_result);
+  TEST("utm_zone", utm_zone_result, utm_zone);
+  TEST("south_flag", south_flag_result, south_flag);
+
+  // test origin
+  std::cout << "get_utm_origin()\n";
+  lvcs.get_utm_origin(x, y, z, utm_zone_result, south_flag_result);
+  TEST_NEAR("easting", x, easting, meter_tol);
+  TEST_NEAR("northing", y, northing, meter_tol);
+  TEST_NEAR("elevation", z, elev, meter_tol);
+  TEST("utm_zone", utm_zone_result, utm_zone);
+  TEST("south_flag", south_flag_result, south_flag);
+
+  // test WGS84 global->local at origin
+  std::cout << "global_to_local(origin, WGS84)\n";
+  lvcs.global_to_local(lon, lat, elev, vpgl_lvcs::wgs84, x, y, z);
+  TEST_NEAR("local_x", x, 0.0, meter_tol);
+  TEST_NEAR("local_y", y, 0.0, meter_tol);
+  TEST_NEAR("local_z", z, 0.0, meter_tol);
+
+  // test UTM global->local at origin
+  std::cout << "global_to_local(origin, UTM)\n";
+  lvcs.global_to_local(easting, northing, elev, vpgl_lvcs::utm, x, y, z);
+  TEST_NEAR("local_x", x, 0.0, meter_tol);
+  TEST_NEAR("local_y", y, 0.0, meter_tol);
+  TEST_NEAR("local_z", z, 0.0, meter_tol);
+
+  // test WGS84 local->global at origin
+  std::cout << "local_to_global(origin, WGS84)\n";
+  lvcs.local_to_global(0.0, 0.0, 0.0, vpgl_lvcs::wgs84, x, y, z);
+  TEST_NEAR("longitude", x, lon, degree_tol);
+  TEST_NEAR("latitude", y, lat, degree_tol);
+  TEST_NEAR("elevation", z, elev, meter_tol);
+
+  // test UTM local->global at origin
+  std::cout << "local_to_global(origin, UTM)\n";
+  lvcs.local_to_global(0.0, 0.0, 0.0, vpgl_lvcs::utm, x, y, z);
+  TEST_NEAR("local_to_global UTM easting", x, easting, meter_tol);
+  TEST_NEAR("local_to_global UTM northing", y, northing, meter_tol);
+  TEST_NEAR("local_to_global UTM elevation", z, elev, meter_tol);
+}
 
 
 static void
@@ -17,6 +87,10 @@ test_lvcs()
   int utm_zone;
   bool south_flag;
 
+  // result tolerance
+  double meter_tol = 1e-3;
+  double degree_tol = 1e-6;
+
 
   // ----- WGS84 lvcs -----
   std::cout << "\nTest WGS84 LVCS\n";
@@ -27,27 +101,27 @@ test_lvcs()
   std::cout << "origin\n";
   lvcs_wgs84.get_origin(y, x, z);
 
-  TEST_NEAR("longitude", x, orig_lon, 1e-6);
-  TEST_NEAR("latitude", y, orig_lat, 1e-6);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("longitude", x, orig_lon, degree_tol);
+  TEST_NEAR("latitude", y, orig_lat, degree_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
 
   // local origin as (0,0,0)
   std::cout << "global_to_local(origin, WGS84)\n";
   lvcs_wgs84.global_to_local(orig_lon, orig_lat, orig_elev, vpgl_lvcs::wgs84,
                              x, y, z);
 
-  TEST_NEAR("local_x", x, 0.0, 1e-3);
-  TEST_NEAR("local_y", y, 0.0, 1e-3);
-  TEST_NEAR("local_z", z, 0.0, 1e-3);
+  TEST_NEAR("local_x", x, 0.0, meter_tol);
+  TEST_NEAR("local_y", y, 0.0, meter_tol);
+  TEST_NEAR("local_z", z, 0.0, meter_tol);
 
   // local origin -> WGS84
-  std::cout << "global_to_local(origin, WGS84)\n";
+  std::cout << "local_to_global(origin, WGS84)\n";
   lvcs_wgs84.local_to_global(0.0, 0.0, 0.0,
                              vpgl_lvcs::wgs84, x, y, z);
 
-  TEST_NEAR("longitude", x, orig_lon, 1e-6);
-  TEST_NEAR("latitude", y, orig_lat, 1e-6);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("longitude", x, orig_lon, degree_tol);
+  TEST_NEAR("latitude", y, orig_lat, degree_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
 
 
   // ----- UTM lvcs -----
@@ -56,19 +130,20 @@ test_lvcs()
                      vpgl_lvcs::DEG, vpgl_lvcs::METERS);
 
   // origin in UTM
-  std::cout << "origin\n";
+  std::cout << "get_utm_origin(x, y, z, zone)\n";
   lvcs_utm.get_utm_origin(x, y, z, utm_zone);
 
-  TEST_NEAR("easting", x, orig_easting, 1e-3);
-  TEST_NEAR("northing", y, orig_northing, 1e-3);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("easting", x, orig_easting, meter_tol);
+  TEST_NEAR("northing", y, orig_northing, meter_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
   TEST("utm_zone", utm_zone, orig_utm_zone);
 
   // origin in UTM with south_flag
+  std::cout << "get_utm_origin(x, y, z, zone, south)\n";
   lvcs_utm.get_utm_origin(x, y, z, utm_zone, south_flag);
-  TEST_NEAR("easting", x, orig_easting, 1e-3);
-  TEST_NEAR("northing", y, orig_northing, 1e-3);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("easting", x, orig_easting, meter_tol);
+  TEST_NEAR("northing", y, orig_northing, meter_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
   TEST("utm_zone", utm_zone, orig_utm_zone);
   TEST("south_flag", south_flag, orig_south_flag);
 
@@ -76,36 +151,60 @@ test_lvcs()
   std::cout << "WGS84 origin\n";
   lvcs_utm.get_origin(y, x, z);
 
-  TEST_NEAR("longitude", x, orig_lon, 1e-6);
-  TEST_NEAR("latitude", y, orig_lat, 1e-6);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("longitude", x, orig_lon, degree_tol);
+  TEST_NEAR("latitude", y, orig_lat, degree_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
 
   // local origin as (0,0,0)
   std::cout << "global_to_local(origin, UTM)\n";
   lvcs_utm.global_to_local(orig_easting, orig_northing, orig_elev, vpgl_lvcs::utm,
                            x, y, z);
 
-  TEST_NEAR("local_x", x, 0.0, 1e-3);
-  TEST_NEAR("local_y", y, 0.0, 1e-3);
-  TEST_NEAR("local_z", z, 0.0, 1e-3);
+  TEST_NEAR("local_x", x, 0.0, meter_tol);
+  TEST_NEAR("local_y", y, 0.0, meter_tol);
+  TEST_NEAR("local_z", z, 0.0, meter_tol);
 
   // local origin -> UTM
   std::cout << "local_to_global(origin, UTM)\n";
   lvcs_utm.local_to_global(0.0, 0.0, 0.0,
                            vpgl_lvcs::utm, x, y, z);
 
-  TEST_NEAR("easting", x, orig_easting, 1e-3);
-  TEST_NEAR("northing", y, orig_northing, 1e-3);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("easting", x, orig_easting, meter_tol);
+  TEST_NEAR("northing", y, orig_northing, meter_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
 
   // local origin -> WGS84
-  std::cout << "local_to_global(origin, WGS84)l\n";
+  std::cout << "local_to_global(origin, WGS84)\n";
   lvcs_utm.local_to_global(0.0, 0.0, 0.0,
                            vpgl_lvcs::wgs84, x, y, z);
 
-  TEST_NEAR("longitude", x, orig_lon, 1e-6);
-  TEST_NEAR("latitude", y, orig_lat, 1e-6);
-  TEST_NEAR("elevation", z, orig_elev, 1e-3);
+  TEST_NEAR("longitude", x, orig_lon, degree_tol);
+  TEST_NEAR("latitude", y, orig_lat, degree_tol);
+  TEST_NEAR("elevation", z, orig_elev, meter_tol);
+
+
+  // ----- UTM force_utm_zone/force_south_flag -----
+  // The WGS84 point (lat = 0, lon = 72) is both on the equator and on the
+  // border between UTM zones 18 & 19.  Determine the UTM coordinate
+  // with various forcing selections.
+  orig_lat = 0.001, orig_lon = -72.0001, orig_elev = 1000;
+
+  // default 18-north
+  test_lvcs_force(orig_lat, orig_lon, orig_elev,
+                  833967.414, 110.683, 18, 0,
+                  meter_tol, degree_tol);
+  // force 19-north
+  test_lvcs_force(orig_lat, orig_lon, orig_elev,
+                  166010.300, 110.683, 19, 0,
+                  meter_tol, degree_tol);
+  // force 18-south
+  test_lvcs_force(orig_lat, orig_lon, orig_elev,
+                  833967.414, 10e6 + 110.683, 18, 1,
+                  meter_tol, degree_tol);
+  // force 19-south
+  test_lvcs_force(orig_lat, orig_lon, orig_elev,
+                  166010.300, 10e6 + 110.683, 19, 1,
+                  meter_tol, degree_tol);
 
 }
 

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -73,6 +73,7 @@ vpgl_lvcs::vpgl_lvcs(const vpgl_lvcs & lvcs)
   , localUTMOrigin_X_East_(lvcs.localUTMOrigin_X_East_)
   , localUTMOrigin_Y_North_(lvcs.localUTMOrigin_Y_North_)
   , localUTMOrigin_Zone_(lvcs.localUTMOrigin_Zone_)
+  , localUTMOrigin_SouthFlag_(lvcs.localUTMOrigin_SouthFlag_)
 {
   if (lat_scale_ == 0.0 || lon_scale_ == 0.0)
     this->compute_scale();
@@ -95,6 +96,7 @@ vpgl_lvcs::operator=(const vpgl_lvcs & lvcs)
   localUTMOrigin_X_East_ = lvcs.localUTMOrigin_X_East_;
   localUTMOrigin_Y_North_ = lvcs.localUTMOrigin_Y_North_;
   localUTMOrigin_Zone_ = lvcs.localUTMOrigin_Zone_;
+  localUTMOrigin_SouthFlag_ = lvcs.localUTMOrigin_SouthFlag_;
   if (lat_scale_ == 0.0 || lon_scale_ == 0.0)
     this->compute_scale();
   return *this;
@@ -135,7 +137,8 @@ vpgl_lvcs::vpgl_lvcs(double orig_lat,
                 localCSOriginLon_ * local_to_degrees,
                 localUTMOrigin_X_East_,
                 localUTMOrigin_Y_North_,
-                localUTMOrigin_Zone_);
+                localUTMOrigin_Zone_,
+                localUTMOrigin_SouthFlag_);
     // std::cout << "utm origin zone: " << localUTMOrigin_Zone_ << ' ' << localUTMOrigin_X_East_ << " East " <<
     // localUTMOrigin_Y_North_ << " North" << std::endl;
     lat_scale_ = 0.0;
@@ -180,7 +183,8 @@ vpgl_lvcs::vpgl_lvcs(double orig_lat,
                 localCSOriginLon_ * local_to_degrees,
                 localUTMOrigin_X_East_,
                 localUTMOrigin_Y_North_,
-                localUTMOrigin_Zone_);
+                localUTMOrigin_Zone_,
+                localUTMOrigin_SouthFlag_);
     // std::cout << "utm origin zone: " << localUTMOrigin_Zone_ << ' ' << localUTMOrigin_X_East_ << " East  " <<
     // localUTMOrigin_Y_North_ << " North  elev: " << localCSOriginElev_ << std::endl;
   }
@@ -226,7 +230,8 @@ vpgl_lvcs::vpgl_lvcs(double lat_low,
                 localCSOriginLon_ * local_to_degrees,
                 localUTMOrigin_X_East_,
                 localUTMOrigin_Y_North_,
-                localUTMOrigin_Zone_);
+                localUTMOrigin_Zone_,
+                localUTMOrigin_SouthFlag_);
     // std::cout << "utm origin zone: " << localUTMOrigin_Zone_ << ' ' << localUTMOrigin_X_East_ << " East  " <<
     // localUTMOrigin_Y_North_ << " North" << std::endl;
   }
@@ -423,15 +428,8 @@ vpgl_lvcs::local_to_global(const double pointin_x,
   double aligned_y = pointin_y;
   local_transform(aligned_x, aligned_y);
 
-  // Check current system is in south hemisphere or north hemisphere
-  bool south_flag = false;
-  if (localCSOriginLat_ < 0)
-    south_flag = true;
-
   if (local_cs_name_ == vpgl_lvcs::utm)
   {
-
-
     if (global_cs_name == vpgl_lvcs::utm)
     {
       if (output_len_unit == METERS)
@@ -457,7 +455,7 @@ vpgl_lvcs::local_to_global(const double pointin_x,
                 local_lat,
                 local_lon,
                 local_elev,
-                south_flag);
+                localUTMOrigin_SouthFlag_);
 
     if (global_cs_name == vpgl_lvcs::wgs84)
     { // global values will be in degrees and in meters
@@ -901,7 +899,8 @@ vpgl_lvcs::read(std::istream & strm)
                 localCSOriginLon_ * local_to_degrees,
                 localUTMOrigin_X_East_,
                 localUTMOrigin_Y_North_,
-                localUTMOrigin_Zone_);
+                localUTMOrigin_Zone_,
+                localUTMOrigin_SouthFlag_);
     // std::cout << "utm origin zone: " << localUTMOrigin_Zone_ << ' ' << localUTMOrigin_X_East_ << " East  " <<
     // localUTMOrigin_Y_North_ << " North" << std::endl;
   }
@@ -1052,6 +1051,7 @@ vpgl_lvcs::b_write(vsl_b_ostream & os) const
   vsl_b_write(os, localUTMOrigin_X_East_);
   vsl_b_write(os, localUTMOrigin_Y_North_);
   vsl_b_write(os, localUTMOrigin_Zone_);
+  vsl_b_write(os, localUTMOrigin_SouthFlag_);
 }
 
 
@@ -1084,6 +1084,7 @@ vpgl_lvcs::b_read(vsl_b_istream & is)
       vsl_b_read(is, localUTMOrigin_X_East_);
       vsl_b_read(is, localUTMOrigin_Y_North_);
       vsl_b_read(is, localUTMOrigin_Zone_);
+      vsl_b_read(is, localUTMOrigin_SouthFlag_);
       break;
 
     default:

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -1077,12 +1077,33 @@ vpgl_lvcs::b_read(vsl_b_istream & is)
 {
   if (!is)
     return;
+  int val;
   short ver;
   vsl_b_read(is, ver);
   switch (ver)
   {
     case 1:
-      int val;
+      vsl_b_read(is, val);
+      local_cs_name_ = (vpgl_lvcs::cs_names)val;
+      vsl_b_read(is, localCSOriginLat_);
+      vsl_b_read(is, localCSOriginLon_);
+      vsl_b_read(is, localCSOriginElev_);
+      vsl_b_read(is, lat_scale_);
+      vsl_b_read(is, lon_scale_);
+      vsl_b_read(is, val);
+      geo_angle_unit_ = (vpgl_lvcs::AngUnits)val;
+      vsl_b_read(is, val);
+      localXYZUnit_ = (vpgl_lvcs::LenUnits)val;
+      vsl_b_read(is, lox_);
+      vsl_b_read(is, loy_);
+      vsl_b_read(is, theta_);
+      vsl_b_read(is, localUTMOrigin_X_East_);
+      vsl_b_read(is, localUTMOrigin_Y_North_);
+      vsl_b_read(is, localUTMOrigin_Zone_);
+      localUTMOrigin_SouthFlag_ = (localCSOriginLat_ < 0);
+      break;
+
+    case 2:
       vsl_b_read(is, val);
       local_cs_name_ = (vpgl_lvcs::cs_names)val;
       vsl_b_read(is, localCSOriginLat_);

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -151,7 +151,7 @@ class vpgl_lvcs : public vbl_ref_count
   void b_read(vsl_b_istream &is);
 
   //: Return IO version number;
-  short version() const { return 1; }
+  short version() const { return 2; }
 
 
   // INTERNALS-----------------------------------------------------------------

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -141,6 +141,9 @@ class vpgl_lvcs : public vbl_ref_count
   void get_utm_origin(double& x, double& y, double& elev, int& zone) const;
   void get_utm_origin(double& x, double& y, double& elev, int& zone, bool& south_flag) const;
 
+  void get_utm(int& zone, bool& south_flag) const;
+  void set_utm(int zone, bool south_flag);
+
   //: Binary save self to stream.
   void b_write(vsl_b_ostream &os) const;
 
@@ -216,6 +219,13 @@ inline void vpgl_lvcs::get_utm_origin(double& x, double& y, double& elev, int& z
   elev = localCSOriginElev_;
   south_flag = localUTMOrigin_SouthFlag_;
 }
+
+inline void vpgl_lvcs::get_utm(int& zone, bool& south_flag) const
+{
+  zone = localUTMOrigin_Zone_;
+  south_flag = localUTMOrigin_SouthFlag_;
+}
+
 
 //------------------------------------------------------------
 //: Return the compass alignment transform.

--- a/core/vpgl/vpgl_lvcs.h
+++ b/core/vpgl/vpgl_lvcs.h
@@ -139,6 +139,7 @@ class vpgl_lvcs : public vbl_ref_count
   bool operator==(vpgl_lvcs const& r) const;
 
   void get_utm_origin(double& x, double& y, double& elev, int& zone) const;
+  void get_utm_origin(double& x, double& y, double& elev, int& zone, bool& south_flag) const;
 
   //: Binary save self to stream.
   void b_write(vsl_b_ostream &os) const;
@@ -178,6 +179,7 @@ class vpgl_lvcs : public vbl_ref_count
   double localUTMOrigin_X_East_{0.0};  // in meters
   double localUTMOrigin_Y_North_{0.0}; // in meters
   int localUTMOrigin_Zone_{0};
+  bool localUTMOrigin_SouthFlag_{false};
 };
 
 //: return the scale for lat lon and elevation
@@ -202,10 +204,17 @@ inline void vpgl_lvcs::get_origin(double& lat, double& lon, double& elev) const
 
 inline void vpgl_lvcs::get_utm_origin(double& x, double& y, double& elev, int& zone) const
 {
+  bool south_flag = false;
+  get_utm_origin(x, y, elev, zone, south_flag);
+}
+
+inline void vpgl_lvcs::get_utm_origin(double& x, double& y, double& elev, int& zone, bool& south_flag) const
+{
   x = localUTMOrigin_X_East_;
   y = localUTMOrigin_Y_North_;
   zone = localUTMOrigin_Zone_;
   elev = localCSOriginElev_;
+  south_flag = localUTMOrigin_SouthFlag_;
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
`vpgl_lvcs::set_utm` for UTM based LVCS, to force the utm_zone and/or south_flag to a different value.  This is useful when the LVCS is near a UTM zone border and/or the equator, when it is often appropriate to force the LVCS to be defined relative to the neighboring UTM or opposite hemisphere.  Additional functionality to support this feature, and additional tests. 

@decrispell 

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ✅ Adds tests and baseline comparison (quantitative).
- ❌Adds Documentation.
