### PR TITLE
 COMP: Replace sprintf to snprintf

### DIFF
--- a/core/vnl/vnl_matlab_print_scalar.cxx
+++ b/core/vnl/vnl_matlab_print_scalar.cxx
@@ -4,22 +4,39 @@
 #include <cstdlib>
 #include <cstring>
 #include <complex>
+
 #include "vnl_matlab_print_scalar.h"
+#include "vcl_compiler.h"
+
 
 void
-vnl_matlab_print_scalar(int v, char * buf, vnl_matlab_print_format)
+vnl_matlab_print_scalar(int v, char * buf, size_t buf_len, vnl_matlab_print_format)
 {
-  std::sprintf(buf, "%4d ", v);
+  std::snprintf(buf, buf_len, "%4d ", v);
 }
 
 void
-vnl_matlab_print_scalar(unsigned v, char * buf, vnl_matlab_print_format)
+vnl_matlab_print_scalar(int v, char * buf, vnl_matlab_print_format) 
 {
-  std::sprintf(buf, "%4u ", v);
+ vnl_matlab_print_scalar(v, buf, SIZE_MAX);
+}
+
+
+void
+vnl_matlab_print_scalar(unsigned v, char * buf, size_t buf_len, vnl_matlab_print_format)
+{
+  std::snprintf(buf, buf_len, "%4u ", v);
 }
 
 void
-vnl_matlab_print_scalar(float v, char * buf, vnl_matlab_print_format format)
+vnl_matlab_print_scalar(unsigned v, char * buf, vnl_matlab_print_format) 
+{
+ vnl_matlab_print_scalar(v, buf, SIZE_MAX);
+}
+
+
+void
+vnl_matlab_print_scalar(float v, char * buf, size_t buf_len, vnl_matlab_print_format format)
 {
   if (format == vnl_matlab_print_format_default)
     format = vnl_matlab_print_format_top();
@@ -27,21 +44,58 @@ vnl_matlab_print_scalar(float v, char * buf, vnl_matlab_print_format format)
   {
     case vnl_matlab_print_format_long:
       if (v == 0.0)
-        std::sprintf(buf, "%8d ", 0);
+        std::snprintf(buf, buf_len, "%8d ", 0);
       else
-        std::sprintf(buf, "%8.5f ", v);
+        std::snprintf(buf, buf_len, "%8.5f ", v);
       break;
     case vnl_matlab_print_format_short:
       if (v == 0.0)
-        std::sprintf(buf, "%6d ", 0);
+        std::snprintf(buf, buf_len, "%6d ", 0);
       else
-        std::sprintf(buf, "%6.3f ", v);
+        std::snprintf(buf, buf_len, "%6.3f ", v);
       break;
     case vnl_matlab_print_format_long_e:
-      std::sprintf(buf, "%11.7e ", v);
+      std::snprintf(buf, buf_len, "%11.7e ", v);
       break;
     case vnl_matlab_print_format_short_e:
-      std::sprintf(buf, "%8.4e ", v);
+      std::snprintf(buf, buf_len, "%8.4e ", v);
+      break;
+    default: /*vnl_matlab_print_format_default:*/
+      std::abort();
+  }
+}
+
+void
+vnl_matlab_print_scalar(float v, char * buf, vnl_matlab_print_format format)
+{
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
+}
+
+
+void
+vnl_matlab_print_scalar(double v, char * buf, size_t buf_len, vnl_matlab_print_format format)
+{
+  if (format == vnl_matlab_print_format_default)
+    format = vnl_matlab_print_format_top();
+  switch (format)
+  {
+    case vnl_matlab_print_format_long:
+      if (v == 0.0)
+        std::snprintf(buf, buf_len, "%16d ", 0);
+      else
+        std::snprintf(buf, buf_len, "%16.13f ", v);
+      break;
+    case vnl_matlab_print_format_short:
+      if (v == 0.0)
+        std::snprintf(buf, buf_len, "%8d ", 0);
+      else
+        std::snprintf(buf, buf_len, "%8.4f ", v);
+      break;
+    case vnl_matlab_print_format_long_e:
+      std::snprintf(buf, buf_len, "%20.14e ", v);
+      break;
+    case vnl_matlab_print_format_short_e:
+      std::snprintf(buf, buf_len, "%10.4e ", v);
       break;
     default: /*vnl_matlab_print_format_default:*/
       std::abort();
@@ -51,41 +105,25 @@ vnl_matlab_print_scalar(float v, char * buf, vnl_matlab_print_format format)
 void
 vnl_matlab_print_scalar(double v, char * buf, vnl_matlab_print_format format)
 {
-  if (format == vnl_matlab_print_format_default)
-    format = vnl_matlab_print_format_top();
-  switch (format)
-  {
-    case vnl_matlab_print_format_long:
-      if (v == 0.0)
-        std::sprintf(buf, "%16d ", 0);
-      else
-        std::sprintf(buf, "%16.13f ", v);
-      break;
-    case vnl_matlab_print_format_short:
-      if (v == 0.0)
-        std::sprintf(buf, "%8d ", 0);
-      else
-        std::sprintf(buf, "%8.4f ", v);
-      break;
-    case vnl_matlab_print_format_long_e:
-      std::sprintf(buf, "%20.14e ", v);
-      break;
-    case vnl_matlab_print_format_short_e:
-      std::sprintf(buf, "%10.4e ", v);
-      break;
-    default: /*vnl_matlab_print_format_default:*/
-      std::abort();
-  }
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
+}
+
+
+void
+vnl_matlab_print_scalar(long double v, char * buf, size_t buf_len, vnl_matlab_print_format format)
+{
+  vnl_matlab_print_scalar(double(v), buf, buf_len, format); // FIXME
 }
 
 void
 vnl_matlab_print_scalar(long double v, char * buf, vnl_matlab_print_format format)
 {
-  vnl_matlab_print_scalar(double(v), buf, format); // FIXME
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
 }
 
+
 void
-vnl_matlab_print_scalar(std::complex<double> v, char * buf, vnl_matlab_print_format format)
+vnl_matlab_print_scalar(std::complex<double> v, char * buf, size_t buf_len, vnl_matlab_print_format format)
 {
   if (format == vnl_matlab_print_format_default)
     format = vnl_matlab_print_format_top();
@@ -130,25 +168,27 @@ vnl_matlab_print_scalar(std::complex<double> v, char * buf, vnl_matlab_print_for
   // Real part
   if (r == 0)
   {
-    std::sprintf(fmt,
-                 "%%"
-                 "%d"
-                 "d ",
-                 width);
-    std::sprintf(buf, fmt, 0);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%%"
+                  "%d"
+                  "d ",
+                  width);
+    std::snprintf(buf, buf_len, fmt, 0);
   }
   else
   {
-    std::sprintf(fmt,
-                 "%%"
-                 "%d"
-                 "."
-                 "%d"
-                 "%c ",
-                 width,
-                 precision,
-                 conv);
-    std::sprintf(buf, fmt, r);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%%"
+                  "%d"
+                  "."
+                  "%d"
+                  "%c ",
+                  width,
+                  precision,
+                  conv);
+    std::snprintf(buf, buf_len, fmt, r);
   }
 
   buf += std::strlen(buf);
@@ -156,12 +196,13 @@ vnl_matlab_print_scalar(std::complex<double> v, char * buf, vnl_matlab_print_for
   // Imaginary part.  Width is reduced as sign is taken care of separately
   if (i == 0)
   {
-    std::sprintf(fmt,
-                 " %%"
-                 "%d"
-                 "s  ",
-                 width - 1);
-    std::sprintf(buf, fmt, "");
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  " %%"
+                  "%d"
+                  "s  ",
+                  width - 1);
+    std::snprintf(buf, buf_len, fmt, "");
   }
   else
   {
@@ -171,19 +212,27 @@ vnl_matlab_print_scalar(std::complex<double> v, char * buf, vnl_matlab_print_for
       sign = '-';
       i = -i;
     }
-    std::sprintf(fmt,
-                 "%c%%"
-                 "%d.%d%ci ",
-                 sign,
-                 width - 1,
-                 precision,
-                 conv);
-    std::sprintf(buf, fmt, i);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%c%%"
+                  "%d.%d%ci ",
+                  sign,
+                  width - 1,
+                  precision,
+                  conv);
+    std::snprintf(buf, buf_len, fmt, i);
   }
 }
 
 void
