### PR TITLE
BUG: Fix bsgm disparity segmentation fault

### DIFF
--- a/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.cxx
@@ -524,7 +524,6 @@ bsgm_disparity_estimator::run_multi_dp(
       throw std::runtime_error("Invalid start index");
     }
 
-
     // Initialize previous row
     for( long long int v = 0; v < row_size; v++ )
       dir_cost_prev[v] = 0;

--- a/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_disparity_estimator.cxx
@@ -24,7 +24,7 @@ bsgm_disparity_estimator::bsgm_disparity_estimator(
   long long int cost_volume_width,
   long long int cost_volume_height,
   long long int num_disparities,
-  // optional shadow processing 
+  // optional shadow processing
   vil_image_view<float> const& shadow_step_prob,
   vil_image_view<float> const& shadow_prob,
   vgl_vector_2d<float> const& sun_dir_tar):
@@ -67,7 +67,7 @@ bsgm_disparity_estimator::bsgm_disparity_estimator(
   if(params_.use_shadow_step_p2_adjustment)
     std::cout << "shadow_step P2 adjust" << std::endl;
   else if(params_.use_gradient_weighted_smoothing)
-    std::cout << "dir grad P2 adjust" << std::endl;  
+    std::cout << "dir grad P2 adjust" << std::endl;
 #endif
   // Setup any necessary cost volumes
   setup_cost_volume( fused_cost_data_, fused_cost_, num_disparities );
@@ -247,7 +247,7 @@ bsgm_disparity_estimator::run_multi_dp(
   //sun dir mag>0 required for shadow dynamic program
   auto bias_weight = params_.bias_weight;
   float mag = sun_dir_tar_.length();
-  if(mag > 0.0f) 
+  if(mag > 0.0f)
     sun_dir_tar_/=mag;
 
   auto bias_dir = sun_dir_tar_;
@@ -362,7 +362,7 @@ bsgm_disparity_estimator::run_multi_dp(
     for( int x = 0; x < w_; x++ )
       for( int d = 0; d < num_disparities_; d++ )
         total_cost[y][x][d] = 0;
-  
+
   // Setup buffers
   std::vector<unsigned short> dir_cost_cur( row_size, (unsigned short)0 );
   std::vector<unsigned short> dir_cost_prev( row_size, (unsigned short)0 );
@@ -518,6 +518,13 @@ bsgm_disparity_estimator::run_multi_dp(
     int x_inc = (x_start < x_end) ? 1 : -1;
     int y_inc = (y_start < y_end) ? 1 : -1;
 
+    // Validate x and y indices
+    if (x_start < 0 || x_start >= w_ || y_start < 0 || y_start >= h_ ||
+        x_end < 0 || x_end >= w_ || y_end < 0 || y_end >= h_) {
+      throw std::runtime_error("Invalid start index");
+    }
+
+
     // Initialize previous row
     for( long long int v = 0; v < row_size; v++ )
       dir_cost_prev[v] = 0;
@@ -563,7 +570,7 @@ bsgm_disparity_estimator::run_multi_dp(
           // In shadow, limit the dynamic program direction to that closest to opposite the sun ray dir
           // that is, update total cost along the direction towards the shadow casting step discontinuity from outside the shadow
           int dc = shad_step_dp_dir_code;
-          
+
           float pthr = params_.shad_shad_stp_prob_thresh;
           float adjw = params_.adj_dir_weight;
           // include dc and dp directions on each side of dc otherwise skip the current dp direction
@@ -571,7 +578,7 @@ bsgm_disparity_estimator::run_multi_dp(
             continue;
           else if((shadow_prob_(x,y) > pthr)&& (dir != dc))
             continue;
-                                                
+
           // weight the effect of adjacent directions compared to the direction most aginst
           // the sun ray direction
           if(dir == dc) adj_weight = 1.0f;
@@ -584,7 +591,7 @@ bsgm_disparity_estimator::run_multi_dp(
             suppress_appearance = (sp > pthr) || (shadow_prob_(x,y) > pthr);
           else
             suppress_appearance = (shadow_prob_(x,y) > pthr);
-        }          
+        }
 
         // Compute the directional smoothing cost and add to total
         if( dy == 0 )
@@ -631,7 +638,7 @@ bsgm_disparity_estimator::compute_dir_cost(
   int prev_offset = cur_min_disparity - prev_min_disparity;
 
   const unsigned short* prc = prev_row_cost;
-  
+
   // Compute jump cost from best previous disparity with p2 penalty
   unsigned short min_prev_cost = *prc; prc++;
   std::tuple<float, float, float, float, float> cst;
@@ -658,7 +665,7 @@ bsgm_disparity_estimator::compute_dir_cost(
       unsigned short prc_d = *prc;
       best_cost = prc_d < best_cost ? prc_d: best_cost;
     }
-    
+
     // ...and +/- 1 disparity with P1 cost
     // -1
     if( d_off > 0 && d_off <= num_disparities_ ){
@@ -682,7 +689,7 @@ bsgm_disparity_estimator::compute_dir_cost(
       *tc += (*crc);
     }
   }// end of disparity loop
-} 
+}
 
 //-------------------------------------------------------------------
 void


### PR DESCRIPTION
This change throws an error instead of accessing an array out of bounds in `bsgm_disparity_estimator.run_multi_dp()` when the width or height is 1. This sometimes happens when a small window is passed to `bsgm_prob_pairwise_dsm` and rectified.

It also trims trailing whitespace in the changed file.

@decrispell 

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- [X] Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
