### PR TITLE
COMP: Fix -Wextra-semi warnings

### DIFF
--- a/core/vnl/vnl_alloc.h
+++ b/core/vnl/vnl_alloc.h
@@ -104,7 +104,7 @@ class VNL_EXPORT vnl_alloc
     }
     *my_free_list = result -> free_list_link;
     return result;
-  };
+  }
 
   /* p may not be 0 */
   static void deallocate(void *p, std::size_t n)

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -703,7 +703,7 @@ class VNL_EXPORT vnl_matrix_fixed
 #endif
   operator const vnl_matrix_ref<T>() const { return  this->as_ref(); }
 #endif
-  explicit operator vnl_matrix<T>() const { return this->as_matrix(); };
+  explicit operator vnl_matrix<T>() const { return this->as_matrix(); }
 
 
   //----------------------------------------------------------------------

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -476,7 +476,7 @@ class VNL_EXPORT vnl_vector
   this->data= indata ;
   this->num_elmts = nelmts;
   this->m_LetArrayManageMemory = manage_own_memory;
-  };
+  }
 //#endif
 
   void assert_size_internal(size_t sz) const;

--- a/core/vpdl/vpdl_distribution.h
+++ b/core/vpdl/vpdl_distribution.h
@@ -64,7 +64,7 @@ class vpdl_distribution
   virtual T log_prob_density(const vector& pt) const
   {
     return std::log(prob_density(pt));
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and

--- a/core/vpdl/vpdl_gaussian.h
+++ b/core/vpdl/vpdl_gaussian.h
@@ -65,7 +65,7 @@ class vpdl_gaussian : public vpdl_gaussian_base<T,n>
   //: Evaluate the log probability density at a point
   T log_prob_density(const vector &pt) const override {
     return vpdt_log_prob_density(impl_,pt);
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and

--- a/core/vpdl/vpdl_gaussian_indep.h
+++ b/core/vpdl/vpdl_gaussian_indep.h
@@ -67,7 +67,7 @@ class vpdl_gaussian_indep : public vpdl_gaussian_base<T,n>
   //: Evaluate the log probability density at a point
   T log_prob_density(const vector &pt) const override {
     return vpdt_log_prob_density(impl_,pt);
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and

--- a/core/vpdl/vpdl_gaussian_sphere.h
+++ b/core/vpdl/vpdl_gaussian_sphere.h
@@ -68,7 +68,7 @@ class vpdl_gaussian_sphere : public vpdl_gaussian_base<T,n>
   //: Evaluate the log probability density at a point
   T log_prob_density(const vector &pt) const override {
     return vpdt_log_prob_density(impl_,pt);
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and


### PR DESCRIPTION
Remove semicolons at the end of function definitions.