### PR TITLE
DRAFT: Optimizations for SGM calculations

### DIFF
--- a/contrib/brl/bbas/bpgl/algo/bpgl_heightmap_from_disparity.hxx
+++ b/contrib/brl/bbas/bpgl/algo/bpgl_heightmap_from_disparity.hxx
@@ -319,13 +319,10 @@ void bpgl_heightmap<T>::heightmap_from_pointset(
         vil_image_view<T>& heightmap_output,
         vil_image_view<T>& scalar_output,
         vil_image_view<T>& radial_std_dev){
-  vul_timer t;
-  float t_h_ = 0.0f, t_rad = 0;
   _heightmap_from_pointset(ptset,
                            heightmap_output,
                            scalar_output,
                            false);
-  t_h_ = t.real(); t.mark();
   vgl_point_2d<T> upper_left(heightmap_bounds_.min_x(), heightmap_bounds_.max_y());
   size_t ni = heightmap_output.ni(), nj = heightmap_output.nj();
   // maximum neighbor distance
@@ -364,8 +361,6 @@ void bpgl_heightmap<T>::heightmap_from_pointset(
       T std_dev = sqrt(var_sum/p_sum);
       radial_std_dev(i,j) = std_dev;
     }
-  t_rad = t.real();
-  // std::cout << "tzprob, trad " << t_h_ << ' ' << t_rad << std::endl;
 }
 
 template<class T>

