### PR TITLE
BUG: contrib acal_single_track_solver

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.cxx
@@ -31,7 +31,7 @@ bool acal_single_track_solver::solve()
     }
   }else{
     // condition large track solutions
-    if(track_rays.size()> large_track_size_){
+    if(track_rays.size() > large_track_size_){
       std::cout << "Processing the large number of rays case ( " << track_rays.size() << " )"<< std::endl;
       vnl_svd<double> svd(covar_plane_cs_);
       size_t nr = covar_plane_cs_.rows();
@@ -53,10 +53,12 @@ bool acal_single_track_solver::solve()
         std::cout << "adding scaled identity matrix " << cond_add << " x I " << std::endl;
         vnl_svd<double> svd_add(cond_covar);
         std::cout << "After add condition is  " << 1.0/svd_add.well_condition() << std::endl;
-        if (!vgl_intersection(track_rays, cond_covar, track_3d_point_)){
-          std::cerr << "Intersection failed - while using conditioned covariance on a large number of rays" << std::endl;
-          return false;
-        }
+      }
+      if (!vgl_intersection(track_rays, cond_covar, track_3d_point_)){
+        std::cerr << "Intersection failed - while using covariance on a large number of rays" << std::endl;
+        return false;
+      }
+      else{
         std::cout << "Large number of rays intersection point (lvcs) " << track_3d_point_ << std::endl;
       }// end large number of rays
     }else if (!vgl_intersection(track_rays, covar_plane_cs_, track_3d_point_)){


### PR DESCRIPTION
Fixes a bug in acal_single_track_solver.cxx that caused track_3d_point_ to be uninitialized in the case that there is a large track size but the problem is not ill conditioned.

@decrispell 
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- <!-- :no_entry_sign: -->:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- <!-- :no_entry_sign: -->:no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- :no_entry_sign: -->:white_check_mark: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- <!-- :no_entry_sign: -->:no_entry_sign: Adds tests and baseline comparison (quantitative).
- <!-- :no_entry_sign: -->:no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
