### PR TITLE
Fix narrowing conversion warnings in vnl_math.h fmod functions

### DIFF
--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -941,7 +941,7 @@ remainder_truncated(unsigned long long x, unsigned long long y)
 inline float
 remainder_truncated(float x, float y)
 {
-  return fmod(x, y);
+  return fmodf(x, y);
 }
 inline double
 remainder_truncated(double x, double y)
@@ -951,7 +951,7 @@ remainder_truncated(double x, double y)
 inline long double
 remainder_truncated(long double x, long double y)
 {
-  return fmod(x, y);
+  return fmodl(x, y);
 }
 
 // floored remainder
@@ -988,17 +988,17 @@ remainder_floored(unsigned long long x, unsigned long long y)
 inline float
 remainder_floored(float x, float y)
 {
-  return fmod(fmod(x, y) + y, y);
+  return fmodf(fmodf(x, y) + y, y);
 }
 inline double
 remainder_floored(double x, double y)
 {
-  return fmod(fmod(x, y) + y, y);
+  return std::fmod(std::fmod(x, y) + y, y);
 }
 inline long double
 remainder_floored(long double x, long double y)
 {
-  return fmod(fmod(x, y) + y, y);
+  return fmodl(fmodl(x, y) + y, y);
 }
 
 } // end of namespace vnl_math


### PR DESCRIPTION
## Summary

Fixes narrowing conversion warnings reported by clang-tidy's `bugprone-narrowing-conversions` check in `core/vnl/vnl_math.h`.

## Changes

Replaced `fmod()` calls with type-specific variants to avoid implicit float-to-double promotions:

| Function | Before | After |
|----------|--------|-------|
| `remainder_truncated(float, float)` | `fmod(x, y)` | `fmodf(x, y)` |
| `remainder_truncated(long double, long double)` | `fmod(x, y)` | `fmodl(x, y)` |
| `remainder_floored(float, float)` | `fmod(fmod(x, y) + y, y)` | `fmodf(fmodf(x, y) + y, y)` |
| `remainder_floored(double, double)` | `fmod(fmod(x, y) + y, y)` | `std::fmod(std::fmod(x, y) + y, y)` |
| `remainder_floored(long double, long double)` | `fmod(fmod(x, y) + y, y)` | `fmodl(fmodl(x, y) + y, y)` |

## Why

The standard `fmod()` function promotes float arguments to double, then returns a double. When assigning this back to a float or long double variable, clang-tidy reports a narrowing conversion warning.

Using type-specific variants (`fmodf` for float, `fmodl` for long double) avoids this promotion and the associated warning.

## Test Plan

- [x] clang-tidy no longer reports narrowing warnings for these functions
- [x] Code follows existing style (C++11 compatible)
- [x] No functional changes - only type-specific math functions used

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>