### PR TITLE
condition large track solution

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.h
@@ -36,9 +36,15 @@ public:
  acal_single_track_solver(std::map<size_t, std::string> inames,std::map<size_t, vgl_point_2d<double> > track,std::map<size_t, vpgl_affine_camera<double> > const& acams):
   inames_(inames), track_(track), track_acams_(acams),verbose_(false), use_covariance_(false){}
   void set_verbose(bool verbose) { verbose_ = verbose; }
-  void set_covar_plane_cs(vnl_matrix<double> const& covar){
+
+  // potentially condition the covariance matrix by adding a scaled identity matrix, s*I.
+  // The scale s is based on the max singular value of the covariance matrix,
+  // i.e., s = frac*max_sing_val
+  void set_covar_plane_cs(vnl_matrix<double> const& covar, size_t large_track_size = 200, double max_sing_val_fraction = 0.02 ){
     covar_plane_cs_ = covar;
     use_covariance_ = true;
+    large_track_size_ = large_track_size;
+    max_sing_val_fraction_ = max_sing_val_fraction;
   }
   // the main solution method
   bool solve();
@@ -62,6 +68,8 @@ public:
   bool verbose_;
   bool use_covariance_;
   vnl_matrix<double> covar_plane_cs_;
+  size_t large_track_size_;
+  double max_sing_val_fraction_;
   std::map<size_t, std::string> inames_;
   std::map<size_t, vgl_point_2d<double> > track_;
   std::map<size_t, vpgl_affine_camera<double> > track_acams_;


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->
When the number of satellite images is large the pose covariance matrix must be conditioned"
<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

-  :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X] or  --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
- :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
