### PR TITLE
ENH: lvcs antimeridian

### DIFF
--- a/core/vpgl/tests/test_lvcs.cxx
+++ b/core/vpgl/tests/test_lvcs.cxx
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <iomanip>
+#include <vector>
 #include "testlib/testlib_test.h"
 #include "vpgl/vpgl_lvcs.h"
 
@@ -70,6 +71,298 @@ test_lvcs_force(double lat, double lon, double elev,
   TEST_NEAR("local_to_global UTM easting", x, easting, meter_tol);
   TEST_NEAR("local_to_global UTM northing", y, northing, meter_tol);
   TEST_NEAR("local_to_global UTM elevation", z, elev, meter_tol);
+}
+
+
+// test LVCS local->global, offset local input, WGS84 output
+void
+_test_lvcs_local_to_global_wgs84(
+    vpgl_lvcs lvcs,
+    double lon, double lat, double elev,
+    double xoff, double yoff, double zoff,
+    double meter_tol, double degree_tol,
+    std::string message="")
+{
+  // report
+  std::cout << "local_to_global(offset ["
+            << xoff << ", " << yoff << ", " << zoff << "]) -> WGS84";
+  if (!message.empty())
+    std::cout << ", " << message;
+  std::cout << "\n";
+
+  // local_to_global
+  double x, y, z;
+  lvcs.local_to_global(xoff, yoff, zoff, vpgl_lvcs::wgs84, x, y, z,
+                       vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+  std::cout << "produced (lon, lat, elev) = ("
+            << x << ", " << y << ", " << z << ")\n";
+
+  // test returned longitude moved in the expected direction
+  if (xoff > 0)
+    TEST_EQUAL("longitude positive shift", x > lon, true);
+  else if (xoff < 0)
+    TEST_EQUAL("longitude negative shift", x < lon, true);
+  else
+    TEST_NEAR("longitude", x, lon, meter_tol);
+
+  // test returned latitude moved in the expected direction
+  if (yoff > 0)
+    TEST_EQUAL("latitude positive shift", y > lat, true);
+  else if (yoff < 0)
+    TEST_EQUAL("latitude negative shift", y < lat, true);
+  else
+    TEST_NEAR("latitude", y, lat, meter_tol);
+
+  // test z
+  TEST_NEAR("elevation", z, elev + zoff, meter_tol);
+}
+
+
+// test LVCS local->global, offset local input, UTM output
+void
+_test_lvcs_local_to_global_utm(
+    vpgl_lvcs lvcs,
+    double easting, double northing, double elev,
+    double xoff, double yoff, double zoff,
+    double meter_tol,
+    std::string message="")
+{
+  // report
+  std::cout << "local_to_global(offset ["
+            << xoff << ", " << yoff << ", " << zoff << "]) -> UTM";
+  if (!message.empty())
+    std::cout << ", " << message;
+  std::cout << "\n";
+
+  // local_to_global
+  double x, y, z;
+  lvcs.local_to_global(xoff, yoff, zoff, vpgl_lvcs::utm, x, y, z,
+                       vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+  std::cout << "produced (easting, northing, elev) = ("
+            << x << ", " << y << ", " << z << ")\n";
+
+  // test x/y/z
+  TEST_NEAR("easting", x, easting + xoff, meter_tol);
+  TEST_NEAR("northing", y, northing + yoff, meter_tol);
+  TEST_NEAR("elevation", z, elev + zoff, meter_tol);
+}
+
+
+// test LVCS global->local, offset WGS84 input, local output
+void
+_test_lvcs_global_to_local_wgs84(
+    vpgl_lvcs lvcs,
+    double lon, double lat, double elev,
+    double lon_off, double lat_off, double elev_off,
+    double meter_tol,
+    std::string message="")
+{
+  // report
+  std::cout << "global_to_local(WGS84 offset ["
+            << lon_off << ", " << lat_off << ", " << elev_off << "]";
+  if (!message.empty())
+    std::cout << ", " << message;
+  std::cout << ")\n";
+
+  // global_to_local
+  double x, y, z;
+  lvcs.global_to_local(lon + lon_off, lat + lat_off, elev + elev_off,
+                       vpgl_lvcs::wgs84, x, y, z);
+  std::cout << "produced (x, y, z) = ("
+            << x << ", " << y << ", " << z << ")\n";
+
+  // test returned x moved in the expected direction
+  if (lon_off > 0)
+    TEST_EQUAL("local_x positive shift", x > 0, true);
+  else if (lon_off < 0)
+    TEST_EQUAL("local_x negative shift", x < 0, true);
+  else
+    TEST_NEAR("local_x", x, 0.0, meter_tol);
+
+  // test returned y moved in the expected direction
+  if (lat_off > 0)
+    TEST_EQUAL("local_y positive shift", y > 0, true);
+  else if (lat_off < 0)
+    TEST_EQUAL("local_y negative shift", y < 0, true);
+  else
+    TEST_NEAR("local_y", y, 0.0, meter_tol);
+
+  // test z
+  TEST_NEAR("local_z", z, elev_off, meter_tol);
+}
+
+
+// test LVCS global->local, offset UTM input, local output
+void
+_test_lvcs_global_to_local_utm(
+    vpgl_lvcs lvcs,
+    double easting, double northing, double elev,
+    double easting_off, double northing_off, double elev_off,
+    double meter_tol,
+    std::string message="")
+{
+  // report
+  std::cout << "global_to_local(UTM offset [" << easting_off << ", "
+            << northing_off << ", " << elev_off << "]";
+  if (!message.empty())
+    std::cout << ", " << message;
+  std::cout << ")\n";
+
+  // global_to_local
+  double x, y, z;
+  lvcs.global_to_local(easting + easting_off, northing + northing_off,
+                       elev + elev_off, vpgl_lvcs::utm, x, y, z);
+
+  // test x/y/z
+  TEST_NEAR("local_x", x, easting_off, meter_tol);
+  TEST_NEAR("local_y", y, northing_off, meter_tol);
+  TEST_NEAR("local_z", z, elev_off, meter_tol);
+}
+
+
+void
+_test_lvcs_antimeridian(vpgl_lvcs lvcs,
+                        double lon, double lat, double elev,
+                        double meter_tol, double degree_tol)
+{
+  // results
+  double x, y, z;
+  double easting, northing;
+  int utm_zone;
+  bool south_flag;
+
+  // meter offsets as (x, y, z)
+  std::vector<std::vector<double> > meter_offsets = {
+      {0, 0, 0},
+      {100, 100, 100},
+      {-100, -100, -100},
+  };
+
+  // WGS84 offsets as (lon, lat, elev)
+  std::vector<std::vector<double> > wgs84_offsets = {
+      {0, 0, 0},
+      {0.01, 0.01, 100},
+      {-0.01, -0.01, -100},
+  };
+
+  // LVCS type
+  auto cs_name = lvcs.get_cs_name();
+  std::string cs_str = vpgl_lvcs::cs_name_strings[cs_name];
+
+  // positive/negative longitude
+  double plon = (lon > 0) ? lon : lon + 360.0;
+  double nlon = (lon < 0) ? lon : lon - 360.0;
+
+  // report
+  std::cout << "\nTest " << cs_str << " lvcs around antimeridian\n"
+            << "(lon, lat, elev) = (" << lon << ", "
+            << lat << ", " << elev << ")\n"
+            << "positive/negative lon = " << plon << "/" << nlon << "\n";
+
+  if (cs_name == vpgl_lvcs::utm)
+  {
+    lvcs.get_utm_origin(easting, northing, z, utm_zone, south_flag);
+    std::cout << "(easting, northing, utm_zone, south_flag) = ("
+              << easting << ", " << northing << ", "
+              << utm_zone << ", " << south_flag << ")\n";
+  }
+  std::cout << "\n";
+
+  // WGS84 origin
+  std::cout << "WGS84 origin\n";
+  lvcs.get_origin(y, x, z);
+  TEST_NEAR("longitude", x, lon, degree_tol);
+  TEST_NEAR("latitude", y, lat, degree_tol);
+  TEST_NEAR("elevation", z, elev, meter_tol);
+
+  // local->global, offset local input, WGS84 output
+  for (auto & offset : meter_offsets)
+  {
+    _test_lvcs_local_to_global_wgs84(lvcs, lon, lat, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol, degree_tol);
+  }
+
+  // local->global, offset local input, UTM output
+  if (cs_name == vpgl_lvcs::utm)
+  {
+    for (auto & offset : meter_offsets)
+    {
+      _test_lvcs_local_to_global_utm(lvcs, easting, northing, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol);
+    }
+  }
+
+  // global->local, offset WGS84 input, local output
+  for (auto & offset : wgs84_offsets)
+  {
+    // standard input
+    _test_lvcs_global_to_local_wgs84(lvcs, lon, lat, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol);
+
+    // positive longitude
+    _test_lvcs_global_to_local_wgs84(lvcs, plon, lat, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol, "positive longitude");
+
+    // negative longitude
+    _test_lvcs_global_to_local_wgs84(lvcs, nlon, lat, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol, "negative longitude");
+  }
+
+  // global->local, offset UTM input, local output
+  if (cs_name == vpgl_lvcs::utm)
+  {
+    for (auto & offset : meter_offsets)
+    {
+      _test_lvcs_global_to_local_utm(lvcs, easting, northing, elev,
+                                     offset[0], offset[1], offset[2],
+                                     meter_tol);
+    }
+  }
+}
+
+
+void
+test_lvcs_antimeridian(double lon, double lat, double elev,
+                       double meter_tol, double degree_tol)
+{
+  // WGS84 LVCS
+  vpgl_lvcs lvcs_wgs84(lat, lon, elev, vpgl_lvcs::wgs84,
+                       vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+  _test_lvcs_antimeridian(lvcs_wgs84, lon, lat, elev,
+                          meter_tol, degree_tol);
+
+  // UTM LVCS
+  vpgl_lvcs lvcs_utm(lat, lon, elev, vpgl_lvcs::utm,
+                     vpgl_lvcs::DEG, vpgl_lvcs::METERS);
+  _test_lvcs_antimeridian(lvcs_utm, lon, lat, elev,
+                          meter_tol, degree_tol);
+
+  // UTM zone
+  int utm_zone;
+  bool south_flag;
+  lvcs_utm.get_utm(utm_zone, south_flag);
+
+  // For UTM zone 1, also test in UTM zone 60
+  if (utm_zone == 1)
+  {
+    std::cout << "\nForce to UTM zone 60 (east-most zone)";
+    lvcs_utm.set_utm(60, south_flag);
+    _test_lvcs_antimeridian(lvcs_utm, lon, lat, elev,
+                            meter_tol, degree_tol);
+  }
+  // For UTM zone 60, also test in UTM zone 1
+  else if (utm_zone == 60)
+  {
+    std::cout << "\nForce to UTM zone 1 (west-most zone)";
+    lvcs_utm.set_utm(1, south_flag);
+    _test_lvcs_antimeridian(lvcs_utm, lon, lat, elev,
+                            meter_tol, degree_tol);
+  }
 }
 
 
@@ -205,6 +498,15 @@ test_lvcs()
   test_lvcs_force(orig_lat, orig_lon, orig_elev,
                   166010.300, 10e6 + 110.683, 19, 1,
                   meter_tol, degree_tol);
+
+
+  // ----- Antimeridian -----
+  // Test points near the antimeridian, where longitude changes from
+  // 180 degrees to -180 degrees.
+  test_lvcs_antimeridian(-179.0, 71.0, 100.0, meter_tol, degree_tol);
+  test_lvcs_antimeridian( 179.0, 71.0, 100.0, meter_tol, degree_tol);
+  test_lvcs_antimeridian(-181.0, 71.0, 100.0, meter_tol, degree_tol);
+  test_lvcs_antimeridian( 181.0, 71.0, 100.0, meter_tol, degree_tol);
 
 }
 

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -819,10 +819,16 @@ vpgl_lvcs::global_to_local(const double pointin_lon,
     local_lat = local_lon = local_elev = 0.0; // dummy initialisation
   }
 
+  // longitude difference in degrees, wrapped to range [-180, 180)
+  double dlon = local_lon - localCSOriginLon_ * local_to_degrees;
+  dlon = std::fmod(dlon + 180.0, 360.0);
+  dlon = (dlon < 0) ? dlon + 360.0 : dlon;
+  dlon = dlon - 180.0;
+
   // Now compute the x, y, z of the point in local vetical CS
   // first convert the local_lat to radians and local cs origin to meters
   pointout_y = (local_lat * DEGREES_TO_RADIANS - localCSOriginLat_ * local_to_radians) / lat_scale_;
-  pointout_x = (local_lon * DEGREES_TO_RADIANS - localCSOriginLon_ * local_to_radians) / lon_scale_;
+  pointout_x = (dlon * DEGREES_TO_RADIANS) / lon_scale_;
 
   pointout_z = local_elev - localCSOriginElev_ * local_to_meters;
 

--- a/core/vpgl/vpgl_lvcs.cxx
+++ b/core/vpgl/vpgl_lvcs.cxx
@@ -482,6 +482,15 @@ vpgl_lvcs::local_to_global(const double pointin_x,
                 local_elev,
                 localUTMOrigin_SouthFlag_);
 
+    // unwrap local_lon relative to the LVCS origin
+    // handles antimeridian where longitude changes from -180 to 180
+    double dlon = local_lon - localCSOriginLon_ * local_to_degrees;
+    dlon = std::fmod(dlon + 180.0, 360.0);
+    dlon = (dlon < 0) ? dlon + 360.0 : dlon;
+    dlon = dlon - 180.0;
+
+    local_lon = dlon + localCSOriginLon_ * local_to_degrees;
+
     if (global_cs_name == vpgl_lvcs::wgs84)
     { // global values will be in degrees and in meters
       global_lat = local_lat;


### PR DESCRIPTION
Handle `vpgl_lvcs` corner cases around the antimeridian, where longitude changes from 180° to -180°.
- `vpgl_lvcs::local_to_global` for UTM LVCS, unwrap longitude relative to the origin.
- `vpgl_lvcs::global_to_local` limit the longitude difference relative to the LVCS origin to the range [-180, 180).  

Includes unit tests for expected operation.

@decrispell 

## PR Checklist
- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌  Adds Documentation.
