### PR TITLE
ENH: contrib bpgl_surface_type

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
@@ -6,9 +6,48 @@
 #include <vul/vul_file_iterator.h>
 #include <vnl/vnl_math.h>
 #include <bsta/bsta_histogram.h>
+#include <algorithm>
 #include <fstream>
 #include <stdexcept>
 #include <bvrml/bvrml_write.h>
+
+// enumeration to/from string
+std::string
+bpgl_surface_type::domain_to_string(bpgl_surface_type::domain d)
+{
+  if (d == RECTIFIED_TARGET) {
+    return "RECTIFIED_TARGET";
+  } else if (d == DSM) {
+    return "DSM";
+  } else if (d == FUSED_DSM) {
+    return "FUSED_DSM";
+  } else if (d == MOSAIC_DSM) {
+    return "MOSAIC_DSM";
+  }
+  return "NO_DOMAIN";
+}
+
+bpgl_surface_type::domain
+bpgl_surface_type::domain_from_string(std::string const& str)
+{
+  // upper case input
+  std::string str_upper = str;
+  std::transform(str_upper.begin(), str_upper.end(),
+                 str_upper.begin(), ::toupper);
+
+  // compare upper case
+  if (str_upper == "RECTIFIED_TARGET") {
+    return RECTIFIED_TARGET;
+  } else if (str_upper == "DSM") {
+    return DSM;
+  } else if (str_upper == "FUSED_DSM") {
+    return FUSED_DSM;
+  } else if (str_upper == "MOSAIC_DSM") {
+    return MOSAIC_DSM;
+  }
+  return NO_DOMAIN;
+}
+
 
 // single type_image from string input
 vil_image_view<float>

--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.cxx
@@ -10,6 +10,31 @@
 #include <stdexcept>
 #include <bvrml/bvrml_write.h>
 
+// single type_image from string input
+vil_image_view<float>
+bpgl_surface_type::type_image(std::string const& type_name) const
+{
+  return type_image(type_from_string(type_name));
+}
+
+// single type_image from stype enumeration
+vil_image_view<float>
+bpgl_surface_type::type_image(stype type) const
+{
+  vil_image_view<float> image;
+  if (!type_image(type, image)) {
+    throw std::runtime_error("bpgl_surface_type::type_image failure");
+  }
+  return image;
+}
+
+// type_images std::map
+std::map<bpgl_surface_type::stype, vil_image_view<float> >
+bpgl_surface_type::type_images() const
+{
+  return type_images_;
+}
+
 bool
 bpgl_surface_type::read(std::string const& directory)
 {

--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
@@ -36,6 +36,9 @@ class bpgl_surface_type
   enum stype { NO_DATA, INVALID_DATA, SHADOW, SHADOW_STEP, GEOMETRIC_CONSISTENCY, NO_SURFACE_TYPE};
   enum domain { RECTIFIED_TARGET, DSM, FUSED_DSM, MOSAIC_DSM, NO_DOMAIN};
 
+  static std::string domain_to_string(domain d);
+  static domain domain_from_string(std::string const& str);
+
   bpgl_surface_type()
     : ni_(0), nj_(0)
   {
@@ -148,34 +151,6 @@ class bpgl_surface_type
   std::string type_to_string(stype const& type) const
   {
     return type_names_.at(type);
-  }
-
-  domain domain_from_string(std::string const& domain_str) const
-  {
-    if (domain_str == "rectified_target") {
-      return RECTIFIED_TARGET;
-    } else if (domain_str == "DSM") {
-      return DSM;
-    } else if (domain_str == "fused_DSM") {
-      return FUSED_DSM;
-    } else if (domain_str == "mosaic_DSM") {
-      return MOSAIC_DSM;
-    }
-    return NO_DOMAIN;
-  }
-
-  std::string domain_to_string(domain const& dom) const
-  {
-    if (dom == RECTIFIED_TARGET) {
-      return "rectified_target";
-    } else if (dom == DSM) {
-      return "DSM";
-    } else if (dom == FUSED_DSM) {
-      return "fused_DSM";
-    } else if (dom == MOSAIC_DSM) {
-      return "mosaic_DSM";
-    }
-    return "no_domain";
   }
 
   bool read(std::string const& path);

--- a/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_surface_type.h
@@ -203,6 +203,10 @@ class bpgl_surface_type
     return true;
   }
 
+  vil_image_view<float> type_image(std::string const& type_name) const;
+  vil_image_view<float> type_image(stype type) const;
+  std::map<stype, vil_image_view<float> > type_images() const;
+
   //: the available types
   std::vector<bpgl_surface_type::stype>& stypes() { return types_; }
 


### PR DESCRIPTION
Minro changes to `bpgl_surface_type `
- `domain_to_string` and `domain_from_string` as static functions. 
- Additional getters, e.g., `type_image` returned as `vil_image_view<float>`

@decrispell 

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✅  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

