### PR TITLE
 COMP: Replacement of sprinf by using std::string

### DIFF
--- a/core/vil1/vil1_stream_url.cxx
+++ b/core/vil1/vil1_stream_url.cxx
@@ -222,24 +222,20 @@ vil1_stream_url::vil1_stream_url(char const * url)
     return;
   }
 
-  // buffer for data transfers over socket.
-  char buffer[4096];
-
   // send HTTP 1.1 request.
-  std::sprintf(buffer, "GET /%s / HTTP/1.1\n", path.c_str());
+  std::string request = "GET /" + path + " / HTTP/1.1\n";
   if (!auth.empty())
-    std::sprintf(buffer + std::strlen(buffer), "Authorization:  Basic %s\n", encode_base64(auth).c_str());
-    //    std::sprintf(buffer+std::strlen(buffer), "Authorization:  user  testuser:testuser\n");
+    request += "Authorization:  Basic " + encode_base64(auth) + "\n";
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  if (send(tcp_socket, buffer, (int)std::strlen(buffer), 0) < 0)
+  if (send(tcp_socket, request.c_str(), (int)request.length(), 0) < 0)
   {
     std::cerr << __FILE__ ": error sending HTTP request\n";
     closesocket(tcp_socket);
     return;
   }
 #else
-  if (::write(tcp_socket, buffer, std::strlen(buffer)) < 0)
+  if (::write(tcp_socket, request.c_str(), request.length()) < 0)
   {
     std::cerr << __FILE__ ": error sending HTTP request\n";
     close(tcp_socket);
@@ -256,6 +252,9 @@ vil1_stream_url::vil1_stream_url(char const * url)
 #endif
 
   //  std::ofstream test2("/test2.jpg", std::ios::binary);
+
+  // buffer for data transfers over socket.
+  char buffer[4096];
 
   // read from socket into memory.
   u_ = new vil1_stream_core;


### PR DESCRIPTION
Replaced the sprintf with std::string. We didn't use snprint since it's not clear 4096 is even big enough to perform the operations. We have to check the return values of snprint which becomes more complex.

At the read from socket into memory, we decided to use the char buffer[4096] lower than where it was initially since std::string where we look at its size won't perform the same result as if char buffer[4096] is used.