--- a/contrib/brl/bseg/bsgm/CMakeLists.txt
+++ b/contrib/brl/bseg/bsgm/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories( ${VXLCORE_INCLUDE_DIR} )
 
 set(bsgm_sources
-    bsgm_census.h                          bsgm_census.cxx
+    bsgm_census.h
     bsgm_disparity_estimator.h             bsgm_disparity_estimator.cxx
     bsgm_multiscale_disparity_estimator.h  bsgm_multiscale_disparity_estimator.cxx
     bsgm_align_pointsets_3d.h              bsgm_align_pointsets_3d.hxx

--- a/contrib/brl/bseg/bsgm/bsgm_census.cxx
+++ b/contrib/brl/bseg/bsgm/bsgm_census.cxx
@@ -1,9 +1,0 @@
-#include "bsgm_census.h"
-
-
-//: Generate a bit-set look-up table for a pre-allocated array of size 256
-void bsgm_generate_bit_set_lut(unsigned char* lut ){
-  lut[0] = 0;
-  for (int b = 0; b < 256; b++ )
-    lut[b] = (b&1) + lut[b/2];
-}

--- a/core/vul/aligned_allocator.hxx
+++ b/core/vul/aligned_allocator.hxx
@@ -1,0 +1,78 @@
+// This is core/vul/aligned_allocator.hxx
+
+#ifndef aligned_allocator_h_
+#define aligned_allocator_h_
+
+#include "aligned_memory.hxx"
+
+//:
+// \file
+// \brief A portable alignment-respecting allocator implementation for SIMD support
+// \author Nathan Harbison
+// \date October 3, 2025
+//
+// \endverbatim
+
+// ---------------------------------------------------------------------------------------------
+// Allocator implementation
+
+// Allocator class that supports aligned allocations,
+// specifically for SIMD support
+template <typename T, Alignment Align>
+class AlignedAllocator {
+private:
+    static_assert(
+        Align >= alignof(T),
+        "Specified alignment is smaller than the required alignment of the type!"
+    );
+    static_assert(
+        Align != 0 && (Align & (Align - 1)) == 0,
+        "Specified alignment is not a power of 2!"
+    );
+
+public:
+    // Types relevant to this class, as specified by the 
+    // Allocator requirements (https://en.cppreference.com/w/cpp/named_req/Allocator.html)
+    typedef T         value_type;
+    typedef T*        pointer;
+    typedef const T*  const_pointer;
+    typedef size_t    size_type;
+
+    // Required as AlignedAllocator has a second template
+    // argument for the alignment that will make the default
+    // std::allocator_traits implementation fail during compilation.
+    // See https://stackoverflow.com/a/48062758/2191065
+    template<class U>
+    struct rebind {
+        using other = AlignedAllocator<U, Align>;
+    };
+
+    AlignedAllocator() noexcept {}
+
+    template <class U>
+    AlignedAllocator(const AlignedAllocator<U, Align>&) noexcept {}
+
+    pointer allocate(size_type n, const_pointer = 0) {
+        void* ptr = alloc_aligned_mem(n * sizeof(T), static_cast<size_t>(Align));
+        return static_cast<pointer>(ptr);
+    }
+
+    void deallocate(pointer p, size_type) noexcept { 
+        free_aligned_mem(p);
+    }
+};
+
+template <typename T, Alignment TAlign, typename U, Alignment UAlign>
+inline bool operator== (const AlignedAllocator<T, TAlign>&, const AlignedAllocator<U, UAlign>&) noexcept { return true; }
+
+template <typename T, Alignment TAlign, typename U, Alignment UAlign>
+inline bool operator!= (const AlignedAllocator<T, TAlign>&, const AlignedAllocator<U, UAlign>&) noexcept { return false; }
+
+// ---------------------------------------------------------------------------------------------
+
+// Alignment-respecting types related to SIMD
+
+template <typename T>
+using aligned_vector = std::vector<T, AlignedAllocator<T, SIMD_ALIGN>>;
+
+#endif // aligned_allocator_h_

--- a/core/vul/section_timer.hxx
+++ b/core/vul/section_timer.hxx
@@ -1,5 +1,5 @@
-// This is brl/bseg/bsgm/section_timer.hxx
-// TODO: move to location for utilities
+// This is core/vul/section_timer.hxx
+
 #ifndef section_timer_h_
 #define section_timer_h_
 
@@ -13,7 +13,7 @@
 #include <memory>
 #include <sstream>
 
-#include <vul/vul_timer.h>
+#include "vul_timer.h"
 
 //: A convenience class to profile a section of code and its 
 //  immediate subsections


### PR DESCRIPTION
Rewrites core disparity calculation algorithm using SIMD intrinsics and multithreading. Still WIP.

Changes made:
- Rewrote core dynamic program of disparity calcuations, `bsgm_disparity_estimator::run_multi_dp` using AVX512 instructions
- Restructured the appearance and total cost volumes' allocation and data arrangement:
  - Both volumes are `thread_local` and `static`, which allows each to be reused by a given process/thread once allocated. Beforehand, each was allocated and initialized every time a disparity calculation is made, which is an expensive operation (each volume can be GBs in size!) that can happen up to 4x per stereo pair.
  - Both are defined as `std::unique_ptr`s, to allow smart deallocation once the thread or process exits. The `static` function `free_cost_volumes` is also provided to allow earlier reaping of their memory.
  - The volumes are allocated with an alignment of 64 bytes (as required for AVX512) and padded as such so that the columns at each (x, y) are also aligned to 64 bytes.
- Implemented alignment-respecting memory allocation functions, along with an `AlignedAllocator` class that provides support for creating an alignment-respecting `std::vector`. See `core/vul/aligned_memory.hxx` and `core/vul/aligned_allocator.hxx`.
- Rewrote `bsgm_disparity_estimator::print_time` into a `SectionTimer` class, which provides generalized support for timing the sections of a given function, for use in `bsgm_prob_pairwise_dsm::process` and `bsgm_disparity_estimator::compute`. See `core/vul/section_timer.hxx`.
- Added an `enum` `DIRECTION` for clearly describing the 16 directions SGM performs passes along.
- Moved smaller functions into class definition of `bsgm_disparity_estimator` (i.e. `bsgm_disparity_estimator::gradient_inside_window` and `bsgm_disparity_estimator::add_margin_to_window`) and other minor formatting changes.

TO-DO:
- Autodetect compiler/hardware support for highest level of SIMD instructions (e.g. SSE, SSE2, AVX2, AVX512), and expose instructions only at highest supported level. 
  - Redefine `bsgm_disparity_estimator::run_multi_dp` using only these exposed instructions, to generalize to other SIMD instruction sets and make the code portable.
  - Redefine `AlignedAllocator` and the provided alignment for the cost volumes to respect the largest supported SIMD vector size.
- Rewrite appearance cost calculations using SIMD instructions and above auto-detect infrastructure
- Implement multithreading for dynamic program forward and backward passes

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

:no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
[x] Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
[x] Makes changes to the contributed directory API (does NOT require semantic versioning increase)
:no_entry_sign: Adds tests and baseline comparison (quantitative).
[x] Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
