### PR TITLE
PERF: Speed up `vnl_sparse_matrix::operator()`

### DIFF
--- a/core/vnl/vnl_sparse_matrix.hxx
+++ b/core/vnl/vnl_sparse_matrix.hxx
@@ -413,16 +413,28 @@ T& vnl_sparse_matrix<T>::operator()(unsigned int r, unsigned int c)
 {
   assert((r < rows()) && (c < columns()));
   row& rw = elements[r];
-  typename row::iterator ri;
-  for (ri = rw.begin(); (ri != rw.end()) && ((*ri).first < c); ++ri)
-    /*nothing*/;
 
-  if ((ri == rw.end()) || ((*ri).first != c)) {
-    // Add new column to the row.
-    ri = rw.insert(ri, vnl_sparse_matrix_pair<T>(c,T()));
+  if (rw.empty())
+  {
+    rw.push_back(vnl_sparse_matrix_pair<T>(c, T()));
+    return rw.back().second;
   }
 
-  return (*ri).second;
+  if (c < rw.back().first)
+  {
+    // Because the last column number in the row is greater than `c`, the following iteration will stop before the end
+    // of the row.
+    typename row::iterator ri = rw.begin();
+    while (ri->first < c)
+      ++ri;
+
+    return (ri->first == c ? ri : rw.insert(ri, vnl_sparse_matrix_pair<T>(c, T())))->second;
+  }
+
+  if (c > rw.back().first)
+    rw.push_back(vnl_sparse_matrix_pair<T>(c, T()));
+
+  return rw.back().second;
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
Made access to the back of a row _O(1)_ (constant-time), rather than _O(n)_. Simplified the loop to find column `c` (in case it is not in the back).

Adding 1000+ columns to the end appears to become more than 5 times as fast. Retrieving existing values from any column appears to become slightly faster than before. Observed using Visual Studio 2022, Release.