-vnl_matlab_print_scalar(std::complex<float> v, char * buf, vnl_matlab_print_format format)
+vnl_matlab_print_scalar(std::complex<double> v, char * buf, vnl_matlab_print_format format)
+{
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
+}
+
+
+void
+vnl_matlab_print_scalar(std::complex<float> v, char * buf, size_t buf_len, vnl_matlab_print_format format)
 {
   if (format == vnl_matlab_print_format_default)
     format = vnl_matlab_print_format_top();
@@ -228,25 +277,27 @@ vnl_matlab_print_scalar(std::complex<float> v, char * buf, vnl_matlab_print_form
   // Real part
   if (r == 0)
   {
-    std::sprintf(fmt,
-                 "%%"
-                 "%d"
-                 "d ",
-                 width);
-    std::sprintf(buf, fmt, 0);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%%"
+                  "%d"
+                  "d ",
+                  width);
+    std::snprintf(buf, buf_len, fmt, 0);
   }
   else
   {
-    std::sprintf(fmt,
-                 "%%"
-                 "%d"
-                 "."
-                 "%d"
-                 "%c ",
-                 width,
-                 precision,
-                 conv);
-    std::sprintf(buf, fmt, r);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%%"
+                  "%d"
+                  "."
+                  "%d"
+                  "%c ",
+                  width,
+                  precision,
+                  conv);
+    std::snprintf(buf, buf_len, fmt, r);
   }
 
   buf += std::strlen(buf);
