### PR TITLE
BUG: Fix `is_equal` support when vnl_vector or matrix contains NaN

### DIFF
--- a/core/vnl/tests/test_matrix_fixed.cxx
+++ b/core/vnl/tests/test_matrix_fixed.cxx
@@ -407,6 +407,12 @@ test_float()
   TEST("m.update([4],1,1)",
        ((m3 = 4), (m.update(m3, 1, 1)), (m(0, 0) == 0 && m(0, 1) == -2 && m(1, 0) == 2 && m(1, 1) == 4)),
        true);
+
+  constexpr auto quiet_NaN = std::numeric_limits<float>::quiet_NaN();
+  TEST("vnl_float_2x2 { NaN, ... } != { 0.0f, ... }", vnl_float_2x2(quiet_NaN) != vnl_float_2x2(0.0f), true);
+  TEST("vnl_float_2x2 { NaN, ... } is_equal { 0.0f, ... } is false",
+       vnl_float_2x2(quiet_NaN).is_equal(vnl_float_2x2(0.0f), 0.0f),
+       false);
 }
 
 static void

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -616,6 +616,12 @@ vnl_vector_test_float()
   }
 
   TEST("vnl_vector_ssd", vnl_vector_ssd(vnl_vector<float>(4, 0.0f), vnl_vector<float>(4, 1.0f)), 4.0);
+
+  constexpr auto quiet_NaN = std::numeric_limits<float>::quiet_NaN();
+  TEST("vnl_vector { NaN } != { 0.0f }", vnl_vector<float>(1, quiet_NaN) != vnl_vector<float>(1, 0.0f), true);
+  TEST("vnl_vector { NaN } is_equal { 0.0f } is false",
+       vnl_vector<float>(1, quiet_NaN).is_equal(vnl_vector<float>(1, 0.0f), 0.0f),
+       false);
 }
 
 void

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -1095,7 +1095,7 @@ bool vnl_matrix<T>::is_equal(vnl_matrix<T> const& rhs, double tol) const
 
   for (unsigned int i = 0; i < this->rows(); ++i)
     for (unsigned int j = 0; j < this->columns(); ++j)
-      if (vnl_math::abs(this->data[i][j] - rhs.data[i][j]) > tol)
+      if (!(vnl_math::abs(this->data[i][j] - rhs.data[i][j]) <= tol))
         return false;                                    // difference greater than tol
 
   return true;

--- a/core/vnl/vnl_matrix_fixed.hxx
+++ b/core/vnl/vnl_matrix_fixed.hxx
@@ -701,7 +701,7 @@ bool vnl_matrix_fixed<T,nrows,ncols>
 
   for (unsigned int i = 0; i < nrows; ++i)
     for (unsigned int j = 0; j < ncols; ++j)
-      if (vnl_math::abs(this->data_[i][j] - rhs.data_[i][j]) > tol)
+      if (!(vnl_math::abs(this->data_[i][j] - rhs.data_[i][j]) <= tol))
         return false;                                    // difference greater than tol
 
   return true;

--- a/core/vnl/vnl_vector.hxx
+++ b/core/vnl/vnl_vector.hxx
@@ -740,7 +740,7 @@ bool vnl_vector<T>::is_equal(vnl_vector<T> const& rhs, double tol) const
   if (this->size() != rhs.size())                           //Size different ?
     return false;
   for (size_t i = 0; i < size(); i++)
-    if (vnl_math::abs(this->data[i] - rhs.data[i]) > tol)    //Element different ?
+    if (!(vnl_math::abs(this->data[i] - rhs.data[i]) <= tol)) //Element different ?
       return false;
 
   return true;


### PR DESCRIPTION
It appears that `is_equal` would sometimes return `true` when a vnl_vector or
matrix would contain the floating point value NaN. Fixed by adjusting the
condition for doing a `return false` out of the `for` loop, in `is_equal`.

Added unit tests that compare a vnl_vector or matrix that contains NaN and one
that just contains the value zero.

So with this commit, `{ NaN, ..., NaN } is_equal { 0, ..., 0 }` will return _false_, as it should.