### PR TITLE
Add tagged record IXSHDL in replacement sensor model

### DIFF
--- a/core/vpgl/file_formats/vpgl_nitf_RSM_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_RSM_camera.cxx
@@ -43,20 +43,28 @@ vpgl_nitf_RSM_camera::init(vil_nitf2_image * nitf_image, bool verbose)
   vil_nitf2_tagged_record_sequence::const_iterator tres_itr;
   vil_nitf2_image_subheader *hdr;
   size_t hcount = 0, hindex = 0;
+  int ixshdl, ixsofl;
   for (unsigned i = 0; i<headers.size(); ++i)
-    if(headers[i]->get_property("IXSHD", isxhd_tres_)){
+    if(headers[i]->get_property("IXSHDL", ixshdl)){
+      std::cout << "IXSHDL PRESENT, COUNT " << ixshdl << std::endl;
+      if(headers[i]->get_property("IXSOFL", ixsofl))
+        std::cout << "IXSOFL PRESENT " << ixsofl << std::endl;
+      if(headers[i]->get_property("IXSHD", isxhd_tres_)){
+        std::cout << "IXSHD PRESENT " << isxhd_tres_.size() << std::endl;
         for (tres_itr = isxhd_tres_.begin(); tres_itr != isxhd_tres_.end(); ++tres_itr)
           {
             std::string type = (*tres_itr)->name();
             if (type == "RSMPCA"){ // looking for "RSMPCA..."
+              std::cout << "RSMPCA PRESENT" << std::endl;
               hindex = i;
               hcount++;
               hdr = headers[i];
             }
           }
+      }
     }
   if(hcount != 1){
-    std::cout << "IXSHD Property failed in vil_nitf2_image_subheader: header count " << hcount << std::endl;
+    std::cout << "FAILED TO FIND RSM TREs in any nitf2_image_subheader: header count " << hcount << std::endl;
     nitf_image->set_current_image(0);
     return false;
   }


### PR DESCRIPTION
Read additional fields in NITF RSM metadata.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

 :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
:no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
:no_entry_sign: --> Adds tests and baseline comparison (quantitative).
:no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