@@ -254,12 +305,13 @@ vnl_matlab_print_scalar(std::complex<float> v, char * buf, vnl_matlab_print_form
   // Imaginary part.  Width is reduced as sign is taken care of separately
   if (i == 0)
   {
-    std::sprintf(fmt,
-                 " %%"
-                 "%d"
-                 "s  ",
-                 width - 1);
-    std::sprintf(buf, fmt, "");
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  " %%"
+                  "%d"
+                  "s  ",
+                  width - 1);
+    std::snprintf(buf, buf_len, fmt, "");
   }
   else
   {
@@ -269,21 +321,35 @@ vnl_matlab_print_scalar(std::complex<float> v, char * buf, vnl_matlab_print_form
       sign = '-';
       i = -i;
     }
-    std::sprintf(fmt,
-                 "%c%%"
-                 "%d.%d%ci ",
-                 sign,
-                 width - 1,
-                 precision,
-                 conv);
-    std::sprintf(buf, fmt, i);
+    std::snprintf(fmt,
+                  sizeof(fmt),
+                  "%c%%"
+                  "%d.%d%ci ",
+                  sign,
+                  width - 1,
+                  precision,
+                  conv);
+    std::snprintf(buf, buf_len, fmt, i);
   }
+}
+
+void
+vnl_matlab_print_scalar(std::complex<float> v, char * buf, vnl_matlab_print_format format)
+{
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
+}
+
+
+void
+vnl_matlab_print_scalar(std::complex<long double> v, char * buf, size_t buf_len, vnl_matlab_print_format format)
+{
+  vnl_matlab_print_scalar(std::complex<double>(std::real(v), std::imag(v)), buf, buf_len, format); // FIXME
 }
 
 void
 vnl_matlab_print_scalar(std::complex<long double> v, char * buf, vnl_matlab_print_format format)
 {
-  vnl_matlab_print_scalar(std::complex<double>(std::real(v), std::imag(v)), buf, format); // FIXME
+  vnl_matlab_print_scalar(v, buf, SIZE_MAX, format);
 }
 
 
@@ -292,7 +358,7 @@ std::ostream &
 vnl_matlab_print_scalar(std::ostream & s, T value, vnl_matlab_print_format format)
 {
   char buf[1024];
-  vnl_matlab_print_scalar(value, buf, format);
+  vnl_matlab_print_scalar(value, buf, sizeof(buf), format);
   return s << buf;
 }
 

--- a/core/vnl/vnl_matlab_print_scalar.h
+++ b/core/vnl/vnl_matlab_print_scalar.h
@@ -14,11 +14,13 @@
 #endif
 #include "vnl_matlab_print_format.h"
 #include "vnl/vnl_export.h"
+#include "vcl_compiler.h"
 
 //: print real or complex scalar into character buffer.
 #define vnl_matlab_print_scalar_declare(T) \
 VNL_EXPORT void vnl_matlab_print_scalar(T v, \
                              char *buf, \
+                             size_t buf_len, \
                              vnl_matlab_print_format =vnl_matlab_print_format_default)
 
 // Even with a function template we would have to
@@ -31,6 +33,27 @@ vnl_matlab_print_scalar_declare(long double);
 vnl_matlab_print_scalar_declare(std::complex<float>);
 vnl_matlab_print_scalar_declare(std::complex<double>);
 vnl_matlab_print_scalar_declare(std::complex<long double>);
+
+
+//: print real or complex scalar into character buffer.
+// These variants are deprecated because the buffer size is not provided
+#define vnl_matlab_print_scalar_declare_old(T) \
+VNL_EXPORT VXL_DEPRECATED void vnl_matlab_print_scalar(T v, \
+                             char *buf, \
+                             vnl_matlab_print_format =vnl_matlab_print_format_default)
+
+// Even with a function template we would have to
+// forward declare all the specializations anyway.
+vnl_matlab_print_scalar_declare_old(int);
+vnl_matlab_print_scalar_declare_old(unsigned int);
+vnl_matlab_print_scalar_declare_old(float);
+vnl_matlab_print_scalar_declare_old(double);
+vnl_matlab_print_scalar_declare_old(long double);
+vnl_matlab_print_scalar_declare_old(std::complex<float>);
+vnl_matlab_print_scalar_declare_old(std::complex<double>);
+vnl_matlab_print_scalar_declare_old(std::complex<long double>);
+
+
 
 //: print scalar to std::ostream.
 template <class T> VNL_EXPORT


### PR DESCRIPTION
Replacement of sprintf to snprintf.

Here only one fix is proposed since it involves doing more involved changes.

Here the snprintf requires the size of buf. Unfortunately, buf, without it’s length, is passed to the function.

We can also see that each function in the file has the same name and a argument list very similar for each of them.

I propose to create at the top a function that has the same name as the others, but with the length of buf added and snprintf used. Then, use that function for the other functions accordingly.

Can I proceed like this for the rest of the functions in the file? Also, should we add a deprecated comment?

