### PR TITLE
COMP: Fix -Wextra-semi warnings (remaining ones)

### DIFF
--- a/core/vgl/algo/vgl_compute_cremona_2d.h
+++ b/core/vgl/algo/vgl_compute_cremona_2d.h
@@ -46,7 +46,7 @@ class vgl_compute_cremona_2d
 
      vgl_compute_cremona_2d() : constr_type_(BI_RATIONAL) {}
      ~vgl_compute_cremona_2d() = default;
-     ;
+     
 
      // Operations----------------------------------------------------------------
 

--- a/core/vgl/algo/vgl_h_matrix_3d.h
+++ b/core/vgl/algo/vgl_h_matrix_3d.h
@@ -58,7 +58,7 @@ class vgl_h_matrix_3d
   vgl_h_matrix_3d(std::vector<vgl_homg_point_3d<T> > const& points1,
                   std::vector<vgl_homg_point_3d<T> > const& points2);
 
-  inline explicit operator vnl_matrix<T>() const { return this->t12_matrix_.as_matrix(); };
+  inline explicit operator vnl_matrix<T>() const { return this->t12_matrix_.as_matrix(); }
 
   // Operations----------------------------------------------------------------
 

--- a/core/vil/vil_file_format.h
+++ b/core/vil/vil_file_format.h
@@ -58,7 +58,7 @@ class vil_file_format
                                char const * /*level_file_format*/,
                                char const * /*filename*/) {
     return nullptr;
-  };
+  }
 
   //: Make a "generic_image" on which put_section may be applied.
   // The stream vs is assumed to be open for writing, as an image header may be

--- a/core/vnl/vnl_alloc.h
+++ b/core/vnl/vnl_alloc.h
@@ -104,7 +104,7 @@ class VNL_EXPORT vnl_alloc
     }
     *my_free_list = result -> free_list_link;
     return result;
-  };
+  }
 
   /* p may not be 0 */
   static void deallocate(void *p, std::size_t n)

--- a/core/vnl/vnl_matrix_fixed.h
+++ b/core/vnl/vnl_matrix_fixed.h
@@ -703,7 +703,7 @@ class VNL_EXPORT vnl_matrix_fixed
 #endif
   operator const vnl_matrix_ref<T>() const { return  this->as_ref(); }
 #endif
-  explicit operator vnl_matrix<T>() const { return this->as_matrix(); };
+  explicit operator vnl_matrix<T>() const { return this->as_matrix(); }
 
 
   //----------------------------------------------------------------------

--- a/core/vnl/vnl_vector.h
+++ b/core/vnl/vnl_vector.h
@@ -476,7 +476,7 @@ class VNL_EXPORT vnl_vector
   this->data= indata ;
   this->num_elmts = nelmts;
   this->m_LetArrayManageMemory = manage_own_memory;
-  };
+  }
 //#endif
 
   void assert_size_internal(size_t sz) const;

--- a/core/vpdl/vpdl_gaussian_indep.h
+++ b/core/vpdl/vpdl_gaussian_indep.h
@@ -67,7 +67,7 @@ class vpdl_gaussian_indep : public vpdl_gaussian_base<T,n>
   //: Evaluate the log probability density at a point
   T log_prob_density(const vector &pt) const override {
     return vpdt_log_prob_density(impl_,pt);
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and

--- a/core/vpdl/vpdl_gaussian_sphere.h
+++ b/core/vpdl/vpdl_gaussian_sphere.h
@@ -68,7 +68,7 @@ class vpdl_gaussian_sphere : public vpdl_gaussian_base<T,n>
   //: Evaluate the log probability density at a point
   T log_prob_density(const vector &pt) const override {
     return vpdt_log_prob_density(impl_,pt);
-  };
+  }
 
   //: Compute the gradient of the unnormalized density at a point
   // \return the density at \a pt since it is usually needed as well, and

--- a/core/vpgl/vpgl_poly_radial_distortion.h
+++ b/core/vpgl/vpgl_poly_radial_distortion.h
@@ -73,7 +73,7 @@ class vpgl_poly_radial_distortion : public vpgl_radial_distortion<T>
     T* coptr = coefficients_;
     for (unsigned int i=0; i<n; ++i, ++kptr, ++coptr)
       *coptr = *kptr;
-  };
+  }
 
   //: Read-only coefficient accessor
   T coefficient( unsigned int i ) const

--- a/v3p/clipper/clipper.hxx
+++ b/v3p/clipper/clipper.hxx
@@ -87,9 +87,9 @@ struct IntPoint {
   cInt Y;
 #ifdef use_xyz
   cInt Z;
-  IntPoint(cInt x = 0, cInt y = 0, cInt z = 0): X(x), Y(y), Z(z) {};
+  IntPoint(cInt x = 0, cInt y = 0, cInt z = 0): X(x), Y(y), Z(z) {}
 #else
-  IntPoint(cInt x = 0, cInt y = 0): X(x), Y(y) {};
+  IntPoint(cInt x = 0, cInt y = 0): X(x), Y(y) {}
 #endif
 
   friend inline bool operator== (const IntPoint& a, const IntPoint& b)
@@ -137,7 +137,7 @@ class PolyNode
 {
 public:
     PolyNode();
-    virtual ~PolyNode()= default;;
+    virtual ~PolyNode()= default;
     Path Contour;
     PolyNodes Childs;
     PolyNode* Parent;
@@ -160,7 +160,7 @@ private:
 class PolyTree: public PolyNode
 {
 public:
-    ~PolyTree() override{ Clear(); };
+    ~PolyTree() override{ Clear(); }
     PolyNode* GetFirst() const;
     void Clear();
     int Total() const;
@@ -226,8 +226,8 @@ public:
   bool AddPaths(const Paths &ppg, PolyType PolyTyp, bool Closed);
   virtual void Clear();
   IntRect GetBounds();
-  bool PreserveCollinear() {return m_PreserveCollinear;};
-  void PreserveCollinear(bool value) {m_PreserveCollinear = value;};
+  bool PreserveCollinear() {return m_PreserveCollinear;}
+  void PreserveCollinear(bool value) {m_PreserveCollinear = value;}
 protected:
   void DisposeLocalMinimaList();
   TEdge* AddBoundsToLML(TEdge *e, bool IsClosed);
@@ -278,10 +278,10 @@ public:
       PolyTree &polytree,
       PolyFillType subjFillType,
       PolyFillType clipFillType);
-  bool ReverseSolution() { return m_ReverseOutput; };
-  void ReverseSolution(bool value) {m_ReverseOutput = value;};
-  bool StrictlySimple() {return m_StrictSimple;};
-  void StrictlySimple(bool value) {m_StrictSimple = value;};
+  bool ReverseSolution() { return m_ReverseOutput; }
+  void ReverseSolution(bool value) {m_ReverseOutput = value;}
+  bool StrictlySimple() {return m_StrictSimple;}
+  void StrictlySimple(bool value) {m_StrictSimple = value;}
   //set the callback function for z value filling on intersections (otherwise Z is 0)
 #ifdef use_xyz
   void ZFillFunction(ZFillCallback zFillFunc);


### PR DESCRIPTION
Remove semicolons at the end of function definitions (remaining ones).