### PR TITLE
add variance calc to bvgl_register_ptsets_3d_rigid

### DIFF
--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -26,6 +26,7 @@
 #include <vnl/vnl_math.h>
 #include <vgl/vgl_pointset_3d.h>
 #include <vgl/vgl_vector_3d.h>
+#include <vgl/vgl_quadric_3d.h>
 #include <bvgl/bvgl_k_nearest_neighbors_3d.h>
 #include <vnl/vnl_random.h>
 // a display of progress as a moving '+' symbol
@@ -131,6 +132,13 @@ public:
   T min_exhaustive_error() const {return min_exhaustive_error_;}
   T min_ransac_error() const {return min_ransac_error_;}
   T min_analytic_error() const {return min_analytic_error_;}
+  T error_variance() const {return error_variance_;}
+
+  //: the grid points used for minimize analytic
+  std::vector<vgl_point_3d<T> > analytic_grid_pts() const {return analytic_grid_pts_;}
+
+  //: the coefficients after fitting quadric patch to grid points
+  vgl_quadric_3d<T> paraboloid_linear() const {return paraboloid_linear_;}
   
 
 
@@ -139,6 +147,9 @@ public:
 
   //: error defined in terms of distances to population fractions
   T distr_error(vgl_vector_3d<T> const& t);
+
+  //: error variance movable and fixed closest points
+  T error_var(vgl_vector_3d<T> const& t);
 
   //: the mean error vector
   vgl_vector_3d<T>  mean_error(vgl_vector_3d<T> const& t);
@@ -161,6 +172,8 @@ public:
   // modifies tz component of analytic translation. tx, ty are analytic min values
   bool minimize_mean_z_error();
 
+  bool minimize_mean_z_error(vgl_vector_3d<T> const& initial_t);
+
   //: does this instance have valid pointsets
   bool valid_instance() const {return (fixed_.size()>0 && movable_.size()>0);}
 
@@ -174,6 +187,7 @@ public:
   T min_exhaustive_error_ = std::numeric_limits<T>::max();
   T min_ransac_error_ = std::numeric_limits<T>::max();
   T min_analytic_error_ = std::numeric_limits<T>::max();
+  T error_variance_ = std::numeric_limits<T>::max();
   vgl_vector_3d<T> exhaustive_t_ = vgl_vector_3d<T>(T(0),T(0),T(0));
 
   vgl_pointset_3d<T> fixed_;
@@ -183,6 +197,8 @@ public:
   vgl_vector_3d<T> best_ransac_t_;
   vgl_vector_3d<T> analytic_t_;
 
+  std::vector<vgl_point_3d<T> > analytic_grid_pts_;
+  vgl_quadric_3d<T> paraboloid_linear_;
 };
 
 

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
@@ -93,6 +93,51 @@ T bvgl_register_ptsets_3d_rigid<T>::distr_error(vgl_vector_3d<T> const& t){
 }
 
 template <class T>
+T  bvgl_register_ptsets_3d_rigid<T>::error_var(vgl_vector_3d<T> const& t)
+{
+  size_t n = frac_trans_.npts();
+  T error = T(0);
+  T cnt = T(0);
+
+  // calculate mean error/distance
+  for (size_t i = 0; i<n; ++i) {
+    const vgl_point_3d<T>& p = frac_trans_.p(i);
+    vgl_point_3d<T> tp(p.x()+t.x(), p.y()+t.y(), p.z()+t.z());
+    vgl_point_3d<T> cp;
+    if (!knn_fixed_.closest_point(tp, cp)) {
+      std::cout << "KNN index failed to find neighbors" << std::endl;
+      return std::numeric_limits<T>::max();
+    }
+    T d = vgl_distance<T>(tp, cp);
+    if (d > outlier_thresh_)
+      continue;
+    cnt += T(1);
+    error += d;
+  }
+  error /= cnt; // error = mean distance
+
+  T mean_error = error;
+  T var = T(0);
+  
+  for (size_t i = 0; i<n; ++i) {
+    const vgl_point_3d<T>& p = frac_trans_.p(i);
+    vgl_point_3d<T> tp(p.x()+t.x(), p.y()+t.y(), p.z()+t.z());
+    vgl_point_3d<T> cp;
+    if (!knn_fixed_.closest_point(tp, cp)) {
+      std::cout << "KNN index failed to find neighbors" << std::endl;
+      return std::numeric_limits<T>::max();
+    }
+    T d = vgl_distance<T>(tp, cp);
+    if (d > outlier_thresh_)
+      continue;
+
+    var += ((d - mean_error)*(d - mean_error)) / cnt;
+  }
+
+  return var;
+}
+
+template <class T>
 bool bvgl_register_ptsets_3d_rigid<T>::minimize_exhaustive()
 {
   if (fixed_.npts() == 0 || frac_trans_.npts() == 0) {
@@ -185,6 +230,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_analytic(vgl_vector_3d<T> const&
       grid_pts.emplace_back(x, y, err);
     }
   }
+  analytic_grid_pts_ = grid_pts;
   std::cout << std::endl; // end progress display
 
   vgl_fit_xy_paraboloid_3d<T> xyp(grid_pts);
@@ -198,11 +244,17 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_analytic(vgl_vector_3d<T> const&
   vgl_point_2d<T> min_xy = xyp.extremum_point();
   analytic_t_ = vgl_vector_3d<T>(min_xy.x(), min_xy.y(), z);
   min_analytic_error_ = distr_error(analytic_t_);
+  error_variance_ = error_var(analytic_t_);
+  paraboloid_linear_ = xyp.paraboloid_linear();
   return true;
 }
 template <class T>
 bool bvgl_register_ptsets_3d_rigid<T>::minimize_mean_z_error(){
-  vgl_vector_3d<T> initial_t = analytic_t_;
+  minimize_mean_z_error(analytic_t_);
+}
+
+template <class T>
+bool bvgl_register_ptsets_3d_rigid<T>::minimize_mean_z_error(vgl_vector_3d<T> const& initial_t){
   std::vector<std::pair<T, T> > tz_error_vals;
   T min_tz = initial_t.z() - 0.3, max_tz = initial_t.z() + 0.31;
   std::cout << "refine tz plot " << std::endl;
@@ -235,7 +287,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_mean_z_error(){
   }
   coef = svd.solve(b);
   double tz_min = -coef[1]/coef[0];
-  analytic_t_.set(analytic_t_.x(), analytic_t_.y(), tz_min);
+  analytic_t_.set(initial_t.x(), initial_t.y(), tz_min);
   min_analytic_error_ = distr_error(analytic_t_);
   return true;
 }

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.hxx
@@ -250,7 +250,7 @@ bool bvgl_register_ptsets_3d_rigid<T>::minimize_analytic(vgl_vector_3d<T> const&
 }
 template <class T>
 bool bvgl_register_ptsets_3d_rigid<T>::minimize_mean_z_error(){
-  minimize_mean_z_error(analytic_t_);
+  return minimize_mean_z_error(analytic_t_);
 }
 
 template <class T>


### PR DESCRIPTION
- added error variance calculation to contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid
- updated class to store linear coefficients after fitting quadric patch during minimize_analytic
- change minimize_mean_z_error so it can now be run using a specified initial_t vector


@decrispell 

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] Adds Documentation.

