### PR TITLE
ENH: utm_zone

### DIFF
--- a/core/vpgl/vpgl_utm.cxx
+++ b/core/vpgl/vpgl_utm.cxx
@@ -330,7 +330,11 @@ vpgl_utm::transform(double lat, double lon,
   if (force_utm_zone >= 0) {
     utm_zone = force_utm_zone;
   } else {
-    utm_zone = int((lon + 180) / 6.0) + 1;
+    // normalize longitude to [0,360)
+    double x = std::fmod(lon + 180.0, 360.0);
+    x = (x < 0) ? x + 360 : x;
+    // utm zone on range [1, 60]
+    utm_zone = int(x / 6.0) + 1;
   }
 
   // UTM north vs. south


### PR DESCRIPTION
`vpgl_utm::transform` calculate utm_zone from longitude values that exceed the typical range of [-180, 180). This permits excursions past the antimeridian which may result in longitude values outside the typical range (e.g., -180.1 or 180.1 degrees).  Includes unit tests to confirm expected operation.

@decrispell 

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
