### PR TITLE
access_match_graph_correspondences

### DIFF
--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.cxx
@@ -1022,3 +1022,33 @@ acal_match_graph::operator==(acal_match_graph const& other) const
       && this->match_tree_metric_ == other.match_tree_metric_;
 }
 
+std::vector<std::pair<vgl_point_2d<double>, vgl_point_2d<double> > > acal_match_graph::corrs(size_t cam_id_i, size_t cam_id_j){
+  std::vector<std::pair<vgl_point_2d<double>, vgl_point_2d<double> > >  ret;
+  std::shared_ptr<match_vertex> vi = match_vertices_[cam_id_i],
+              vj = match_vertices_[cam_id_i];
+  if(!vi || !vj) return ret;
+  std::vector<match_edge*>& i_edges = vi->edges_;
+  size_t ne = i_edges.size();
+  if(ne == 0)
+    return ret;
+  bool found = false;
+  for(size_t e = 0; e<ne&&!found; ++e){
+    std::shared_ptr<match_vertex> vv = i_edges[e]->v1_;
+    if(vv->cam_id_ == cam_id_j){
+      std::vector<acal_match_pair>& mch =  i_edges[e]->matches_;
+      size_t nm = mch.size();
+      if(nm == 0)
+        return ret;
+      for(size_t m = 0; m<nm; ++m){
+        acal_match_pair& p = mch[m];
+        ret.emplace_back(p.corr1_.pt_, p.corr2_.pt_);
+      }
+      found = true;
+    }
+  }
+  return ret;
+}
+      
+  
+              
+    

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -167,6 +167,8 @@ class acal_match_graph
 
   std::map<size_t, std::string> image_names();
 
+  std::vector<std::pair<vgl_point_2d<double>, vgl_point_2d<double> > > corrs(size_t cam_id_i, size_t cam_id_j);
+
   //: debug
   void print_connected_components();
   void print_n_tracks_for_conn_comp();


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

-  :no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!-- 
If either of the above two items is true, 
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- <!-- [X] or  --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- no_entry_sign: --> Adds tests and baseline comparison (quantitative).
- :no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
