### PR TITLE
fix unsigned char 2

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.hxx
@@ -795,15 +795,15 @@ template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::save_rect_shadow_info_overlay0(std::string const& path) const{
   size_t ni = rect_bview0_.ni(), nj = rect_bview0_.nj(); 
   int conv = 8;
-  if(std::is_same<PIX_T, unsigned char>::value)
+  if(std::is_same<PIX_T, vxl_byte>::value)
     conv = 1;
-  vil_image_view<unsigned char> temp(ni, nj, 3);
-  temp.fill(0);
+  vil_image_view<vxl_byte> temp(ni, nj, 3);
+  temp.fill(vxl_byte(0));
   for(size_t j = 0;j<nj; ++j)
     for(size_t i = 0;i<ni; ++i){
-      unsigned char s = shadow_fwd_(i,j)*250.0f;
-      unsigned char ss = shadow_step_fwd_(i,j)*250.0f;
-      unsigned char v0 = rect_bview0_(i,j)/conv;
+      vxl_byte s = shadow_fwd_(i,j)*250.0f;
+      vxl_byte ss = shadow_step_fwd_(i,j)*250.0f;
+      vxl_byte v0 = rect_bview0_(i,j)/conv;
       if(v0>255) v0 = 255;
       if(ss>25.0)
         temp(i,j,1) = ss;
@@ -823,16 +823,16 @@ void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::save_rect_shadow_info_overlay0(std::s
 template <class CAM_T, class PIX_T>
 void bsgm_prob_pairwise_dsm<CAM_T, PIX_T>::save_rect_shadow_info_overlay1(std::string const& path) const{
   size_t ni = rect_bview1_.ni(), nj = rect_bview1_.nj(); 
-  vil_image_view<unsigned char> temp(ni, nj, 3);
-  temp.fill(unsigned char(0));
+  vil_image_view<vxl_byte> temp(ni, nj, 3);
+  temp.fill(vxl_byte(0));
   int conv = 8;
-  if(std::is_same<PIX_T, unsigned char>::value)
+  if(std::is_same<PIX_T, vxl_byte>::value)
     conv = 1;
   for(size_t j = 0;j<nj; ++j)
     for(size_t i = 0;i<ni; ++i){
-      unsigned char s = shadow_rev_(i,j)*250.0f;
-      unsigned char ss = shadow_step_rev_(i,j)*250.0f;
-      unsigned char v1 = rect_bview1_(i,j)/conv;
+      vxl_byte s = shadow_rev_(i,j)*250.0f;
+      vxl_byte ss = shadow_step_rev_(i,j)*250.0f;
+      vxl_byte v1 = rect_bview1_(i,j)/conv;
       if(v1>255) v1 = 255;
       if(ss>25.0)
         temp(i,j,1) = ss;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

:no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
:no_entry_sign:  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
:no_entry_sign: --> Adds tests and baseline comparison (quantitative).
:no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
