### PR TITLE
Speed up `vnl_sparse_matrix::get(r, c)`, let "const" `operator()` overload call `get(r, c)`

### DIFF
--- a/core/vnl/vnl_sparse_matrix.hxx
+++ b/core/vnl/vnl_sparse_matrix.hxx
@@ -442,15 +442,7 @@ T& vnl_sparse_matrix<T>::operator()(unsigned int r, unsigned int c)
 template <class T>
 T vnl_sparse_matrix<T>::operator()(unsigned int r, unsigned int c) const
 {
-  assert((r < rows()) && (c < columns()));
-  row const& rw = elements[r];
-  typename row::const_iterator ri = rw.begin();
-  while (ri != rw.end() && (*ri).first < c)
-    ++ri;
-  if (ri == rw.end() || (*ri).first != c)
-    return T(); // uninitialised value (default constructor) is returned
-  else
-    return (*ri).second;
+  return this->get(r, c);
 }
 
 //------------------------------------------------------------

--- a/core/vnl/vnl_sparse_matrix.hxx
+++ b/core/vnl/vnl_sparse_matrix.hxx
@@ -453,13 +453,19 @@ T vnl_sparse_matrix<T>::get(unsigned int r, unsigned int c) const
 {
   assert((r < rows()) && (c < columns()));
   row const& rw = elements[r];
+
+  if (rw.empty() || c > rw.back().first)
+    return T();
+
+  // Because at this point `rw.back().first >= c`, the following iteration will stop before the end of the row.
   typename row::const_iterator ri = rw.begin();
-  while (ri != rw.end() && (*ri).first < c)
+  while (ri->first < c)
     ++ri;
-  if (ri == rw.end() || (*ri).first != c)
-    return T(); // uninitialised value (default constructor) is returned
+
+  if (ri->first == c)
+    return ri->second;
   else
-    return (*ri).second;
+    return T();
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
Speed up `vnl_sparse_matrix::get(r, c)`, similar to 
 - pull request https://github.com/vxl/vxl/pull/926
 - pull request https://github.com/vxl/vxl/pull/928

Let the "const" `vnl_sparse_matrix::operator()` overload call `vnl_sparse_matrix::get(r, c)`.
