### PR TITLE
ENH: Add `vnl_vector_fixed::is_equal`, just like `vnl_vector::is_equal`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 5.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 5.3.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vnl/tests/test_vector.cxx
+++ b/core/vnl/tests/test_vector.cxx
@@ -347,7 +347,33 @@ vnl_vector_test_int()
          (out_values[0] == minus_v2[0] && out_values[1] == minus_v2[1] && out_values[2] == minus_v2[2] &&
           out_values[3] == minus_v2[3]), true);
   }
+  { // test vnl_vector_fixed::is_equal
+    using int_vector_fixed_type = vnl_vector_fixed<int, 2>;
 
+    TEST("vnl_vector_fixed(0) instances compare equal",
+         int_vector_fixed_type(0).is_equal(int_vector_fixed_type(0), 0.0),
+         true);
+    TEST("vnl_vector_fixed(1) instances compare equal",
+         int_vector_fixed_type(1).is_equal(int_vector_fixed_type(1), 0.0),
+         true);
+    TEST("vnl_vector_fixed(0) and vnl_vector_fixed(1) do not compare equal",
+         int_vector_fixed_type(0).is_equal(int_vector_fixed_type(1), 0.0),
+         false);
+
+    using double_vector_fixed_type = vnl_vector_fixed<double, 2>;
+
+    const double_vector_fixed_type default_vector_fixed{};
+
+    TEST("A default double_vector_fixed_type compares equal to itself",
+         default_vector_fixed.is_equal(default_vector_fixed, 0.0),
+         true);
+    TEST("vnl_vector_fixed(0.9) and vnl_vector_fixed(1.1) do not compare equal with zero tol",
+         double_vector_fixed_type(0.9).is_equal(double_vector_fixed_type(1.1), 0.0),
+         false);
+    TEST("vnl_vector_fixed(0.9) and vnl_vector_fixed(1.1) compare equal with tol 0.3",
+         double_vector_fixed_type(0.9).is_equal(double_vector_fixed_type(1.1), 0.3),
+         true);
+  }
 }
 
 bool

--- a/core/vnl/vnl_vector_fixed.h
+++ b/core/vnl/vnl_vector_fixed.h
@@ -443,6 +443,9 @@ class VNL_EXPORT vnl_vector_fixed
   //: Return true iff the size is zero.
   bool empty() const { return n==0; }
 
+  //:  Return true if all elements of the two vectors are equal, within given tolerance
+  bool is_equal(vnl_vector_fixed const& rhs, double tol) const;
+
   //: Return true if *this == v
   bool operator_eq (vnl_vector_fixed<T,n> const& v) const
   {

--- a/core/vnl/vnl_vector_fixed.hxx
+++ b/core/vnl/vnl_vector_fixed.hxx
@@ -142,6 +142,19 @@ vnl_vector_fixed<T,n>::assert_finite_internal() const
 }
 
 template <class T, unsigned int n>
+bool vnl_vector_fixed<T,n>::is_equal(vnl_vector_fixed<T,n> const& rhs, double tol) const
+{
+  if (this == &rhs)                                         //Same object ? => equal.
+    return true;
+
+  for (size_t i = 0; i < n; ++i)
+    if (!(vnl_math::abs(this->data_[i] - rhs.data_[i]) <= tol)) //Element different ?
+      return false;
+
+  return true;
+}
+
+template <class T, unsigned int n>
 void
 vnl_vector_fixed<T,n>::print(std::ostream& s) const
 {


### PR DESCRIPTION
Allows calling `is_equal(rhs, tol)` directly on a `vnl_vector_fixed`.