### PR TITLE
BUG: Link bsgm to acal

### DIFF
--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -16,7 +16,7 @@ aux_source_directory(Templates bsgm_sources)
 
 vxl_add_library(LIBRARY_NAME bsgm LIBRARY_SOURCES ${bsgm_sources})
 
-target_link_libraries( bsgm vidl_pro ${VXL_LIB_PREFIX}bpgl_algo ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}bsta ${VXL_LIB_PREFIX}bjson ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vcl)
+target_link_libraries( bsgm vidl_pro ${VXL_LIB_PREFIX}acal ${VXL_LIB_PREFIX}bpgl_algo ${VXL_LIB_PREFIX}brip ${VXL_LIB_PREFIX}bsta ${VXL_LIB_PREFIX}bjson ${VXL_LIB_PREFIX}vpgl ${VXL_LIB_PREFIX}vgl_io ${VXL_LIB_PREFIX}vgl_algo ${VXL_LIB_PREFIX}vil_algo ${VXL_LIB_PREFIX}vnl_algo ${VXL_LIB_PREFIX}vnl ${VXL_LIB_PREFIX}vgl ${VXL_LIB_PREFIX}vil ${VXL_LIB_PREFIX}vul ${VXL_LIB_PREFIX}vcl)
 
 add_subdirectory( app )
 


### PR DESCRIPTION
## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.

Fixes #946 