### PR TITLE
ENH: vpgl_nitf_rational_camera::read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 5.1.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 5.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
@@ -263,8 +263,9 @@ void vpgl_nitf_rational_camera::geostr_to_latlon_v2(std::string const& str, std:
     coords.emplace_back(latlons[i+1], latlons[i]);
 }
 
+//: Read from a nitf image
 bool
-vpgl_nitf_rational_camera::init(vil_nitf2_image * nitf_image, bool verbose)
+vpgl_nitf_rational_camera::read(vil_nitf2_image * nitf_image, bool verbose)
 {
   std::vector<vil_nitf2_image_subheader *> headers = nitf_image->get_image_headers();
   vil_nitf2_image_subheader * hdr = headers[0];
@@ -347,34 +348,40 @@ vpgl_nitf_rational_camera::init(vil_nitf2_image * nitf_image, bool verbose)
   return true;
 }
 
-vpgl_nitf_rational_camera::vpgl_nitf_rational_camera(std::string const & nitf_image_path, bool verbose)
+//: Read from a nitf image file
+bool
+vpgl_nitf_rational_camera::read(std::string const & nitf_image_path, bool verbose)
 {
   // first open the nitf image
   vil_image_resource_sptr image = vil_load_image_resource(nitf_image_path.c_str());
   if (!image)
   {
-    std::cout << "Image load failed in vpgl_nitf_rational_camera_constructor\n";
-    return;
+    std::cerr << "Image load failed in vpgl_nitf_rational_camera_constructor\n";
+    return false;
   }
   std::string format = image->file_format();
   std::string prefix = format.substr(0, 4);
   if (prefix != "nitf")
   {
-    std::cout << "not a nitf image in vpgl_nitf_rational_camera_constructor\n";
-    return;
+    std::cerr << "not a nitf image in vpgl_nitf_rational_camera_constructor\n";
+    return false;
   }
   // cast to an nitf2_image
   auto * nitf_image = (vil_nitf2_image *)image.ptr();
 
   // read information
-  this->init(nitf_image, verbose);
+  return this->read(nitf_image, verbose);
 }
 
 vpgl_nitf_rational_camera::vpgl_nitf_rational_camera(vil_nitf2_image * nitf_image, bool verbose)
 {
-  this->init(nitf_image, verbose);
+  this->read(nitf_image, verbose);
 }
 
+vpgl_nitf_rational_camera::vpgl_nitf_rational_camera(std::string const & nitf_image_path, bool verbose)
+{
+  this->read(nitf_image_path, verbose);
+}
 
 // print all camera information
 void

--- a/core/vpgl/file_formats/vpgl_nitf_rational_camera.h
+++ b/core/vpgl/file_formats/vpgl_nitf_rational_camera.h
@@ -45,6 +45,10 @@ class vpgl_nitf_rational_camera : public vpgl_rational_camera<double>
   vpgl_nitf_rational_camera(vil_nitf2_image* nift_image,
                             bool verbose = false);
 
+  //: Read from nitf
+  bool read(std::string const& nitf_image, bool verbose = false);
+  bool read(vil_nitf2_image* nitf_image, bool verbose = false);
+
   std::string rational_extension_type() const {return nitf_rational_type_;}
 
   std::string image_id() const {return image_id_;}
@@ -68,8 +72,6 @@ class vpgl_nitf_rational_camera : public vpgl_rational_camera<double>
   static void geostr_to_latlon_v2(std::string const& str, std::vector<std::pair<double, double> >& coords);
 
  private:
-  // internal functions
-  bool init(vil_nitf2_image* nitf_image, bool verbose);
 
   // data members
   std::string nitf_rational_type_;


### PR DESCRIPTION
`vpgl_nitf_rational_camera::read` public function.  Allows uses to construct an empty `vpgl_nitf_rational_camera` then populate from a NITF and confirm success.

## PR Checklist

- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✅  Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

@decrispell 