### PR TITLE
Fixed a buffer overrun found by ASan

### DIFF
--- a/core/vnl/vnl_matlab_print.hxx
+++ b/core/vnl/vnl_matlab_print.hxx
@@ -31,7 +31,7 @@ vnl_matlab_print(std::ostream & s, const T * array, unsigned length, vnl_matlab_
   {
     // Format according to selected style
     // In both cases an exact 0 goes out as such
-    vnl_matlab_print_scalar(array[j], buf, format);
+    vnl_matlab_print_scalar(array[j], buf, sizeof(buf), format);
     s << buf;
   }
 


### PR DESCRIPTION
Months ago a coleague and I added a safer variant of vnl_matlab_print_scalar() that takes the size of the buffer. Solution was just to use this new variant.
