### PR TITLE
CONTRIB: bsgm_prob_pairwise_dsm window invalid masks

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
+++ b/contrib/brl/bseg/bsgm/bsgm_prob_pairwise_dsm.h
@@ -535,6 +535,10 @@ class bsgm_prob_pairwise_dsm
       prob_ptset_.clear();
       rectify_windows();
     }
+
+    // compute invalid masks
+    this->compute_invalid_masks();
+
     // compute forward disparity & height
     this->compute_disparity_fwd();
     this->compute_height_fwd(false);  // false -> don't compute fwd heightmap


### PR DESCRIPTION
`bsgm_prob_pairwise_dsm::process_with_windows` add missing `compute_invalid_masks`

@decrispell 

## PR Checklist
- ❌  Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ❌ Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ✅ Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.
