### PR TITLE
COMP: Fixes for compiler warnings

### DIFF
--- a/contrib/brl/bbas/bsta/bsta_histogram.h
+++ b/contrib/brl/bbas/bsta/bsta_histogram.h
@@ -139,12 +139,18 @@ template <class T> class bsta_histogram : public bsta_histogram_base
   //: array of bin values
   std::vector<T> value_array() const {
     std::vector<T> v(nbins_);
-    for (unsigned b = 0; b<nbins_; ++b) v[b]=avg_bin_value(b); return v; }
+    for (unsigned b = 0; b<nbins_; ++b)
+      v[b]=avg_bin_value(b);
+    return v;
+  }
 
   //: array of bin counts
   std::vector<T> count_array() const {
     std::vector<T> v(nbins_);
-    for (unsigned b = 0; b<nbins_; ++b) v[b]=counts(b); return v; }
+    for (unsigned b = 0; b<nbins_; ++b)
+      v[b]=counts(b);
+    return v;
+  }
 
  //: Smooth the histogram with a Parzen window of sigma
   void parzen(const T sigma);

--- a/core/vpgl/vpgl_perspective_camera.h
+++ b/core/vpgl/vpgl_perspective_camera.h
@@ -71,10 +71,6 @@ public:
   //: Main constructor based on K[R|t]
   vpgl_perspective_camera(const vpgl_calibration_matrix<T> & K, vgl_rotation_3d<T> R, const vgl_vector_3d<T> & t);
 
-
-  //: Copy constructor
-  vpgl_perspective_camera(const vpgl_perspective_camera & cam);
-
   //: Destructor
   ~vpgl_perspective_camera() override = default;
 

--- a/core/vpgl/vpgl_perspective_camera.hxx
+++ b/core/vpgl/vpgl_perspective_camera.hxx
@@ -69,15 +69,6 @@ vpgl_perspective_camera<T>::vpgl_perspective_camera(const vpgl_calibration_matri
 
 //-------------------------------------------
 template <class T>
-vpgl_perspective_camera<T>::vpgl_perspective_camera(const vpgl_perspective_camera & that)
-  : vpgl_proj_camera<T>(that)
-  , K_(that.K_)
-  , camera_center_(that.camera_center_)
-  , R_(that.R_)
-{}
-
-//-------------------------------------------
-template <class T>
 vpgl_perspective_camera<T> *
 vpgl_perspective_camera<T>::clone() const
 {


### PR DESCRIPTION
Provides fixes for compiler warnings generated when explicitly enabled for `gcc` or MSVC:
- Unclear indentation in `contrib/brl/bbas/bsta/bsta_histogram.h`
- Removes `vpgl_perspective_camera`'s copy constructor, as it appears [identical to the default copy constructor](https://stackoverflow.com/a/3278636) C++ generates. If a user-defined copy constructor is provided, then C++ assumes it has some logic that the default copy constructor can't handle. Thus, most likely [a user-defined copy assignment operator is also needed, and so the default copy assignment operator is marked as deprecated if it is used](https://stackoverflow.com/a/51864979), and similarly for the default destructor.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
