### PR TITLE
STYLE: Prefer explicit const designation and use <climits>

### DIFF
--- a/contrib/oul/ouml/image_ops.h
+++ b/contrib/oul/ouml/image_ops.h
@@ -5,13 +5,8 @@
 #include <vil1/vil1_save.h>
 #include "image_convert.h"
 #include <vxl_config.h> // for vxl_byte
-
-#ifndef INT_MAX
-#define INT_MAX (int)0x7fffffff
-#endif
-#ifndef INT_MIN
-#define INT_MIN (int)(-0x80000000)
-#endif
+                        //
+#include <climits> // for INT_MAX and INT_MIN
 
 template <class T>
 vil1_memory_image_of<T> &operator -=

--- a/core/testlib/testlib_main.cxx
+++ b/core/testlib/testlib_main.cxx
@@ -67,8 +67,8 @@ void
 testlib_enter_stealth_mode()
 {
   // check for Dashboard test
-  char * const env_var1 = std::getenv("DART_TEST_FROM_DART");
-  char * const env_var2 = std::getenv("DASHBOARD_TEST_FROM_CTEST"); // DART Client built in CMake
+  const char * const env_var1 = std::getenv("DART_TEST_FROM_DART");
+  const char * const env_var2 = std::getenv("DASHBOARD_TEST_FROM_CTEST"); // DART Client built in CMake
   if (env_var1 || env_var2)
   {
 
@@ -94,8 +94,8 @@ testlib_enter_stealth_mode()
 int
 testlib_run_test_unit(std::vector<std::string>::size_type i, int argc, char * argv[])
 {
-  char * const env_var1 = std::getenv("DART_TEST_FROM_DART");
-  char * const env_var2 = std::getenv("DASHBOARD_TEST_FROM_CTEST"); // DART Client built in CMake
+  const char * const env_var1 = std::getenv("DART_TEST_FROM_DART");
+  const char * const env_var2 = std::getenv("DASHBOARD_TEST_FROM_CTEST"); // DART Client built in CMake
   if (env_var1 || env_var2)
   {
     try

--- a/core/testlib/testlib_root_dir.cxx
+++ b/core/testlib/testlib_root_dir.cxx
@@ -17,7 +17,7 @@
 std::string
 testlib_root_dir()
 {
-  char * ptr = std::getenv("VXLSRC");
+  const char * ptr = std::getenv("VXLSRC");
   if (ptr)
     return { ptr };
 

--- a/core/vbl/tests/vbl_test_shared_pointer.cxx
+++ b/core/vbl/tests/vbl_test_shared_pointer.cxx
@@ -46,8 +46,8 @@ test_class()
   sp a(new some_class);
   sp b((some_class *)nullptr);
 
-  void * const olda = (void *)a.as_pointer();
-  void * const oldb = (void *)b.as_pointer();
+  const void * const olda = (void *)a.as_pointer();
+  const void * const oldb = (void *)b.as_pointer();
 
   for (int i = 0; i < 10003; ++i)
   {

--- a/core/vbl/vbl_bit_array_2d.cxx
+++ b/core/vbl/vbl_bit_array_2d.cxx
@@ -48,7 +48,7 @@ vbl_bit_array_2d::enlarge(unsigned int num_rows, unsigned int num_cols)
 {
   assert(num_rows >= num_rows_ && num_cols >= num_cols_);
 
-  unsigned char * const tempdata = data_;
+  const unsigned char * const tempdata = data_;
   const unsigned int tempm = num_rows_;
   const unsigned int tempn = num_cols_;
 

--- a/core/vil/file_formats/vil_bmp.cxx
+++ b/core/vil/file_formats/vil_bmp.cxx
@@ -464,7 +464,7 @@ vil_bmp_image::get_copy_view(unsigned x0, unsigned nx, unsigned y0, unsigned ny)
     // In other words,  swap B and R
     assert((want_bytes_per_raster & 3) == 0); //  must be multiple of 4
     auto * data = reinterpret_cast<vxl_byte *>(buf->data());
-    vxl_byte * const data_end = data + (want_bytes_per_raster * ny);
+    const vxl_byte * const data_end = data + (want_bytes_per_raster * ny);
     for (; data != data_end; data += 4)
     {
       // memory layout for pixel color values:

--- a/core/vil/file_formats/vil_geotiff_header.cxx
+++ b/core/vil/file_formats/vil_geotiff_header.cxx
@@ -34,7 +34,7 @@ vil_geotiff_header::vil_geotiff_header(TIFF * tif)
 bool
 vil_geotiff_header::gtif_tiepoints(std::vector<std::vector<double>> & tiepoints)
 {
-  double * points = nullptr;
+  const double * points = nullptr;
   short count = 0;
   if (TIFFGetField(tif_, GTIFF_TIEPOINTS, &count, &points) < 0)
     return false;
@@ -62,7 +62,7 @@ vil_geotiff_header::gtif_tiepoints(std::vector<std::vector<double>> & tiepoints)
 bool
 vil_geotiff_header::gtif_pixelscale(double & scale_x, double & scale_y, double & scale_z)
 {
-  double * data = nullptr;
+  const double * data = nullptr;
   short count = 0;
   if (TIFFGetField(tif_, GTIFF_PIXELSCALE, &count, &data))
   {
@@ -205,7 +205,7 @@ vil_geotiff_header::GCS_WGS84_MET_DEG()
     int length = 0;
     tagtype_t ttype;
     bool status = false;
-    short * val = nullptr;
+    const short * val = nullptr;
 
     // confirm linear units (optional) are in meters
     status = get_key_value(GeogLinearUnitsGeoKey, &value, size, length, ttype);

--- a/core/vil/file_formats/vil_jpeg.cxx
+++ b/core/vil/file_formats/vil_jpeg.cxx
@@ -240,7 +240,7 @@ vil_jpeg_image::put_view(const vil_image_view_base & view, unsigned x0, unsigned
                                                              view2.nplanes(),
                                                              view2.nplanes() * view2.ni(),
                                                              1);
-    JSAMPLE * const scanline = line.top_left_ptr();
+    JSAMPLE const * const scanline = line.top_left_ptr();
 
     for (unsigned int j = 0; j < view2.nj(); ++j)
     {

--- a/core/vil/file_formats/vil_nitf2_field_formatter.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_formatter.cxx
@@ -25,7 +25,7 @@ vil_nitf2_field_formatter::read_char_array(std::istream & input, int size)
 std::string
 vil_nitf2_field_formatter::read_string(std::istream & input, int size)
 {
-  char * const cstr = read_char_array(input, size);
+  const char * const cstr = read_char_array(input, size);
   std::string str = std::string(cstr);
   delete[] cstr;
   return str;

--- a/core/vil/file_formats/vil_nitf2_field_functor.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_functor.cxx
@@ -17,7 +17,7 @@ vil_nitf2_field_specified::operator()(vil_nitf2_field_sequence * record,
     // Invalid tag
     return false;
   }
-  vil_nitf2_field * const field = record->get_field(tag);
+  const vil_nitf2_field * const field = record->get_field(tag);
   if (field != nullptr)
   {
     std::string value;

--- a/core/vil/file_formats/vil_nitf2_field_sequence.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_sequence.cxx
@@ -56,7 +56,7 @@ vil_nitf2_field_sequence::create_array_fields(const vil_nitf2_field_definitions 
     else if (node && node->is_repeat_node())
     {
       // recursively create nested vector fields
-      vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
+      const vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
       if (!create_array_fields(repeat_node->field_definitions, num_dimensions + 1))
       {
         return false;
@@ -65,7 +65,7 @@ vil_nitf2_field_sequence::create_array_fields(const vil_nitf2_field_definitions 
     else if (node && node->is_condition_node())
     {
       // pass through create_array_fields to nested nodes
-      vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
+      const vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
       if (!create_array_fields(condition_node->field_definitions, num_dimensions))
       {
         return false;
@@ -89,7 +89,7 @@ vil_nitf2_field_sequence::set_array_fields_dimension(const vil_nitf2_field_defin
   {
     if (node && node->is_field_definition())
     {
-      vil_nitf2_field_definition * const field_def = node->field_definition();
+      const vil_nitf2_field_definition * const field_def = node->field_definition();
       vil_nitf2_array_field * field = get_field(field_def->tag)->array_field();
       if (field)
       {
@@ -106,13 +106,13 @@ vil_nitf2_field_sequence::set_array_fields_dimension(const vil_nitf2_field_defin
     else if (node && node->is_repeat_node())
     {
       // recursively set dimension vector fields
-      vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
+      const vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
       set_array_fields_dimension(repeat_node->field_definitions, index, repeat_count);
     }
     else if (node && node->is_condition_node())
     {
       // pass through set_array_fields_dimension to nested nodes
-      vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
+      const vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
       set_array_fields_dimension(condition_node->field_definitions, index, repeat_count);
     }
     else
@@ -206,7 +206,7 @@ vil_nitf2_field_sequence::read(vil_nitf2_istream & input,
           {
             // read vector field element
             bool read_error = true;
-            vil_nitf2_field_definition * const field_def = node->field_definition();
+            const vil_nitf2_field_definition * const field_def = node->field_definition();
             if (field_def)
             {
               vil_nitf2_array_field * field = get_field(field_def->tag)->array_field();
@@ -231,7 +231,7 @@ vil_nitf2_field_sequence::read(vil_nitf2_istream & input,
     }
     else if (node && node->is_repeat_node())
     {
-      vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
+      const vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
 
       // Compute how many times it repeats
       int repeat_count = 0;
@@ -303,7 +303,7 @@ vil_nitf2_field_sequence::read(vil_nitf2_istream & input,
     }
     else if (node && node->is_condition_node())
     {
-      vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
+      const vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
 
       // evaluate condition
       bool condition = false;
@@ -348,7 +348,7 @@ vil_nitf2_field_sequence::write(vil_nitf2_ostream & output,
   {
     if (node && node->is_field_definition())
     {
-      vil_nitf2_field_definition * const field_def = node->field_definition();
+      const vil_nitf2_field_definition * const field_def = node->field_definition();
       if (!field_def)
       {
         std::cerr << "vil_nitf2_field_sequence::write(): Missing field definition!\n";
@@ -431,7 +431,7 @@ vil_nitf2_field_sequence::write(vil_nitf2_ostream & output,
     }
     else if (node && node->is_repeat_node())
     {
-      vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
+      const vil_nitf2_field_definition_repeat_node * const repeat_node = node->repeat_node();
       // Compute how many times it repeats
       int repeat_count = 0;
       bool computed_repeat = false;
@@ -458,7 +458,7 @@ vil_nitf2_field_sequence::write(vil_nitf2_ostream & output,
     }
     else if (node && node->is_condition_node())
     {
-      vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
+      const vil_nitf2_field_definition_condition_node * const condition_node = node->condition_node();
 
       // evaluate condition
       bool condition = false;
@@ -490,7 +490,7 @@ vil_nitf2_field_sequence::~vil_nitf2_field_sequence()
   // Delete fields, which I own
   for (auto & field_map_entry : fields)
   {
-    vil_nitf2_field * const field = field_map_entry.second;
+    const vil_nitf2_field * const field = field_map_entry.second;
     delete field;
   }
 }

--- a/core/vil/file_formats/vil_nitf2_image_subheader.cxx
+++ b/core/vil/file_formats/vil_nitf2_image_subheader.cxx
@@ -718,7 +718,7 @@ vil_nitf2_image_subheader::get_tree(int i) const
 void
 vil_nitf2_image_subheader::add_rpc_definitions()
 {
-  vil_nitf2_tagged_record_definition * tr = vil_nitf2_tagged_record_definition::find("RPC00B");
+  const vil_nitf2_tagged_record_definition * tr = vil_nitf2_tagged_record_definition::find("RPC00B");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("RPC00B", "Rational Polynomial Coefficients Type B")
@@ -786,7 +786,7 @@ vil_nitf2_image_subheader::add_rpc_definitions()
 void
 vil_nitf2_image_subheader::add_USE_definitions()
 {
-  vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("USE00A");
+  const vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("USE00A");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("USE00A", "EXPLOITATION USABILITY EXTENSION FORMAT")
@@ -852,7 +852,7 @@ vil_nitf2_image_subheader::get_sun_params(double & sun_el, double & sun_az) cons
 void
 vil_nitf2_image_subheader::add_ICHIPB_definitions()
 {
-  vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("ICHIPB");
+  const vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("ICHIPB");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("ICHIPB", "ICHIPB SUPPORT DATA EXTENSION")
@@ -914,7 +914,7 @@ vil_nitf2_image_subheader::add_ICHIPB_definitions()
 void
 vil_nitf2_image_subheader::add_STDIDC_definitions()
 {
-  vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("STDIDC");
+  const vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("STDIDC");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("STDIDC", "STDIDC SUPPORT DATA EXTENSION")
@@ -946,7 +946,7 @@ vil_nitf2_image_subheader::add_STDIDC_definitions()
 void
 vil_nitf2_image_subheader::add_STDIDB_definitions()
 {
-  vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("STDIDB");
+  const vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("STDIDB");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("STDIDB", "STDIDB SUPPORT DATA EXTENSION")
@@ -983,7 +983,7 @@ vil_nitf2_image_subheader::add_STDIDB_definitions()
 void
 vil_nitf2_image_subheader::add_MPD26A_definitions()
 {
-  vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("MPD26A");
+  const vil_nitf2_tagged_record_definition * const tr = vil_nitf2_tagged_record_definition::find("MPD26A");
   if (!tr)
   {
     vil_nitf2_tagged_record_definition::define("MPD26A", "MPD26A SUPPORT DATA EXTENSION")

--- a/core/vil/file_formats/vil_nitf2_tagged_record.cxx
+++ b/core/vil/file_formats/vil_nitf2_tagged_record.cxx
@@ -541,11 +541,11 @@ vil_nitf2_tagged_record::output(std::ostream & os) const
   os << "CETAG: " << name() << '\n' << "CELEN: " << length() << std::endl;
   for (auto & m_field_definition : *m_definition->m_field_definitions)
   {
-    vil_nitf2_field_definition * const field_def = m_field_definition->field_definition();
+    const vil_nitf2_field_definition * const field_def = m_field_definition->field_definition();
     // to do: handle other nodes
     if (!field_def)
       break;
-    vil_nitf2_field * const field = get_field(field_def->tag);
+    const vil_nitf2_field * const field = get_field(field_def->tag);
     os << field_def->tag << ": ";
     if (field)
     {

--- a/core/vil/file_formats/vil_openjpeg.cxx
+++ b/core/vil/file_formats/vil_openjpeg.cxx
@@ -796,7 +796,7 @@ vil_openjpeg_image ::opj2vil(void * opj_view, unsigned int i0, unsigned int ni, 
 
     for (unsigned int j = 0; j < nj; ++j)
     {
-      int * const src_row = src_plane + (j0 + j) * opj_view_t->comps[p].w + i0;
+      const int * const src_row = src_plane + (j0 + j) * opj_view_t->comps[p].w + i0;
       T_PIXEL * const dst_row = dst_plane + j * vil_view_t->jstep();
 
       for (unsigned int i = 0; i < ni; ++i)

--- a/core/vil/file_formats/vil_png.cxx
+++ b/core/vil/file_formats/vil_png.cxx
@@ -501,7 +501,7 @@ vil_png_image::get_copy_view(unsigned x0, unsigned nx, unsigned y0, unsigned ny)
     return nullptr;
 
   // PNG lib wants everything in memory - the first get_rows reads the whole image.
-  png_byte ** const rows = p_->get_rows();
+  png_byte * const * const rows = p_->get_rows();
   if (!rows)
     return nullptr;
 
@@ -589,7 +589,7 @@ vil_png_image::put_view(const vil_image_view_base & view, unsigned x0, unsigned 
 
   // PNG lib wants everything in memory - the writing isn't done till this image is deleted.
 
-  png_byte ** const rows = p_->get_rows();
+  png_byte * const * const rows = p_->get_rows();
   if (!rows)
     return false;
 

--- a/core/vil/file_formats/vil_pnm.cxx
+++ b/core/vil/file_formats/vil_pnm.cxx
@@ -343,9 +343,9 @@ vil_image_view_base_sptr
 vil_pnm_image::get_copy_view(unsigned x0, unsigned ni, unsigned y0, unsigned nj) const
 {
   bool * bb = nullptr;
-  unsigned char * ib = nullptr;
-  unsigned short * jb = nullptr;
-  unsigned int * kb = nullptr;
+  vxl_byte * ib = nullptr;
+  vxl_uint_16 * jb = nullptr;
+  vxl_uint_32 * kb = nullptr;
 
   vil_memory_chunk_sptr buf;
 

--- a/core/vil/file_formats/vil_pyramid_image_list.cxx
+++ b/core/vil/file_formats/vil_pyramid_image_list.cxx
@@ -318,7 +318,7 @@ vil_pyramid_image_list::get_copy_view(unsigned int i0,
               << '\n';
     return nullptr;
   }
-  pyramid_level * const pl = levels_[level];
+  const pyramid_level * const pl = levels_[level];
   const float actual_scale = pl->scale_;
 
   float fi0 = actual_scale * i0, fni = actual_scale * n_i, fj0 = actual_scale * j0, fnj = actual_scale * n_j;
@@ -352,7 +352,7 @@ vil_pyramid_image_list::get_copy_view(unsigned int i0,
                                       float & actual_scale) const
 {
   // find the resource that is closest to the specified scale
-  pyramid_level * const pl = this->closest(scale);
+  const pyramid_level * const pl = this->closest(scale);
   if (!pl)
   {
     actual_scale = 0;

--- a/core/vil/file_formats/vil_tiff.cxx
+++ b/core/vil/file_formats/vil_tiff.cxx
@@ -1087,7 +1087,7 @@ vil_tiff_image::fill_block_from_view(unsigned bi,
   unsigned view_istep = 1, view_jstep = im.ni()*bytes_per_pixel, view_pstep = 1;
 #endif
   std::ptrdiff_t view_istep = 0, view_jstep = 0, view_pstep = 0;
-  vxl_byte * view_buf = nullptr;
+  const vxl_byte * view_buf = nullptr;
   // Cast the pixel type and reinterpret upper_left_ptr as a byte array.
   switch (h_->pix_fmt)
   {
@@ -1451,7 +1451,7 @@ vil_tiff_pyramid_resource::get_copy_view(unsigned i0,
                                          float & actual_scale) const
 {
   // Get the closest scale
-  tiff_pyramid_level * const pl = this->closest(scale);
+  const tiff_pyramid_level * const pl = this->closest(scale);
   if (!pl)
     return nullptr;
   actual_scale = pl->scale_;

--- a/core/vil/file_formats/vil_tiff_header.cxx
+++ b/core/vil/file_formats/vil_tiff_header.cxx
@@ -15,7 +15,7 @@ static std::string
 date_and_time()
 {
   std::time_t clock = 0;
-  struct std::tm * t_m = nullptr;
+  struct std::tm const * t_m = nullptr;
   clock = std::time(nullptr);
   t_m = std::localtime(&clock);
   char tmp[20];
@@ -29,7 +29,7 @@ date_and_time()
 static void
 read_string(TIFF * tif, ttag_t tag, std::string & stag, const std::string & deflt = "not_defined")
 {
-  char * adr = nullptr;
+  const char * adr = nullptr;
   TIFFGetField(tif, tag, &adr);
   if (adr)
     stag = std::string(adr);
@@ -160,7 +160,7 @@ vil_tiff_header::read_header()
 
   // EXTRASAMPLES tag requires two input arguments, which is different
   // from other 16bit values.
-  vxl_uint_16 * sample_info = nullptr;
+  const vxl_uint_16 * sample_info = nullptr;
   extra_samples.val = 0;
   extra_samples.valid = false;
   const int ret_extrasamples = TIFFGetField(tif_, TIFFTAG_EXTRASAMPLES, &extra_samples.val, &sample_info);
@@ -168,7 +168,7 @@ vil_tiff_header::read_header()
     extra_samples.valid = true;
 
   read_short_tag(tif_, TIFFTAG_FILLORDER, fill_order);
-  vxl_uint_16 * gc = nullptr;
+  const vxl_uint_16 * gc = nullptr;
   TIFFGetField(tif_, TIFFTAG_GRAYRESPONSECURVE, &gc);
   read_short_tag(tif_, TIFFTAG_GRAYRESPONSEUNIT, gray_response_unit);
   read_string(tif_, TIFFTAG_HOSTCOMPUTER, host_computer);
@@ -241,7 +241,7 @@ vil_tiff_header::read_header()
   }
 #endif
   uint32_t count = 0, f = 0;
-  char * data = nullptr;
+  const char * data = nullptr;
   f = TIFFGetField(tif_, 42113, &count, &data);
   if (f)
   {
@@ -289,7 +289,7 @@ vil_tiff_header::is_striped() const
 bool
 vil_tiff_header::is_GEOTIFF() const
 {
-  short * data = nullptr;
+  const short * data = nullptr;
   short count = 0;
   return TIFFGetField(tif_, 34735 /*TIFFTAG_GEOKEYDIRECTORY*/, &count, &data) != 0;
 }

--- a/core/vil/io/tests/test_memory_chunk_io.cxx
+++ b/core/vil/io/tests/test_memory_chunk_io.cxx
@@ -48,7 +48,7 @@ test_memory_chunk_io_as(T value)
   vpl_unlink("vil_memory_chunk_test_io.bvl.tmp");
 #endif
 
-  T * const data2 = reinterpret_cast<T *>(chunk2.data());
+  const T * const data2 = reinterpret_cast<T *>(chunk2.data());
 
   TEST("Size OK", chunk2.size() == chunk1.size(), true);
   TEST("Type OK", chunk1.pixel_format(), chunk2.pixel_format());

--- a/core/vil/vil_stream_url.cxx
+++ b/core/vil/vil_stream_url.cxx
@@ -195,7 +195,7 @@ vil_stream_url::vil_stream_url(const char * url)
 #endif
 
   // get network address of server.
-  hostent * const hp = gethostbyname(host.c_str());
+  const hostent * const hp = gethostbyname(host.c_str());
   if (!hp)
   {
     std::cerr << __FILE__ ": failed to lookup host\n";

--- a/core/vil1/examples/vil1_convolve.cxx
+++ b/core/vil1/examples/vil1_convolve.cxx
@@ -72,11 +72,11 @@ main(int argc, char ** argv)
   // Build kernel in "kernelimg"
   vil1_memory_image_of<float> kernelimg(0, 0);
   const std::string & kernel(a_kernel());
-  for (vil1_kernel_info * kp = kernels; kp->name; ++kp)
+  for (const vil1_kernel_info * kp = kernels; kp->name; ++kp)
     if (kernel == kp->name)
     {
       kernelimg.resize(kp->w, kp->h);
-      double * v = kp->mask;
+      const double * v = kp->mask;
       double power = 0;
       for (int y = 0; y < kp->h; ++y)
         for (int x = 0; x < kp->w; ++x)

--- a/core/vil1/examples/vil1_scale.cxx
+++ b/core/vil1/examples/vil1_scale.cxx
@@ -262,7 +262,7 @@ pnmscaleT<T, longT>::go()
   T * xelrow = nullptr;
   T * tempxelrow = nullptr;
   T * newxelrow = nullptr;
-  T * xP = nullptr;
+  const T * xP = nullptr;
   T * nxP = nullptr;
   int row = 0, col = 0, needtoreadrow = 0;
   long fracrowtofill = 0, fracrowleft = 0;

--- a/core/vil1/file_formats/vil1_png.cxx
+++ b/core/vil1/file_formats/vil1_png.cxx
@@ -440,7 +440,7 @@ vil1_png_generic_image::get_section(void * buf, int x0, int y0, int xs, int ys) 
     return false;
 
   // PNG lib wants everything in memory - the first get_rows reads the whole image.
-  png_byte ** const rows = p->get_rows();
+  png_byte * const * const rows = p->get_rows();
   if (!rows)
     return false;
 
@@ -469,7 +469,7 @@ vil1_png_generic_image::put_section(const void * buf, int x0, int y0, int xs, in
 
   // PNG lib wants everything in memory - the writing isn't done till this image is deleted.
 
-  png_byte ** const rows = p->get_rows();
+  png_byte * const * const rows = p->get_rows();
   if (!rows)
     return false;
 

--- a/core/vil1/file_formats/vil1_tiff.cxx
+++ b/core/vil1/file_formats/vil1_tiff.cxx
@@ -751,7 +751,7 @@ vil1_tiff_generic_image::get_section(void * buf, int x0, int y0, int xs, int ys)
         // printf("reading strip %d, y  = %d .. %d\n", strip_id, ymin, ymax);
         for (long y = ymin; y <= ymax; ++y)
         {
-          unsigned char * const in_row = p->buf + (y - strip_min_row) * p->scanlinesize;
+          const unsigned char * const in_row = p->buf + (y - strip_min_row) * p->scanlinesize;
           unsigned char * const out_row = (unsigned char *)buf + ((y - y0) * xs * pixel_bit_size + 7) / 8;
           std::memcpy(out_row, in_row + (x0 * pixel_bit_size + 7) / 8, (xs * pixel_bit_size + 7) / 8);
         }

--- a/core/vil1/tests/test_resample.cxx
+++ b/core/vil1/tests/test_resample.cxx
@@ -28,7 +28,7 @@ static unsigned char * t = (unsigned char *)nullptr;
 static void
 test_resample(int argc, char * argv[])
 {
-  char * filename = argv[1];
+  const char * filename = argv[1];
   if (argc < 2)
   {
     filename = default_filename;

--- a/core/vil1/vil1_byte_swap.cxx
+++ b/core/vil1/vil1_byte_swap.cxx
@@ -15,7 +15,7 @@ void
 vil1_byte_swap(void * b_, void * e_)
 {
   char * const b = static_cast<char *>(b_);
-  char * const e = static_cast<char *>(e_);
+  const char * const e = static_cast<char *>(e_);
   assert(b < e);
   const std::ptrdiff_t n = e - b;
   for (std::ptrdiff_t i = 0; i < n / 2; ++i)

--- a/core/vil1/vil1_load.cxx
+++ b/core/vil1/vil1_load.cxx
@@ -38,7 +38,7 @@ vil1_load_raw(vil1_stream * is)
 
   // failed.
   std::cerr << __FILE__ ": Tried";
-  for (vil1_file_format ** p = vil1_file_format::all(); *p; ++p)
+  for (vil1_file_format * const * p = vil1_file_format::all(); *p; ++p)
     std::cerr << " \'" << (*p)->tag() << "\'" << std::flush;
   std::cerr << ": none succeeded\n";
 

--- a/core/vil1/vil1_new.cxx
+++ b/core/vil1/vil1_new.cxx
@@ -48,7 +48,7 @@ vil1_new(vil1_stream * os,
   if (!file_format) // avoid segfault in strcmp()
     file_format = "pnm";
 
-  for (vil1_file_format ** p = vil1_file_format::all(); *p; ++p)
+  for (vil1_file_format * const * p = vil1_file_format::all(); *p; ++p)
   {
     vil1_file_format * fmt = *p;
     if (std::strcmp(fmt->tag(), file_format) == 0)

--- a/core/vil1/vil1_stream_url.cxx
+++ b/core/vil1/vil1_stream_url.cxx
@@ -193,7 +193,7 @@ vil1_stream_url::vil1_stream_url(const char * url)
 #endif
 
   // get network address of server.
-  hostent * const hp = gethostbyname(host.c_str());
+  const hostent * const hp = gethostbyname(host.c_str());
   if (!hp)
   {
     std::cerr << __FILE__ ": failed to lookup host\n";

--- a/core/vnl/algo/vnl_amoeba.cxx
+++ b/core/vnl/algo/vnl_amoeba.cxx
@@ -301,7 +301,7 @@ vnl_amoebaFit::amoeba(vnl_vector<double> & x, std::vector<vnl_amoeba_SimplexCorn
 
     set_corner_a_plus_bl(&reflect, vbar, simplex[n].v, -1);
 
-    vnl_amoeba_SimplexCorner * next = &reflect;
+    const vnl_amoeba_SimplexCorner * next = &reflect;
     const char * how = "reflect ";
     if (reflect.fv < simplex[n - 1].fv)
     {
@@ -322,7 +322,7 @@ vnl_amoebaFit::amoeba(vnl_vector<double> & x, std::vector<vnl_amoeba_SimplexCorn
     {
       // Reflection *is* totally crap...
       {
-        vnl_amoeba_SimplexCorner * tmp = &simplex[n];
+        const vnl_amoeba_SimplexCorner * tmp = &simplex[n];
         if (reflect.fv < tmp->fv)
           // replace simplex[n] by reflection as at least it's better than that
           tmp = &reflect;

--- a/core/vnl/algo/vnl_bracket_minimum.cxx
+++ b/core/vnl/algo/vnl_bracket_minimum.cxx
@@ -11,9 +11,9 @@
 #include <vnl/algo/vnl_bracket_minimum.h>
 #include <vnl/algo/vnl_fit_parabola.h>
 
-static const double GOLDEN_RATIO = 1.618033988749894848; // = 0.5*(std::sqrt(5)-1);
-static const double EPS = 1e-7;                          // Loose tolerance
-static const double EPSqr = 1e-14;
+static constexpr double GOLDEN_RATIO = 1.618033988749894848; // = 0.5*(std::sqrt(5)-1);
+static constexpr double EPS = 1e-7;                          // Loose tolerance
+static constexpr double EPSqr = 1e-14;
 inline void
 swap(double & a, double & b) noexcept
 {

--- a/core/vnl/algo/vnl_brent_minimizer.cxx
+++ b/core/vnl/algo/vnl_brent_minimizer.cxx
@@ -10,8 +10,8 @@
 #include <vnl/algo/vnl_bracket_minimum.h>
 
 // static const double GOLDEN_RATIO = 1.618033988749894848; // = 0.5*(std::sqrt(5)-1);
-static const double COMPL_GOLD = 0.381966011250105152; // = 0.5*(3-std::sqrt(5));
-static const double EPS = 1e-8;
+static constexpr double COMPL_GOLD = 0.381966011250105152; // = 0.5*(3-std::sqrt(5));
+static constexpr double EPS = 1e-8;
 
 // Wrapper to make it easy to evaluate the cost function
 class vnl_brent_minimizer_func

--- a/core/vnl/algo/vnl_conjugate_gradient.cxx
+++ b/core/vnl/algo/vnl_conjugate_gradient.cxx
@@ -70,7 +70,7 @@ vnl_conjugate_gradient::preconditioner_(double * out, double * in, void * userda
   // e.g. P = inv(diag(A'A)) for linear least squares systems.
 
   auto * self = static_cast<vnl_conjugate_gradient *>(userdata);
-  vnl_cost_function * const f = self->f_;
+  const vnl_cost_function * const f = self->f_;
 
   const int n = f->get_number_of_unknowns();
   for (int i = 0; i < n; ++i)

--- a/core/vnl/algo/vnl_generalized_eigensystem.cxx
+++ b/core/vnl/algo/vnl_generalized_eigensystem.cxx
@@ -52,7 +52,7 @@ vnl_generalized_eigensystem::vnl_generalized_eigensystem(const vnl_matrix<double
 
   // transpose-copy V1 to V
   {
-    double * vptr = &V1[0];
+    const double * vptr = &V1[0];
     for (int c = 0; c < n; ++c)
       for (int r = 0; r < n; ++r)
         V(r, c) = *vptr++;

--- a/core/vnl/algo/vnl_generalized_eigensystem.cxx
+++ b/core/vnl/algo/vnl_generalized_eigensystem.cxx
@@ -37,7 +37,7 @@ vnl_generalized_eigensystem::vnl_generalized_eigensystem(const vnl_matrix<double
   // If b was not pos-def, retry with projection onto nullspace
   if (ierr == 7 * n + 1)
   {
-    const double THRESH = 1e-8;
+    constexpr double THRESH = 1e-8;
     vnl_symmetric_eigensystem<double> eig(B);
     if (eig.D(0, 0) < -THRESH)
     {

--- a/core/vnl/algo/vnl_ldl_cholesky.cxx
+++ b/core/vnl/algo/vnl_ldl_cholesky.cxx
@@ -245,7 +245,7 @@ vnl_ldl_cholesky::update(const vnl_matrix<double> & W0)
   vnl_vector<double> gamma(r); // Workspace
   for (unsigned j = 0; j < n; ++j)
   {
-    double * const Wj = W[j];
+    const double * const Wj = W[j];
     for (unsigned i = 0; i < r; ++i)
     {
       const double a2 = a[i] + Wj[i] * Wj[i] / d_[j];

--- a/core/vnl/algo/vnl_rnpoly_solve.cxx
+++ b/core/vnl/algo/vnl_rnpoly_solve.cxx
@@ -96,12 +96,12 @@ public:
   }
 };
 
-static const double twopi = vnl_math::twopi;
+static constexpr double twopi = vnl_math::twopi;
 
-static const double epsilonB = 2.e-03;
+static constexpr double epsilonB = 2.e-03;
 static const vnl_rnpoly_solve_cmplx epsilonZ = vnl_rnpoly_solve_cmplx(1.e-04, 1.e-04);
-static const double final_eps = 1.e-10;
-static const double stepinit = 1.e-02;
+static constexpr double final_eps = 1.e-10;
+static constexpr double stepinit = 1.e-02;
 
 
 std::vector<vnl_vector<double> *>

--- a/core/vnl/algo/vnl_sparse_lm.cxx
+++ b/core/vnl/algo/vnl_sparse_lm.cxx
@@ -183,7 +183,7 @@ vnl_sparse_lm::minimize(vnl_vector<double> & a,
         // this large inverse is the bottle neck of this algorithm
         vnl_matrix<double> H;
         const vnl_cholesky Sa_cholesky(Sa, vnl_cholesky::quiet);
-        vnl_svd<double> * Sa_svd = nullptr;
+        const vnl_svd<double> * Sa_svd = nullptr;
         // use SVD as a backup if Cholesky is deficient
         if (Sa_cholesky.rank_deficiency() > 0)
         {

--- a/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
+++ b/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
@@ -528,7 +528,7 @@ vnl_sparse_symmetric_eigensystem::RestoreVectors(int n, int m, double * q, int b
   if (base == 0)
     read_idx = 0;
 
-  double * const temp = temp_store[read_idx];
+  const double * const temp = temp_store[read_idx];
   std::memcpy(q, temp, n * m * sizeof(double));
 #ifdef DEBUG
   std::cout << "Restore vectors " << base << ' ' << temp << '\n';

--- a/core/vnl/tests/test_inverse.cxx
+++ b/core/vnl/tests/test_inverse.cxx
@@ -9,7 +9,7 @@
 static void
 test_inverse()
 {
-  const double eps = 1e-11;
+  constexpr double eps = 1e-11;
   vnl_random rng(9667566ul);
   vnl_double_2x2 residue2;
   vnl_double_2x2 id2;

--- a/core/vnl/tests/test_math.cxx
+++ b/core/vnl/tests/test_math.cxx
@@ -113,9 +113,9 @@ test_math()
   test_static_const_definition();
   test_math_constants();
 
-  const int n = -11;
-  const float f = -7.5f;
-  const double d = -vnl_math::pi;
+  constexpr int n = -11;
+  constexpr float f = -7.5f;
+  constexpr double d = -vnl_math::pi;
   const std::complex<double> i(0, 1);
   const std::complex<double> z(-1, 2);
   const std::complex<double> e_ipi = std::exp(d * i);
@@ -436,16 +436,16 @@ test_math()
 
     std::cout << "+ +" << std::endl;
 
-    const unsigned short x_short_u = 7;
-    const unsigned short y_short_u = 2;
+    constexpr unsigned short x_short_u = 7;
+    constexpr unsigned short y_short_u = 2;
     signed short x_short_s = 7;
     signed short y_short_s = 2;
-    const unsigned int x_int_u = 7;
-    const unsigned int y_int_u = 2;
+    constexpr unsigned int x_int_u = 7;
+    constexpr unsigned int y_int_u = 2;
     signed int x_int_s = 7;
     signed int y_int_s = 2;
-    const unsigned long x_long_u = 7;
-    const unsigned long y_long_u = 2;
+    constexpr unsigned long x_long_u = 7;
+    constexpr unsigned long y_long_u = 2;
     signed long x_long_s = 7;
     signed long y_long_s = 2;
     float x_float = 7;
@@ -596,16 +596,16 @@ test_math()
 
     std::cout << "+ +" << std::endl;
 
-    const unsigned short x_short_u = 7;
-    const unsigned short y_short_u = 2;
+    constexpr unsigned short x_short_u = 7;
+    constexpr unsigned short y_short_u = 2;
     signed short x_short_s = 7;
     signed short y_short_s = 2;
-    const unsigned int x_int_u = 7;
-    const unsigned int y_int_u = 2;
+    constexpr unsigned int x_int_u = 7;
+    constexpr unsigned int y_int_u = 2;
     signed int x_int_s = 7;
     signed int y_int_s = 2;
-    const unsigned long x_long_u = 7;
-    const unsigned long y_long_u = 2;
+    constexpr unsigned long x_long_u = 7;
+    constexpr unsigned long y_long_u = 2;
     signed long x_long_s = 7;
     signed long y_long_s = 2;
     float x_float = 7;

--- a/core/vnl/tests/test_power.cxx
+++ b/core/vnl/tests/test_power.cxx
@@ -7,7 +7,7 @@
 static void
 test_power()
 {
-  const double eps = 1e-11;
+  constexpr double eps = 1e-11;
   vnl_double_2x2 residue2;
   vnl_double_2x2 id2;
   id2.set_identity();

--- a/core/vnl/tests/test_random.cxx
+++ b/core/vnl/tests/test_random.cxx
@@ -23,7 +23,7 @@ test_random()
 
   double sum = 0.0;
   double sum_sq = 0.0;
-  const int n = 10000;
+  constexpr int n = 10000;
   for (int i = 0; i < n; ++i)
   {
     const double r = mz_random.normal();

--- a/core/vnl/tests/test_sample.cxx
+++ b/core/vnl/tests/test_sample.cxx
@@ -10,9 +10,9 @@ static void
 test_sample_uniform()
 {
   std::cout << "*************** sample uniform ***************\n";
-  const unsigned N = 100000;
-  const double a = 123.456;
-  const double b = 543.210;
+  constexpr unsigned N = 100000;
+  constexpr double a = 123.456;
+  constexpr double b = 543.210;
   vnl_sample_reseed(); // initialise the random seed in a random way
 
   double X[N];

--- a/core/vnl/vnl_fastops.cxx
+++ b/core/vnl/vnl_fastops.cxx
@@ -23,7 +23,7 @@ vnl_fastops::AtA(vnl_matrix<double> & out, const vnl_matrix<double> & A)
   const unsigned int m = A.rows();
 
   const double * const * const a = A.data_array();
-  double ** const ata = out.data_array();
+  double * const * const ata = out.data_array();
 
   /* Simple Implementation for reference:
       for (unsigned int i = 0; i < n; ++i)
@@ -76,7 +76,7 @@ vnl_fastops::AB(vnl_matrix<double> & out, const vnl_matrix<double> & A, const vn
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const outdata = out.data_array();
+  double * const * const outdata = out.data_array();
 
   for (unsigned int i = 0; i < ma; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -111,7 +111,7 @@ vnl_fastops::AtB(vnl_matrix<double> & out, const vnl_matrix<double> & A, const v
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const outdata = out.data_array();
+  double * const * const outdata = out.data_array();
 
   for (unsigned int i = 0; i < na; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -212,7 +212,7 @@ vnl_fastops::ABt(vnl_matrix<double> & out, const vnl_matrix<double> & A, const v
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const outdata = out.data_array();
+  double * const * const outdata = out.data_array();
 
   for (unsigned int i = 0; i < ma; ++i)
     for (unsigned int j = 0; j < mb; ++j)
@@ -255,7 +255,7 @@ vnl_fastops::ABAt(vnl_matrix<double> & out, const vnl_matrix<double> & A, const 
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const outdata = out.data_array();
+  double * const * const outdata = out.data_array();
 
   // initialize
   for (unsigned int i = 0; i < ma; ++i)
@@ -323,7 +323,7 @@ vnl_fastops::inc_X_by_AtA(vnl_matrix<double> & X, const vnl_matrix<double> & A)
   const unsigned int l = A.rows();
 
   const double * const * const a = A.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   if (l == 2)
   {
@@ -381,7 +381,7 @@ vnl_fastops::inc_X_by_AB(vnl_matrix<double> & X, const vnl_matrix<double> & A, c
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   for (unsigned int i = 0; i < ma; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -417,7 +417,7 @@ vnl_fastops::dec_X_by_AB(vnl_matrix<double> & X, const vnl_matrix<double> & A, c
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   for (unsigned int i = 0; i < ma; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -453,7 +453,7 @@ vnl_fastops::inc_X_by_AtB(vnl_matrix<double> & X, const vnl_matrix<double> & A, 
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   for (unsigned int i = 0; i < na; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -493,7 +493,7 @@ vnl_fastops::dec_X_by_AtB(vnl_matrix<double> & X, const vnl_matrix<double> & A, 
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   for (unsigned int i = 0; i < na; ++i)
     for (unsigned int j = 0; j < nb; ++j)
@@ -596,7 +596,7 @@ vnl_fastops::dec_X_by_AtA(vnl_matrix<double> & X, const vnl_matrix<double> & A)
   const unsigned int l = A.rows();
 
   const double * const * const a = A.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   if (l == 2)
   {
@@ -682,7 +682,7 @@ vnl_fastops::inc_X_by_ABt(vnl_matrix<double> & X, const vnl_matrix<double> & A, 
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   if (na == 3)
   {
@@ -738,7 +738,7 @@ vnl_fastops::dec_X_by_ABt(vnl_matrix<double> & X, const vnl_matrix<double> & A, 
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const x = X.data_array();
+  double * const * const x = X.data_array();
 
   if (na == 3)
   {
@@ -798,7 +798,7 @@ vnl_fastops::inc_X_by_ABAt(vnl_matrix<double> & X, const vnl_matrix<double> & A,
 
   const double * const * const a = A.data_array();
   const double * const * const b = B.data_array();
-  double ** const Xdata = X.data_array();
+  double * const * const Xdata = X.data_array();
 
   for (unsigned int i = 0; i < ma; ++i)
     for (unsigned int j = 0; j < nb; ++j)

--- a/core/vnl/vnl_gamma.cxx
+++ b/core/vnl/vnl_gamma.cxx
@@ -31,8 +31,8 @@ vnl_log_gamma(double x)
 }
 
 constexpr int MAX_ITS = 100;
-const double MaxRelError = 3.0e-7;
-const double vnl_very_small = 1.0e-30;
+constexpr double MaxRelError = 3.0e-7;
+constexpr double vnl_very_small = 1.0e-30;
 
 //: Use series expansion of incomplete gamma function
 static double
@@ -123,7 +123,7 @@ vnl_digamma(double z)
 {
   const double t0 = (z - 0.5) / (z + 4.65) - 1.0;
   const double tlg = std::log(4.65 + z);
-  const double tc = 2.50662827563479526904;
+  constexpr double tc = 2.50662827563479526904;
   const double t1 = 225.525584619175212544 / z;
   const double t2 = -268.295973841304927459 / (1 + z);
   const double t3 = +80.9030806934622512966 / (2 + z);

--- a/core/vnl/vnl_matrix.hxx
+++ b/core/vnl/vnl_matrix.hxx
@@ -1307,7 +1307,7 @@ vnl_matrix<T>::read_ascii(std::istream & s)
     return s.good() || s.eof();
   }
 
-  const bool debug = false;
+  constexpr bool debug = false;
 
   std::vector<T> first_row_vals;
   if (debug)

--- a/core/vpdl/tests/test_gaussian_indep.cxx
+++ b/core/vpdl/tests/test_gaussian_indep.cxx
@@ -228,7 +228,7 @@ test_gaussian_indep_type(T epsilon, const std::string & type_name)
               box_test,
               epsilon);
 
-    vpdl_distribution<T> * const base = &gauss; // pointer to the base class
+    const vpdl_distribution<T> * const base = &gauss; // pointer to the base class
     TEST_NEAR(("box probability (base==derived) <" + type_name + ">").c_str(),
               base->box_prob(test2.as_ref(), test1.as_ref()),
               gauss.box_prob(test2.as_ref(), test1.as_ref()),

--- a/core/vpdl/tests/test_gaussian_sphere.cxx
+++ b/core/vpdl/tests/test_gaussian_sphere.cxx
@@ -221,7 +221,7 @@ test_gaussian_sphere_type(T epsilon, const std::string & type_name)
               box_test,
               epsilon);
 
-    vpdl_distribution<T> * const base = &gauss; // pointer to the base class
+    const vpdl_distribution<T> * const base = &gauss; // pointer to the base class
     TEST_NEAR(("box probability (base==derived) <" + type_name + ">").c_str(),
               base->box_prob(test2.as_ref(), test1.as_ref()),
               gauss.box_prob(test2.as_ref(), test1.as_ref()),

--- a/core/vpgl/algo/tests/test_affine_tensor_transfer.cxx
+++ b/core/vpgl/algo/tests/test_affine_tensor_transfer.cxx
@@ -174,7 +174,7 @@ rat_cameras(vpgl_local_rational_camera<double> & cam0,
   ss0 << "232.111831665" << std::endl;
 
   std::istringstream istr(ss0.str());
-  vpgl_local_rational_camera<double> * const cam0_ptr = read_local_rational_camera<double>(istr);
+  const vpgl_local_rational_camera<double> * const cam0_ptr = read_local_rational_camera<double>(istr);
 
   ss1 << " satId ="
          "????"
@@ -288,7 +288,7 @@ rat_cameras(vpgl_local_rational_camera<double> & cam0,
   ss1 << "232.111831665" << std::endl;
 
   std::istringstream istr1(ss1.str());
-  vpgl_local_rational_camera<double> * const cam1_ptr = read_local_rational_camera<double>(istr1);
+  const vpgl_local_rational_camera<double> * const cam1_ptr = read_local_rational_camera<double>(istr1);
 
   ss2 << " satId ="
          "????"
@@ -402,7 +402,7 @@ rat_cameras(vpgl_local_rational_camera<double> & cam0,
   ss2 << "232.111831665" << std::endl;
 
   std::istringstream istr2(ss2.str());
-  vpgl_local_rational_camera<double> * const cam2_ptr = read_local_rational_camera<double>(istr2);
+  const vpgl_local_rational_camera<double> * const cam2_ptr = read_local_rational_camera<double>(istr2);
   cam0 = *cam0_ptr;
   cam1 = *cam1_ptr;
   cam2 = *cam2_ptr;

--- a/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.cxx
@@ -440,7 +440,7 @@ vpgl_nitf_RSM_camera_extractor::determine_overflow_status(vil_nitf2_image * nitf
   }
   vil_nitf2_tagged_record_sequence::const_iterator tres_itr;
   // get the data extension
-  vil_nitf2_des * const des = (nitf_image->get_des())[ixsofl - 1]; // should agree with subheader index
+  const vil_nitf2_des * const des = (nitf_image->get_des())[ixsofl - 1]; // should agree with subheader index
   if (!des)
   {
     std::cout << "null des" << std::endl;
@@ -553,7 +553,7 @@ vpgl_nitf_RSM_camera_extractor::init(vil_nitf2_image * nitf_image, bool verbose)
 
   for (unsigned i = 0; i < headers.size(); ++i)
   {
-    vil_nitf2_image_subheader * const hdr = headers[i];
+    const vil_nitf2_image_subheader * const hdr = headers[i];
     if (nitf_status_[i] == INVALID)
       continue;
     // Get standard metadata from the nitf2_image and image subheader

--- a/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_rational_camera.cxx
@@ -276,7 +276,7 @@ bool
 vpgl_nitf_rational_camera::read(vil_nitf2_image * nitf_image, bool verbose)
 {
   const std::vector<vil_nitf2_image_subheader *> & headers = nitf_image->get_image_headers();
-  vil_nitf2_image_subheader * const hdr = headers[0];
+  const vil_nitf2_image_subheader * const hdr = headers[0];
 
   // initialize the array
   double tre_data[90];

--- a/core/vpgl/file_formats/vpgl_replacement_sensor_model_tres.cxx
+++ b/core/vpgl/file_formats/vpgl_replacement_sensor_model_tres.cxx
@@ -193,7 +193,7 @@ void
 vpgl_replacement_sensor_model_tres::define_RSMIDA()
 {
 
-  vil_nitf2_tagged_record_definition * const tri = vil_nitf2_tagged_record_definition::find("RSMIDA");
+  const vil_nitf2_tagged_record_definition * const tri = vil_nitf2_tagged_record_definition::find("RSMIDA");
   if (!tri)
   {
     vil_nitf2_tagged_record_definition::define("RSMIDA", "Replacement Sensor Model Identification")
@@ -285,7 +285,7 @@ vpgl_replacement_sensor_model_tres::define_RSMIDA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMPCA()
 {
-  vil_nitf2_tagged_record_definition * const trp = vil_nitf2_tagged_record_definition::find("RSMPCA");
+  const vil_nitf2_tagged_record_definition * const trp = vil_nitf2_tagged_record_definition::find("RSMPCA");
   if (!trp)
   {
     vil_nitf2_tagged_record_definition::define("RSMPCA", "Replacement Sensor Model Polynomial Coefficients")
@@ -336,7 +336,7 @@ void
 vpgl_replacement_sensor_model_tres::define_RSMPIA()
 {
   // check for multiple polynomials
-  vil_nitf2_tagged_record_definition * const trpi = vil_nitf2_tagged_record_definition::find("RSMPIA");
+  const vil_nitf2_tagged_record_definition * const trpi = vil_nitf2_tagged_record_definition::find("RSMPIA");
   if (!trpi)
   {
     vil_nitf2_tagged_record_definition::define("RSMPIA", "Multiple Section Polynomials")
@@ -378,7 +378,7 @@ vpgl_replacement_sensor_model_tres::define_RSMPIA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMECA()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMECA");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMECA");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMECA", "Indirect Error Covariance")
@@ -490,7 +490,7 @@ vpgl_replacement_sensor_model_tres::define_RSMECA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMECB()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMECB");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMECB");
   if (!trgi)
   {
 
@@ -618,7 +618,7 @@ vpgl_replacement_sensor_model_tres::define_RSMECB()
 void
 vpgl_replacement_sensor_model_tres::define_RSMDCA()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMDCA");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMDCA");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMDCA", "Direct Error Covariance")
@@ -629,7 +629,7 @@ vpgl_replacement_sensor_model_tres::define_RSMDCA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMDCB()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMDCB");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMDCB");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMDCB", "Extended Direct Error Covariance")
@@ -640,7 +640,7 @@ vpgl_replacement_sensor_model_tres::define_RSMDCB()
 void
 vpgl_replacement_sensor_model_tres::define_RSMAPA()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMAPA");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMAPA");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMAPA", "Adjustable Parameters")
@@ -651,7 +651,7 @@ vpgl_replacement_sensor_model_tres::define_RSMAPA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMAPB()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMAPB");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMAPB");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMAPB", "Extended Adjustable Parameters")
@@ -662,7 +662,7 @@ vpgl_replacement_sensor_model_tres::define_RSMAPB()
 void
 vpgl_replacement_sensor_model_tres::define_RSMGIA()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMGIA");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMGIA");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMGIA", "Multi-section Grids")
@@ -673,7 +673,7 @@ vpgl_replacement_sensor_model_tres::define_RSMGIA()
 void
 vpgl_replacement_sensor_model_tres::define_RSMGGA()
 {
-  vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMGGA");
+  const vil_nitf2_tagged_record_definition * const trgi = vil_nitf2_tagged_record_definition::find("RSMGGA");
   if (!trgi)
   {
     vil_nitf2_tagged_record_definition::define("RSMGGA", "Ground to Image Grid")

--- a/core/vpgl/io/vpgl_io_camera.cxx
+++ b/core/vpgl/io/vpgl_io_camera.cxx
@@ -8,7 +8,7 @@ vsl_b_write(vsl_b_ostream & os, const vpgl_camera_double_sptr & cam_sptr)
 {
   if (!cam_sptr)
     return;
-  vpgl_camera<double> * const cam = cam_sptr.ptr();
+  const vpgl_camera<double> * const cam = cam_sptr.ptr();
   vsl_b_write(os, cam);
 }
 
@@ -18,7 +18,7 @@ vsl_b_write(vsl_b_ostream & os, const vpgl_camera_float_sptr & cam_sptr)
 {
   if (!cam_sptr)
     return;
-  vpgl_camera<float> * const cam = cam_sptr.ptr();
+  const vpgl_camera<float> * const cam = cam_sptr.ptr();
   vsl_b_write(os, cam);
 }
 

--- a/core/vpgl/io/vpgl_io_camera.h
+++ b/core/vpgl/io/vpgl_io_camera.h
@@ -10,7 +10,7 @@
 //: Binary save camera to stream
 template <class T>
 void
-vsl_b_write(vsl_b_ostream & os, vpgl_camera<T> * const & camera);
+vsl_b_write(vsl_b_ostream & os, const vpgl_camera<T> * const & camera);
 
 //: Binary load camera from stream.
 template <class T>

--- a/core/vpgl/io/vpgl_io_camera.hxx
+++ b/core/vpgl/io/vpgl_io_camera.hxx
@@ -26,40 +26,40 @@
 //: Binary save camera to stream
 template <class T>
 void
-vsl_b_write(vsl_b_ostream & os, vpgl_camera<T> * const & camera)
+vsl_b_write(vsl_b_ostream & os, const vpgl_camera<T> * const & camera)
 {
   if (camera->type_name() == "vpgl_proj_camera")
   {
     // projective camera
-    vpgl_proj_camera<T> * procam = static_cast<vpgl_proj_camera<T> *>(camera);
+    const vpgl_proj_camera<T> * procam = static_cast<const vpgl_proj_camera<T> *>(camera);
     vsl_b_write(os, procam->type_name());
     vsl_b_write(os, *procam);
   }
   else if (camera->type_name() == "vpgl_perspective_camera")
   {
     // perspective camera
-    vpgl_perspective_camera<T> * percam = static_cast<vpgl_perspective_camera<T> *>(camera);
+    const vpgl_perspective_camera<T> * percam = static_cast<const vpgl_perspective_camera<T> *>(camera);
     vsl_b_write(os, percam->type_name());
     vsl_b_write(os, *percam);
   }
   else if (camera->type_name() == "vpgl_affine_camera")
   {
     // affine camera
-    vpgl_affine_camera<T> * affcam = static_cast<vpgl_affine_camera<T> *>(camera);
+    const vpgl_affine_camera<T> * affcam = static_cast<const vpgl_affine_camera<T> *>(camera);
     vsl_b_write(os, affcam->type_name());
     vsl_b_write(os, *affcam);
   }
   else if (camera->type_name() == "vpgl_rational_camera")
   {
     // rational camera
-    vpgl_rational_camera<T> * ratcam = static_cast<vpgl_rational_camera<T> *>(camera);
+    const vpgl_rational_camera<T> * ratcam = static_cast<const vpgl_rational_camera<T> *>(camera);
     vsl_b_write(os, ratcam->type_name());
     vsl_b_write(os, *ratcam);
   }
   else if (camera->type_name() == "vpgl_local_rational_camera")
   {
     // local rational camera
-    vpgl_local_rational_camera<T> * lratcam = static_cast<vpgl_local_rational_camera<T> *>(camera);
+    const vpgl_local_rational_camera<T> * lratcam = static_cast<const vpgl_local_rational_camera<T> *>(camera);
     vsl_b_write(os, lratcam->type_name());
     vsl_b_write(os, *lratcam);
   }
@@ -129,6 +129,6 @@ vsl_b_read(vsl_b_istream & is, vpgl_camera<T> *& camera)
 
 #define VPGL_IO_CAMERA_INSTANTIATE(T)                           \
   template void vsl_b_read(vsl_b_istream &, vpgl_camera<T> *&); \
-  template void vsl_b_write(vsl_b_ostream &, vpgl_camera<T> * const &)
+  template void vsl_b_write(vsl_b_ostream &, const vpgl_camera<T> * const &)
 
 #endif // vpgl_io_camera_hxx_

--- a/core/vpgl/io/vpgl_io_lvcs.cxx
+++ b/core/vpgl/io/vpgl_io_lvcs.cxx
@@ -108,7 +108,7 @@ vsl_b_write(vsl_b_ostream & os, const vpgl_lvcs_sptr & lvcs_sptr)
 {
   if (!lvcs_sptr)
     return;
-  vpgl_lvcs * const lvcs = lvcs_sptr.ptr();
+  const vpgl_lvcs * const lvcs = lvcs_sptr.ptr();
   vsl_b_write(os, *lvcs);
 }
 

--- a/core/vpgl/tests/test_local_rational_camera.cxx
+++ b/core/vpgl/tests/test_local_rational_camera.cxx
@@ -106,7 +106,7 @@ test_local_rational_camera()
   const std::string path = "./test.lrcam";
   const bool good = lrcam.save(path);
   TEST("save to file", good, true);
-  vpgl_local_rational_camera<double> * const lrc_r = read_local_rational_camera<double>(path);
+  const vpgl_local_rational_camera<double> * const lrc_r = read_local_rational_camera<double>(path);
   double ulr = NAN, vlr = NAN;
   lrc_r->project(0.0, 0.0, 0.0, ulr, vlr);
   TEST_NEAR("read from file", std::fabs(ug - ulr) + std::fabs(vg - vlr), 0.0, 1e-3);

--- a/core/vrel/examples/robust_homography2d_fit.cxx
+++ b/core/vrel/examples/robust_homography2d_fit.cxx
@@ -67,7 +67,7 @@ main()
   //
   {
     const int num_dep_res = hg->num_samples_to_instantiate();
-    vrel_objective * const lms = new vrel_lms_obj(num_dep_res);
+    const vrel_objective * const lms = new vrel_lms_obj(num_dep_res);
 
     auto * ransam = new vrel_ran_sam_search;
     ransam->set_trace_level(trace_level);

--- a/core/vrel/examples/robust_line_fit.cxx
+++ b/core/vrel/examples/robust_line_fit.cxx
@@ -100,7 +100,7 @@ main()
   //
   {
     const int num_sam_inst = lr->num_samples_to_instantiate();
-    vrel_objective * const lms = new vrel_lms_obj(num_sam_inst);
+    const vrel_objective * const lms = new vrel_lms_obj(num_sam_inst);
     auto * ransam = new vrel_ran_sam_search;
     ransam->set_sampling_params(max_outlier_frac, desired_prob_good, max_pops);
     ransam->set_trace_level(trace_level);
@@ -198,7 +198,7 @@ main()
   //  should provide an initial parameter estimate.
   //
   {
-    vrel_m_est_obj * const m_est = new vrel_tukey_obj(4.0);
+    const vrel_m_est_obj * const m_est = new vrel_tukey_obj(4.0);
 
     lr->set_no_prior_scale();
 
@@ -230,7 +230,7 @@ main()
   }
 
   {
-    vrel_m_est_obj * const m_est = new vrel_tukey_obj(4.0);
+    const vrel_m_est_obj * const m_est = new vrel_tukey_obj(4.0);
 
     lr->set_no_prior_scale();
 

--- a/core/vrel/tests/test_irls.cxx
+++ b/core/vrel/tests/test_irls.cxx
@@ -174,7 +174,7 @@ test_irls()
   regression_points(true_params.as_vector(), sigma, pts);
   auto * lr = new vrel_linear_regression(pts, use_intercept);
   const int dof = lr->param_dof();
-  vrel_wls_obj * const m_est = new vrel_tukey_obj(dof);
+  const vrel_wls_obj * const m_est = new vrel_tukey_obj(dof);
   int max_iterations = 50;
   testlib_test_begin("ctor");
   auto * irls = new vrel_irls(max_iterations);
@@ -240,7 +240,7 @@ test_irls()
   std::vector<image_point_match> matches;
   sigma = 0.25;
   generate_similarity_matches(params.as_vector(), sigma, matches);
-  vrel_estimation_problem * const match_prob = new similarity_from_matches(matches);
+  const vrel_estimation_problem * const match_prob = new similarity_from_matches(matches);
 
   vrel_irls irls_m(20);
   irls_m.set_trace_level(trace_level);

--- a/core/vrel/tests/test_lms_lts.cxx
+++ b/core/vrel/tests/test_lms_lts.cxx
@@ -14,7 +14,7 @@ test_lms_lts()
   //
   int dof = 3;
   double frac = 0.5;
-  vrel_objective * const lms1 = new vrel_lms_obj(dof, frac);
+  const vrel_objective * const lms1 = new vrel_lms_obj(dof, frac);
 
   std::vector<double> test_lms;
   test_lms.push_back(-1.0);
@@ -38,7 +38,7 @@ test_lms_lts()
   TEST_NEAR("LMS with 0.5 inlier fraction:", obj, corr_obj, 1e-6);
 
   frac = 0.7;
-  vrel_objective * const lms2 = new vrel_lms_obj(dof, frac);
+  const vrel_objective * const lms2 = new vrel_lms_obj(dof, frac);
   corr_obj = 4.0 * 4.0;
   obj = lms2->fcn(test_lms.begin(), test_lms.end(), 0.0, nullptr);
   TEST_NEAR("LMS with 0.7 inlier fraction:", obj, corr_obj, 1e-6);
@@ -48,7 +48,7 @@ test_lms_lts()
   //
   dof = 3;
   frac = 0.5;
-  vrel_objective * const lts1 = new vrel_lts_obj(dof, frac);
+  const vrel_objective * const lts1 = new vrel_lts_obj(dof, frac);
   std::vector<double> test_lts;
   test_lts.push_back(-1.0);
   test_lts.push_back(-2.0);
@@ -72,7 +72,7 @@ test_lms_lts()
   TEST_NEAR("LTS with 0.5 inlier fraction:", obj, corr_obj, 1e-6);
 
   frac = 0.7;
-  vrel_objective * const lts2 = new vrel_lts_obj(dof, frac);
+  const vrel_objective * const lts2 = new vrel_lts_obj(dof, frac);
   corr_obj += vnl_math::sqr(-4.0) + vnl_math::sqr(-2.4) + vnl_math::sqr(3.1);
   obj = lts2->fcn(test_lts.begin(), test_lts.end(), 0.0, nullptr);
   TEST_NEAR("LTS with 0.7 inlier fraction:", obj, corr_obj, 1e-6);

--- a/core/vrel/tests/test_m_est_obj.cxx
+++ b/core/vrel/tests/test_m_est_obj.cxx
@@ -15,7 +15,7 @@ static void
 test_m_est_obj()
 {
   constexpr double c = 4.0;
-  vrel_m_est_obj * const m_est = new vrel_tukey_obj(c);
+  const vrel_m_est_obj * const m_est = new vrel_tukey_obj(c);
   constexpr double sigma = 2.5;
 
   //
@@ -77,7 +77,7 @@ test_m_est_obj()
   // Test the functions specific to the Cauchy rho function
   //
   const double cauchy_cnst = 2;
-  vrel_m_est_obj * const m_est2 = new vrel_cauchy_obj(cauchy_cnst);
+  const vrel_m_est_obj * const m_est2 = new vrel_cauchy_obj(cauchy_cnst);
   TEST_NEAR("cauchy rho 1", m_est2->rho(0), 0.0, 1e-6);
   TEST_NEAR("cauchy rho 2", m_est2->rho(0.5), 0.0303123, 1e-6);
 
@@ -89,7 +89,7 @@ test_m_est_obj()
   // Test the functions specific to the truncated quadratic rho function
   //
   const double trunc_quad_cnst = 2;
-  vrel_m_est_obj * const m_est3 = new vrel_trunc_quad_obj(trunc_quad_cnst);
+  const vrel_m_est_obj * const m_est3 = new vrel_trunc_quad_obj(trunc_quad_cnst);
   TEST_NEAR("trunc_quad rho 1", m_est3->rho(0), 0.0, 1e-6);
   TEST_NEAR("trunc_quad rho 2", m_est3->rho(0.5), 0.25, 1e-6);
   TEST_NEAR("trunc_quad rho 3", m_est3->rho(3.0), vnl_math::sqr(trunc_quad_cnst), 1e-6);

--- a/core/vrel/tests/test_orthogonal_regression.cxx
+++ b/core/vrel/tests/test_orthogonal_regression.cxx
@@ -87,7 +87,7 @@ test_orthogonal_regression()
   //
   //  The first set of tests are for the constructor, and parameter access methods.
   //
-  vrel_estimation_problem * lr1 = new vrel_orthogonal_regression(pts);
+  const vrel_estimation_problem * lr1 = new vrel_orthogonal_regression(pts);
   TEST("ctor 1", !lr1, false);
 
   TEST("num_points_to_instantiate (1)", lr1->num_samples_to_instantiate(), 3);

--- a/core/vrel/tests/test_ran_sam_search.cxx
+++ b/core/vrel/tests/test_ran_sam_search.cxx
@@ -180,9 +180,9 @@ test_ran_sam_search()
   //  function.
   //
   const bool use_intercept = true;
-  vrel_estimation_problem * const lr = new vrel_linear_regression(pts, use_intercept);
+  const vrel_estimation_problem * const lr = new vrel_linear_regression(pts, use_intercept);
   const int dof = lr->num_samples_to_instantiate();
-  vrel_objective * const lms = new vrel_lms_obj(dof);
+  const vrel_objective * const lms = new vrel_lms_obj(dof);
   auto * ransam = new vrel_ran_sam_search();
   TEST("ctor", !ransam, false);
 #if 0
@@ -269,7 +269,7 @@ test_ran_sam_search()
   std::vector<image_point_match> matches;
   vnl_double_4 sim_params(1.4, -0.2, 20.0, -18.0);
   generate_similarity_matches(sim_params.as_vector(), sigma, matches); // 20 matches, 13 points
-  vrel_estimation_problem * const match_prob = new similarity_from_matches(matches);
+  const vrel_estimation_problem * const match_prob = new similarity_from_matches(matches);
 #if 0
   ransam->set_sampling_params( 0.5, 0.999, 1 );
   ransam->calc_num_samples( match_prob->num_data_points(), match_prob->num_correspondences_all(),

--- a/core/vsl/tests/test_clipon_polymorphic_io.cxx
+++ b/core/vsl/tests/test_clipon_polymorphic_io.cxx
@@ -251,8 +251,8 @@ test_clipon_polymorphic_io()
   vsl_add_to_binary_loader(test2_derived_class_io());
 
   test2_derived_class d1_out(1234);
-  test2_base_class * const b1_out = &d1_out;
-  test2_base_class * const b2_out = nullptr;
+  const test2_base_class * const b1_out = &d1_out;
+  const test2_base_class * const b2_out = nullptr;
 
   vsl_b_ofstream bfs_out("vsl_clipon_polymorphic_io_test.bvl.tmp");
   TEST("Opened vsl_polymorphic_io_test.bvl.tmp for writing", (!bfs_out), false);

--- a/core/vsl/tests/test_polymorphic_io.cxx
+++ b/core/vsl/tests/test_polymorphic_io.cxx
@@ -208,8 +208,8 @@ test_polymorphic_io()
   vsl_add_to_binary_loader(test_derived_class());
 
   test_derived_class d1_out(1234);
-  test_base_class * const b1_out = &d1_out;
-  test_base_class * const b2_out = nullptr;
+  const test_base_class * const b1_out = &d1_out;
+  const test_base_class * const b2_out = nullptr;
 
   vsl_b_ofstream bfs_out("vsl_polymorphic_io_test.bvl.tmp");
   TEST("Opened vsl_polymorphic_io_test.bvl.tmp for writing", (!bfs_out), false);

--- a/core/vsl/vsl_indent.cxx
+++ b/core/vsl/vsl_indent.cxx
@@ -73,7 +73,7 @@ vsl_indent_clear(std::ostream & os)
 std::ostream &
 operator<<(std::ostream & os, const vsl_indent & /*indent*/)
 {
-  indent_data_type * const data = indent_data(os);
+  const indent_data_type * const data = indent_data(os);
 
   const int n = data->first * data->second;
   for (int i = 0; i < n; i++)

--- a/core/vul/vul_arg.cxx
+++ b/core/vul/vul_arg.cxx
@@ -320,7 +320,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
     arg->set_ = false;
 
   // Generate shorter command name
-  char * cmdname = argv[0] + std::strlen(argv[0]);
+  const char * cmdname = argv[0] + std::strlen(argv[0]);
   while (cmdname > argv[0] && *cmdname != '/' && *cmdname != '\\')
     --cmdname;
   if (*cmdname == '\\' || *cmdname == '/')
@@ -334,7 +334,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
   char ** my_argv = argv + 1; // Skip program name
   while (*my_argv)
   {
-    char * const argmt = *my_argv;
+    const char * const argmt = *my_argv;
     bool eaten = false;
     for (unsigned int i = 0; i < args_.size(); ++i)
     {
@@ -370,7 +370,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
   if (verbose_)
   {
     std::cerr << "args remaining:";
-    for (char ** av = argv; *av; ++av)
+    for (char * const * av = argv; *av; ++av)
       std::cerr << " [" << *av << ']';
     std::cerr << std::endl;
   }
@@ -402,7 +402,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
 
   // 3. Move my_argv down to first unused arg, and reset argc
   argc = 1;
-  for (char ** av = my_argv; *av; ++av)
+  for (char * const * av = my_argv; *av; ++av)
     ++argc;
   for (int i = 1; i < argc; ++i)
     argv[i] = my_argv[i - 1];
@@ -414,7 +414,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
   if (autonomy_ == all)
   {
     std::cerr << "vul_arg_info_list: Some arguments were unused: ";
-    for (char ** av = argv; *av; ++av)
+    for (char * const * av = argv; *av; ++av)
       std::cerr << ' ' << *av;
     std::cerr << std::endl;
     display_help(cmdname);
@@ -422,7 +422,7 @@ vul_arg_info_list::parse(int & argc, char **& argv, bool warn_about_unrecognized
 
   // 4.3 It's often bad if a switch was not recognized.
   if (warn_about_unrecognized_arguments)
-    for (char ** av = argv; *av; ++av)
+    for (char * const * av = argv; *av; ++av)
       if (**av == '-')
       {
         display_help(cmdname);
@@ -1028,7 +1028,7 @@ parse(vul_arg<std::vector<double>> * argmt, char ** argv)
   int sucked = 0;
   // Defaults should be cleared when the user supplies a value
   argmt->value_.clear();
-  char * current = argv[0];
+  const char * current = argv[0];
   while (current)
   {
     char * endptr = nullptr;

--- a/core/vul/vul_get_timestamp.cxx
+++ b/core/vul/vul_get_timestamp.cxx
@@ -61,7 +61,7 @@ vul_get_time_as_string(vul_time_style style /*default=vul_asc*/)
   std::time(&time_secs);
 
   // Convert time to struct tm form
-  struct std::tm * time = nullptr;
+  struct std::tm const * time = nullptr;
   time = std::localtime(&time_secs);
 
   switch (style)

--- a/core/vul/vul_reg_exp.cxx
+++ b/core/vul/vul_reg_exp.cxx
@@ -139,7 +139,7 @@ vul_reg_exp::vul_reg_exp(const vul_reg_exp & rxp)
   this->regmust = rxp.regmust;     // Copy field
   if (rxp.regmust != nullptr)
   {
-    char * dum = rxp.program;
+    const char * dum = rxp.program;
     ind = 0;
     while (dum != rxp.regmust)
     {
@@ -533,7 +533,7 @@ reg(int paren, int * flagp)
 {
   char * ret = nullptr;
   char * br = nullptr;
-  char * ender = nullptr;
+  const char * ender = nullptr;
   int parno = 0;
   int flags = 0;
 

--- a/core/vul/vul_url.cxx
+++ b/core/vul/vul_url.cxx
@@ -134,7 +134,7 @@ vul_http_open(const char * url)
 #endif
 
   // get network address of server.
-  hostent * const hp = gethostbyname(host.c_str());
+  const hostent * const hp = gethostbyname(host.c_str());
   if (!hp)
   {
     std::cerr << __FILE__ ": failed to lookup host\n";
@@ -353,7 +353,7 @@ vul_http_exists(const char * url)
 #endif
 
   // get network address of server.
-  hostent * const hp = gethostbyname(host.c_str());
+  const hostent * const hp = gethostbyname(host.c_str());
   if (!hp)
   {
     std::cerr << __FILE__ ": failed to lookup host\n";

--- a/core/vul/vul_user_info.cxx
+++ b/core/vul/vul_user_info.cxx
@@ -39,7 +39,7 @@ void
 vul_user_info::init(const char * name_)
 {
 #if !defined(_WIN32) || defined(__CYGWIN__)
-  struct passwd * const pw = getpwnam(name_);
+  struct passwd const * const pw = getpwnam(name_);
   if (!pw)
   {
 #endif

--- a/v3p/clipper/clipper.cpp
+++ b/v3p/clipper/clipper.cpp
@@ -221,7 +221,7 @@ PolyNode* PolyNode::GetNextSiblingUp() const
 bool PolyNode::IsHole() const
 {
   bool result = true;
-  PolyNode* node = Parent;
+  const PolyNode * node = Parent;
   while (node)
   {
       result = !result;
@@ -352,20 +352,20 @@ class Int128
 
 Int128 Int128Mul (long64 lhs, long64 rhs)
 {
-  bool negate = (lhs < 0) != (rhs < 0);
+  const bool negate = (lhs < 0) != (rhs < 0);
 
   if (lhs < 0) lhs = -lhs;
-  ulong64 int1Hi = ulong64(lhs) >> 32;
+  const ulong64 int1Hi = ulong64(lhs) >> 32;
   auto int1Lo = ulong64(lhs & 0xFFFFFFFF);
 
   if (rhs < 0) rhs = -rhs;
-  ulong64 int2Hi = ulong64(rhs) >> 32;
+  const ulong64 int2Hi = ulong64(rhs) >> 32;
   auto int2Lo = ulong64(rhs & 0xFFFFFFFF);
 
   //nb: see comments in clipper.pas
-  ulong64 a = int1Hi * int2Hi;
-  ulong64 b = int1Lo * int2Lo;
-  ulong64 c = int1Hi * int2Lo + int1Lo * int2Hi;
+  const ulong64 a = int1Hi * int2Hi;
+  const ulong64 b = int1Lo * int2Lo;
+  const ulong64 c = int1Hi * int2Lo + int1Lo * int2Hi;
 
   Int128 tmp;
   tmp.hi = long64(a + (c >> 32));
@@ -389,7 +389,7 @@ bool Orientation(const Path &poly)
 
 double Area(const Path &poly)
 {
-  int size = (int)poly.size();
+  const int size = (int)poly.size();
   if (size < 3) return 0;
 
   double a = 0;
@@ -404,7 +404,7 @@ double Area(const Path &poly)
 
 double Area(const OutPt *op)
 {
-  const OutPt *startOp = op;
+  const OutPt * const startOp = op;
   if (!op) return 0;
   double a = 0;
   do {
@@ -423,7 +423,7 @@ double Area(const OutRec &outRec)
 
 bool PointIsVertex(const IntPoint &Pt, OutPt *pp)
 {
-  OutPt *pp2 = pp;
+  const OutPt * pp2 = pp;
   do
   {
     if (pp2->Pt == Pt) return true;
@@ -440,12 +440,12 @@ int PointInPolygon(const IntPoint &pt, const Path &path)
 {
   //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
   int result = 0;
-  size_t cnt = path.size();
+  const size_t cnt = path.size();
   if (cnt < 3) return 0;
   IntPoint ip = path[0];
   for(size_t i = 1; i <= cnt; ++i)
   {
-    IntPoint ipNext = (i == cnt ? path[0] : path[i]);
+    const IntPoint ipNext = (i == cnt ? path[0] : path[i]);
     if (ipNext.Y == pt.Y)
     {
         if ((ipNext.X == pt.X) || (ip.Y == pt.Y &&
@@ -458,8 +458,7 @@ int PointInPolygon(const IntPoint &pt, const Path &path)
         if (ipNext.X > pt.X) result = 1 - result;
         else
         {
-          double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
-            (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
+          const double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) - (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
           if (!d) return -1;
           if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
         }
@@ -467,8 +466,7 @@ int PointInPolygon(const IntPoint &pt, const Path &path)
       {
         if (ipNext.X > pt.X)
         {
-          double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) -
-            (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
+          const double d = (double)(ip.X - pt.X) * (ipNext.Y - pt.Y) - (double)(ipNext.X - pt.X) * (ip.Y - pt.Y);
           if (!d) return -1;
           if ((d > 0) == (ipNext.Y > ip.Y)) result = 1 - result;
         }
@@ -484,7 +482,7 @@ int PointInPolygon (const IntPoint &pt, OutPt *op)
 {
   //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
   int result = 0;
-  OutPt* startOp = op;
+  const OutPt * const startOp = op;
   for(;;)
   {
     if (op->Next->Pt.Y == pt.Y)
@@ -499,8 +497,8 @@ int PointInPolygon (const IntPoint &pt, OutPt *op)
         if (op->Next->Pt.X > pt.X) result = 1 - result;
         else
         {
-          double d = (double)(op->Pt.X - pt.X) * (op->Next->Pt.Y - pt.Y) -
-            (double)(op->Next->Pt.X - pt.X) * (op->Pt.Y - pt.Y);
+          const double d =
+            (double)(op->Pt.X - pt.X) * (op->Next->Pt.Y - pt.Y) - (double)(op->Next->Pt.X - pt.X) * (op->Pt.Y - pt.Y);
           if (!d) return -1;
           if ((d > 0) == (op->Next->Pt.Y > op->Pt.Y)) result = 1 - result;
         }
@@ -508,8 +506,8 @@ int PointInPolygon (const IntPoint &pt, OutPt *op)
       {
         if (op->Next->Pt.X > pt.X)
         {
-          double d = (double)(op->Pt.X - pt.X) * (op->Next->Pt.Y - pt.Y) -
-            (double)(op->Next->Pt.X - pt.X) * (op->Pt.Y - pt.Y);
+          const double d =
+            (double)(op->Pt.X - pt.X) * (op->Next->Pt.Y - pt.Y) - (double)(op->Next->Pt.X - pt.X) * (op->Pt.Y - pt.Y);
           if (!d) return -1;
           if ((d > 0) == (op->Next->Pt.Y > op->Pt.Y)) result = 1 - result;
         }
@@ -524,11 +522,11 @@ int PointInPolygon (const IntPoint &pt, OutPt *op)
 
 bool Poly2ContainsPoly1(OutPt *OutPt1, OutPt *OutPt2)
 {
-  OutPt* op = OutPt1;
+  const OutPt * op = OutPt1;
   do
   {
     //nb: PointInPolygon returns 0 if false, +1 if true, -1 if pt on polygon
-    int res = PointInPolygon(op->Pt, OutPt2);
+    const int res = PointInPolygon(op->Pt, OutPt2);
     if (res >= 0) return res > 0;
     op = op->Next;
   }
@@ -589,7 +587,7 @@ inline double GetDx(const IntPoint pt1, const IntPoint pt2)
 
 inline void SetDx(TEdge &e)
 {
-  cInt dy  = (e.Top.Y - e.Bot.Y);
+  const cInt dy = (e.Top.Y - e.Bot.Y);
   if (dy == 0) e.Dx = HORIZONTAL;
   else e.Dx = (double)(e.Top.X - e.Bot.X) / dy;
 }
@@ -597,7 +595,7 @@ inline void SetDx(TEdge &e)
 
 inline void SwapSides(TEdge &Edge1, TEdge &Edge2)
 {
-  EdgeSide Side =  Edge1.Side;
+  const EdgeSide Side = Edge1.Side;
   Edge1.Side = Edge2.Side;
   Edge2.Side = Side;
 }
@@ -605,7 +603,7 @@ inline void SwapSides(TEdge &Edge1, TEdge &Edge2)
 
 inline void SwapPolyIndexes(TEdge &Edge1, TEdge &Edge2)
 {
-  int OutIdx =  Edge1.OutIdx;
+  const int OutIdx = Edge1.OutIdx;
   Edge1.OutIdx = Edge2.OutIdx;
   Edge2.OutIdx = OutIdx;
 }
@@ -657,7 +655,7 @@ void IntersectPoint(TEdge &Edge1, TEdge &Edge2, IntPoint &ip)
   {
     b1 = Edge1.Bot.X - Edge1.Bot.Y * Edge1.Dx;
     b2 = Edge2.Bot.X - Edge2.Bot.Y * Edge2.Dx;
-    double q = (b2-b1) / (Edge1.Dx - Edge2.Dx);
+    const double q = (b2 - b1) / (Edge1.Dx - Edge2.Dx);
     ip.Y = Round(q);
     if (std::fabs(Edge1.Dx) < std::fabs(Edge2.Dx))
       ip.X = Round(Edge1.Dx * q + b1);
@@ -708,7 +706,7 @@ void DisposeOutPts(OutPt*& pp)
     pp->Prev->Next = nullptr;
   while( pp )
   {
-    OutPt *tmpPp = pp;
+    const OutPt * const tmpPp = pp;
     pp = pp->Next;
     delete tmpPp;
   }
@@ -746,7 +744,7 @@ TEdge* RemoveEdge(TEdge* e)
   //removes e from double_linked_list (but without removing from memory)
   e->Prev->Next = e->Next;
   e->Next->Prev = e->Prev;
-  TEdge* result = e->Next;
+  TEdge * const result = e->Next;
   e->Prev = nullptr; //flag as removed (see ClipperBase.Clear)
   return result;
 }
@@ -766,7 +764,7 @@ inline void ReverseHorizontal(TEdge &e)
 
 void SwapPoints(IntPoint &pt1, IntPoint &pt2)
 {
-  IntPoint tmp = pt1;
+  const IntPoint tmp = pt1;
   pt1 = pt2;
   pt2 = tmp;
 }
@@ -796,19 +794,19 @@ bool GetOverlapSegment(IntPoint pt1a, IntPoint pt1b, IntPoint pt2a,
 
 bool FirstIsBottomPt(const OutPt* btmPt1, const OutPt* btmPt2)
 {
-  OutPt *p = btmPt1->Prev;
+  const OutPt * p = btmPt1->Prev;
   while ((p->Pt == btmPt1->Pt) && (p != btmPt1)) p = p->Prev;
-  double dx1p = std::fabs(GetDx(btmPt1->Pt, p->Pt));
+  const double dx1p = std::fabs(GetDx(btmPt1->Pt, p->Pt));
   p = btmPt1->Next;
   while ((p->Pt == btmPt1->Pt) && (p != btmPt1)) p = p->Next;
-  double dx1n = std::fabs(GetDx(btmPt1->Pt, p->Pt));
+  const double dx1n = std::fabs(GetDx(btmPt1->Pt, p->Pt));
 
   p = btmPt2->Prev;
   while ((p->Pt == btmPt2->Pt) && (p != btmPt2)) p = p->Prev;
-  double dx2p = std::fabs(GetDx(btmPt2->Pt, p->Pt));
+  const double dx2p = std::fabs(GetDx(btmPt2->Pt, p->Pt));
   p = btmPt2->Next;
   while ((p->Pt == btmPt2->Pt) && (p != btmPt2)) p = p->Next;
-  double dx2n = std::fabs(GetDx(btmPt2->Pt, p->Pt));
+  const double dx2n = std::fabs(GetDx(btmPt2->Pt, p->Pt));
 
   if (std::max(dx1p, dx1n) == std::max(dx2p, dx2n) &&
     std::min(dx1p, dx1n) == std::min(dx2p, dx2n))
@@ -914,7 +912,7 @@ TEdge* FindNextLocMin(TEdge* E)
     while (E->Bot != E->Prev->Bot || E->Curr == E->Top) E = E->Next;
     if (!IsHorizontal(*E) && !IsHorizontal(*E->Prev)) break;
     while (IsHorizontal(*E->Prev)) E = E->Prev;
-    TEdge* E2 = E;
+    TEdge * const E2 = E;
     while (IsHorizontal(*E)) E = E->Next;
     if (E->Top.Y == E->Prev->Bot.Y) continue; //ie just an intermediate horz.
     if (E2->Prev->Bot.X < E->Bot.X) E = E2;
@@ -927,7 +925,7 @@ TEdge* FindNextLocMin(TEdge* E)
 TEdge* ClipperBase::ProcessBound(TEdge* E, bool NextIsForward)
 {
   TEdge *Result = E;
-  TEdge *Horz = nullptr;
+  const TEdge * Horz = nullptr;
 
   if (E->OutIdx == Skip)
   {
@@ -1169,7 +1167,7 @@ bool ClipperBase::AddPath(const Path &pg, PolyType PolyTyp, bool Closed)
 
   m_edges.push_back(edges);
   bool leftBoundIsForward;
-  TEdge* EMin = nullptr;
+  const TEdge * EMin = nullptr;
 
   //workaround to avoid an endless loop in the while loop below when
   //open paths have matching start and end points ...
@@ -1309,7 +1307,7 @@ IntRect ClipperBase::GetBounds()
     result.bottom = std::max(result.bottom, lm->LeftBound->Bot.Y);
     TEdge* e = lm->LeftBound;
     for (;;) {
-      TEdge* bottomE = e;
+      const TEdge * const bottomE = e;
       while (e->NextInLML)
       {
         if (e->Bot.X < result.left) result.left = e->Bot.X;
@@ -1364,8 +1362,8 @@ void ClipperBase::DisposeOutRec(PolyOutList::size_type index)
 
 void ClipperBase::DeleteFromAEL(TEdge *e)
 {
-  TEdge* AelPrev = e->PrevInAEL;
-  TEdge* AelNext = e->NextInAEL;
+  TEdge * const AelPrev = e->PrevInAEL;
+  TEdge * const AelNext = e->NextInAEL;
   if (!AelPrev &&  !AelNext && (e != m_ActiveEdges)) return; //already deleted
   if (AelPrev) AelPrev->NextInAEL = AelNext;
   else m_ActiveEdges = AelNext;
@@ -1398,9 +1396,9 @@ void ClipperBase::SwapPositionsInAEL(TEdge *Edge1, TEdge *Edge2)
 
   if (Edge1->NextInAEL == Edge2)
   {
-    TEdge* Next = Edge2->NextInAEL;
+    TEdge * const Next = Edge2->NextInAEL;
     if (Next) Next->PrevInAEL = Edge1;
-    TEdge* Prev = Edge1->PrevInAEL;
+    TEdge * const Prev = Edge1->PrevInAEL;
     if (Prev) Prev->NextInAEL = Edge2;
     Edge2->PrevInAEL = Prev;
     Edge2->NextInAEL = Edge1;
@@ -1409,9 +1407,9 @@ void ClipperBase::SwapPositionsInAEL(TEdge *Edge1, TEdge *Edge2)
   }
   else if (Edge2->NextInAEL == Edge1)
   {
-    TEdge* Next = Edge1->NextInAEL;
+    TEdge * const Next = Edge1->NextInAEL;
     if (Next) Next->PrevInAEL = Edge2;
-    TEdge* Prev = Edge2->PrevInAEL;
+    TEdge * const Prev = Edge2->PrevInAEL;
     if (Prev) Prev->NextInAEL = Edge1;
     Edge1->PrevInAEL = Prev;
     Edge1->NextInAEL = Edge2;
@@ -1420,8 +1418,8 @@ void ClipperBase::SwapPositionsInAEL(TEdge *Edge1, TEdge *Edge2)
   }
   else
   {
-    TEdge* Next = Edge1->NextInAEL;
-    TEdge* Prev = Edge1->PrevInAEL;
+    TEdge * const Next = Edge1->NextInAEL;
+    TEdge * const Prev = Edge1->PrevInAEL;
     Edge1->NextInAEL = Edge2->NextInAEL;
     if (Edge1->NextInAEL) Edge1->NextInAEL->PrevInAEL = Edge1;
     Edge1->PrevInAEL = Edge2->PrevInAEL;
@@ -1443,8 +1441,8 @@ void ClipperBase::UpdateEdgeIntoAEL(TEdge *&e)
     throw clipperException("UpdateEdgeIntoAEL: invalid call");
 
   e->NextInLML->OutIdx = e->OutIdx;
-  TEdge* AelPrev = e->PrevInAEL;
-  TEdge* AelNext = e->NextInAEL;
+  TEdge * const AelPrev = e->PrevInAEL;
+  TEdge * const AelNext = e->NextInAEL;
   if (AelPrev) AelPrev->NextInAEL = e->NextInLML;
   else m_ActiveEdges = e->NextInLML;
   if (AelNext) AelNext->PrevInAEL = e->NextInLML;
@@ -1515,7 +1513,7 @@ bool Clipper::Execute(ClipType clipType, Paths &solution,
   m_ClipFillType = clipFillType;
   m_ClipType = clipType;
   m_UsingPolyTree = false;
-  bool succeeded = ExecuteInternal();
+  const bool succeeded = ExecuteInternal();
   if (succeeded) BuildResult(solution);
   DisposeAllOutRecs();
   m_ExecuteLocked = false;
@@ -1532,7 +1530,7 @@ bool Clipper::Execute(ClipType clipType, PolyTree& polytree,
   m_ClipFillType = clipFillType;
   m_ClipType = clipType;
   m_UsingPolyTree = true;
-  bool succeeded = ExecuteInternal();
+  const bool succeeded = ExecuteInternal();
   if (succeeded) BuildResult2(polytree);
   DisposeAllOutRecs();
   m_ExecuteLocked = false;
@@ -1619,14 +1617,14 @@ bool Clipper::ExecuteInternal()
 
 void Clipper::SetWindingCount(TEdge &edge)
 {
-  TEdge *e = edge.PrevInAEL;
+  const TEdge * e = edge.PrevInAEL;
   //find the edge of the same polytype that immediately preceeds 'edge' in AEL
   while (e  && ((e->PolyTyp != edge.PolyTyp) || (e->WindDelta == 0))) e = e->PrevInAEL;
   if (!e)
   {
     if (edge.WindDelta == 0)
     {
-      PolyFillType pft = (edge.PolyTyp == ptSubject ? m_SubjFillType : m_ClipFillType);
+      const PolyFillType pft = (edge.PolyTyp == ptSubject ? m_SubjFillType : m_ClipFillType);
       edge.WindCnt = (pft == pftNegative ? -1 : 1);
     }
     else
@@ -1647,7 +1645,7 @@ void Clipper::SetWindingCount(TEdge &edge)
     {
       //are we inside a subj polygon ...
       bool Inside = true;
-      TEdge *e2 = e->PrevInAEL;
+      const TEdge * e2 = e->PrevInAEL;
       while (e2)
       {
         if (e2->PolyTyp == e->PolyTyp && e2->WindDelta != 0)
@@ -1864,12 +1862,12 @@ OutPt* Clipper::AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &Pt)
 
   if (prevE && prevE->OutIdx >= 0 && prevE->Top.Y < Pt.Y && e->Top.Y < Pt.Y)
   {
-    cInt xPrev = TopX(*prevE, Pt.Y);
-    cInt xE = TopX(*e, Pt.Y);
+    const cInt xPrev = TopX(*prevE, Pt.Y);
+    const cInt xE = TopX(*e, Pt.Y);
     if (xPrev == xE && (e->WindDelta != 0) && (prevE->WindDelta != 0) &&
       SlopesEqual(IntPoint(xPrev, Pt.Y), prevE->Top, IntPoint(xE, Pt.Y), e->Top, m_UseFullRange))
     {
-      OutPt* outPt = AddOutPt(prevE, Pt);
+      OutPt * const outPt = AddOutPt(prevE, Pt);
       AddJoin(result, outPt, e->Top);
     }
   }
@@ -1937,7 +1935,7 @@ void Clipper::CopyAELToSEL()
 
 void Clipper::AddJoin(OutPt *op1, OutPt *op2, const IntPoint OffPt)
 {
-  Join* j = new Join;
+  Join * const j = new Join;
   j->OutPt1 = op1;
   j->OutPt2 = op2;
   j->OffPt = OffPt;
@@ -1963,7 +1961,7 @@ void Clipper::ClearGhostJoins()
 
 void Clipper::AddGhostJoin(OutPt *op, const IntPoint OffPt)
 {
-  Join* j = new Join;
+  Join * const j = new Join;
   j->OutPt1 = op;
   j->OutPt2 = nullptr;
   j->OffPt = OffPt;
@@ -1977,7 +1975,7 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
   while (PopLocalMinima(botY, lm))
   {
     TEdge* lb = lm->LeftBound;
-    TEdge* rb = lm->RightBound;
+    TEdge * const rb = lm->RightBound;
 
     OutPt *Op1 = nullptr;
     if (!lb)
@@ -2040,8 +2038,8 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
       SlopesEqual(lb->PrevInAEL->Bot, lb->PrevInAEL->Top, lb->Curr, lb->Top, m_UseFullRange) &&
       (lb->WindDelta != 0) && (lb->PrevInAEL->WindDelta != 0))
     {
-        OutPt *Op2 = AddOutPt(lb->PrevInAEL, lb->Bot);
-        AddJoin(Op1, Op2, lb->Top);
+      OutPt * const Op2 = AddOutPt(lb->PrevInAEL, lb->Bot);
+      AddJoin(Op1, Op2, lb->Top);
     }
 
     if(lb->NextInAEL != rb)
@@ -2051,8 +2049,8 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
         SlopesEqual(rb->PrevInAEL->Curr, rb->PrevInAEL->Top, rb->Curr, rb->Top, m_UseFullRange) &&
         (rb->WindDelta != 0) && (rb->PrevInAEL->WindDelta != 0))
       {
-          OutPt *Op2 = AddOutPt(rb->PrevInAEL, rb->Bot);
-          AddJoin(Op1, Op2, rb->Top);
+        OutPt * const Op2 = AddOutPt(rb->PrevInAEL, rb->Bot);
+        AddJoin(Op1, Op2, rb->Top);
       }
 
       TEdge* e = lb->NextInAEL;
@@ -2074,8 +2072,8 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY)
 
 void Clipper::DeleteFromSEL(TEdge *e)
 {
-  TEdge* SelPrev = e->PrevInSEL;
-  TEdge* SelNext = e->NextInSEL;
+  TEdge * const SelPrev = e->PrevInSEL;
+  TEdge * const SelNext = e->NextInSEL;
   if( !SelPrev &&  !SelNext && (e != m_SortedEdges) ) return; //already deleted
   if( SelPrev ) SelPrev->NextInSEL = SelNext;
   else m_SortedEdges = SelNext;
@@ -2100,8 +2098,8 @@ void Clipper::SetZ(IntPoint& pt, TEdge& e1, TEdge& e2)
 
 void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt)
 {
-  bool e1Contributing = ( e1->OutIdx >= 0 );
-  bool e2Contributing = ( e2->OutIdx >= 0 );
+  const bool e1Contributing = (e1->OutIdx >= 0);
+  const bool e2Contributing = (e2->OutIdx >= 0);
 
 #ifdef use_xyz
         SetZ(Pt, *e1, *e2);
@@ -2162,7 +2160,7 @@ void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt)
   {
     if ( IsEvenOddFillType( *e1) )
     {
-      int oldE1WindCnt = e1->WindCnt;
+      const int oldE1WindCnt = e1->WindCnt;
       e1->WindCnt = e2->WindCnt;
       e2->WindCnt = oldE1WindCnt;
     } else
@@ -2296,7 +2294,7 @@ void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt)
 void Clipper::SetHoleState(TEdge *e, OutRec *outrec)
 {
   TEdge *e2 = e->PrevInAEL;
-  TEdge *eTmp = nullptr;
+  const TEdge * eTmp = nullptr;
   while (e2)
   {
     if (e2->OutIdx >= 0 && e2->WindDelta != 0)
@@ -2326,8 +2324,8 @@ OutRec* GetLowermostRec(OutRec *outRec1, OutRec *outRec2)
     outRec1->BottomPt = GetBottomPt(outRec1->Pts);
   if (!outRec2->BottomPt)
     outRec2->BottomPt = GetBottomPt(outRec2->Pts);
-  OutPt *OutPt1 = outRec1->BottomPt;
-  OutPt *OutPt2 = outRec2->BottomPt;
+  const OutPt * const OutPt1 = outRec1->BottomPt;
+  const OutPt * const OutPt2 = outRec2->BottomPt;
   if (OutPt1->Pt.Y > OutPt2->Pt.Y) return outRec1;
   else if (OutPt1->Pt.Y < OutPt2->Pt.Y) return outRec2;
   else if (OutPt1->Pt.X < OutPt2->Pt.X) return outRec1;
@@ -2362,8 +2360,8 @@ OutRec* Clipper::GetOutRec(int Idx)
 void Clipper::AppendPolygon(TEdge *e1, TEdge *e2)
 {
   //get the start and ends of both output polygons ...
-  OutRec *outRec1 = m_PolyOuts[e1->OutIdx];
-  OutRec *outRec2 = m_PolyOuts[e2->OutIdx];
+  OutRec * const outRec1 = m_PolyOuts[e1->OutIdx];
+  OutRec * const outRec2 = m_PolyOuts[e2->OutIdx];
 
   OutRec *holeStateRec;
   if (OutRec1RightOfOutRec2(outRec1, outRec2))
@@ -2376,10 +2374,10 @@ void Clipper::AppendPolygon(TEdge *e1, TEdge *e2)
   //get the start and ends of both output polygons and
   //join e2 poly onto e1 poly and delete pointers to e2 ...
 
-  OutPt* p1_lft = outRec1->Pts;
-  OutPt* p1_rt = p1_lft->Prev;
-  OutPt* p2_lft = outRec2->Pts;
-  OutPt* p2_rt = p2_lft->Prev;
+  OutPt * const p1_lft = outRec1->Pts;
+  OutPt * const p1_rt = p1_lft->Prev;
+  OutPt * const p2_lft = outRec2->Pts;
+  OutPt * const p2_rt = p2_lft->Prev;
 
   //join e2 poly onto e1 poly and delete pointers to e2 ...
   if(  e1->Side == esLeft )
@@ -2433,8 +2431,8 @@ void Clipper::AppendPolygon(TEdge *e1, TEdge *e2)
   outRec2->BottomPt = nullptr;
   outRec2->FirstLeft = outRec1;
 
-  int OKIdx = e1->OutIdx;
-  int ObsoleteIdx = e2->OutIdx;
+  const int OKIdx = e1->OutIdx;
+  const int ObsoleteIdx = e2->OutIdx;
 
   e1->OutIdx = Unassigned; //nb: safe because we only get here via AddLocalMaxPoly
   e2->OutIdx = Unassigned;
@@ -2459,7 +2457,7 @@ OutPt* Clipper::AddOutPt(TEdge *e, const IntPoint &pt)
 {
   if(  e->OutIdx < 0 )
   {
-    OutRec *outRec = CreateOutRec();
+    OutRec * const outRec = CreateOutRec();
     outRec->IsOpen = (e->WindDelta == 0);
     auto* newOp = new OutPt;
     outRec->Pts = newOp;
@@ -2473,11 +2471,11 @@ OutPt* Clipper::AddOutPt(TEdge *e, const IntPoint &pt)
     return newOp;
   } else
   {
-    OutRec *outRec = m_PolyOuts[e->OutIdx];
+    OutRec * const outRec = m_PolyOuts[e->OutIdx];
     //OutRec.Pts is the 'Left-most' point & OutRec.Pts.Prev is the 'Right-most'
-    OutPt* op = outRec->Pts;
+    OutPt * const op = outRec->Pts;
 
-    bool ToFront = (e->Side == esLeft);
+    const bool ToFront = (e->Side == esLeft);
     if (ToFront && (pt == op->Pt)) return op;
     else if (!ToFront && (pt == op->Prev->Pt)) return op->Prev;
 
@@ -2496,11 +2494,11 @@ OutPt* Clipper::AddOutPt(TEdge *e, const IntPoint &pt)
 
 OutPt* Clipper::GetLastOutPt(TEdge *e)
 {
-    OutRec *outRec = m_PolyOuts[e->OutIdx];
-    if (e->Side == esLeft)
-        return outRec->Pts;
-    else
-        return outRec->Pts->Prev;
+  const OutRec * const outRec = m_PolyOuts[e->OutIdx];
+  if (e->Side == esLeft)
+    return outRec->Pts;
+  else
+    return outRec->Pts->Prev;
 }
 //------------------------------------------------------------------------------
 
@@ -2543,7 +2541,7 @@ TEdge *GetMaximaPair(TEdge *e)
 TEdge *GetMaximaPairEx(TEdge *e)
 {
   //as GetMaximaPair() but returns 0 if MaxPair isn't in AEL (unless it's horizontal)
-  TEdge* result = GetMaximaPair(e);
+  TEdge * const result = GetMaximaPair(e);
   if (result && (result->OutIdx == Skip ||
     (result->NextInAEL == result->PrevInAEL && !IsHorizontal(*result)))) return nullptr;
   return result;
@@ -2557,9 +2555,9 @@ void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2)
 
   if(  Edge1->NextInSEL == Edge2 )
   {
-    TEdge* Next = Edge2->NextInSEL;
+    TEdge * const Next = Edge2->NextInSEL;
     if( Next ) Next->PrevInSEL = Edge1;
-    TEdge* Prev = Edge1->PrevInSEL;
+    TEdge * const Prev = Edge1->PrevInSEL;
     if( Prev ) Prev->NextInSEL = Edge2;
     Edge2->PrevInSEL = Prev;
     Edge2->NextInSEL = Edge1;
@@ -2568,9 +2566,9 @@ void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2)
   }
   else if(  Edge2->NextInSEL == Edge1 )
   {
-    TEdge* Next = Edge1->NextInSEL;
+    TEdge * const Next = Edge1->NextInSEL;
     if( Next ) Next->PrevInSEL = Edge2;
-    TEdge* Prev = Edge2->PrevInSEL;
+    TEdge * const Prev = Edge2->PrevInSEL;
     if( Prev ) Prev->NextInSEL = Edge1;
     Edge1->PrevInSEL = Prev;
     Edge1->NextInSEL = Edge2;
@@ -2579,8 +2577,8 @@ void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2)
   }
   else
   {
-    TEdge* Next = Edge1->NextInSEL;
-    TEdge* Prev = Edge1->PrevInSEL;
+    TEdge * const Next = Edge1->NextInSEL;
+    TEdge * const Prev = Edge1->PrevInSEL;
     Edge1->NextInSEL = Edge2->NextInSEL;
     if( Edge1->NextInSEL ) Edge1->NextInSEL->PrevInSEL = Edge1;
     Edge1->PrevInSEL = Edge2->PrevInSEL;
@@ -2632,7 +2630,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
 {
   Direction dir;
   cInt horzLeft, horzRight;
-  bool IsOpen = (horzEdge->WindDelta == 0);
+  const bool IsOpen = (horzEdge->WindDelta == 0);
 
   GetHorzDirection(*horzEdge, dir, horzLeft, horzRight);
 
@@ -2668,7 +2666,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
   for (;;) //loop through consec. horizontal edges
   {
 
-    bool IsLastHorz = (horzEdge == eLastHorz);
+    const bool IsLastHorz = (horzEdge == eLastHorz);
     TEdge* e = GetNextInAEL(horzEdge, dir);
     while(e)
     {
@@ -2720,8 +2718,8 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
                     HorzSegmentsOverlap(horzEdge->Bot.X,
                     horzEdge->Top.X, eNextHorz->Bot.X, eNextHorz->Top.X))
                 {
-                    OutPt* op2 = GetLastOutPt(eNextHorz);
-                    AddJoin(op2, op1, eNextHorz->Top);
+                  OutPt * const op2 = GetLastOutPt(eNextHorz);
+                  AddJoin(op2, op1, eNextHorz->Top);
                 }
                 eNextHorz = eNextHorz->NextInSEL;
             }
@@ -2749,7 +2747,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
           IntPoint Pt = IntPoint(e->Curr.X, horzEdge->Curr.Y);
           IntersectEdges( e, horzEdge, Pt);
         }
-        TEdge* eNext = GetNextInAEL(e, dir);
+        TEdge * const eNext = GetNextInAEL(e, dir);
         SwapPositionsInAEL( horzEdge, e );
         e = eNext;
     } //end while(e)
@@ -2773,8 +2771,8 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
               HorzSegmentsOverlap(horzEdge->Bot.X,
               horzEdge->Top.X, eNextHorz->Bot.X, eNextHorz->Top.X))
           {
-              OutPt* op2 = GetLastOutPt(eNextHorz);
-              AddJoin(op2, op1, eNextHorz->Top);
+            OutPt * const op2 = GetLastOutPt(eNextHorz);
+            AddJoin(op2, op1, eNextHorz->Top);
           }
           eNextHorz = eNextHorz->NextInSEL;
       }
@@ -2789,14 +2787,14 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
       UpdateEdgeIntoAEL(horzEdge);
       if (horzEdge->WindDelta == 0) return;
       //nb: HorzEdge is no longer horizontal here
-      TEdge* ePrev = horzEdge->PrevInAEL;
-      TEdge* eNext = horzEdge->NextInAEL;
+      TEdge * const ePrev = horzEdge->PrevInAEL;
+      TEdge * const eNext = horzEdge->NextInAEL;
       if (ePrev && ePrev->Curr.X == horzEdge->Bot.X &&
         ePrev->Curr.Y == horzEdge->Bot.Y && ePrev->WindDelta != 0 &&
         (ePrev->OutIdx >= 0 && ePrev->Curr.Y > ePrev->Top.Y &&
         SlopesEqual(*horzEdge, *ePrev, m_UseFullRange)))
       {
-        OutPt* op2 = AddOutPt(ePrev, horzEdge->Bot);
+        OutPt * const op2 = AddOutPt(ePrev, horzEdge->Bot);
         AddJoin(op1, op2, horzEdge->Top);
       }
       else if (eNext && eNext->Curr.X == horzEdge->Bot.X &&
@@ -2804,7 +2802,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
         eNext->OutIdx >= 0 && eNext->Curr.Y > eNext->Top.Y &&
         SlopesEqual(*horzEdge, *eNext, m_UseFullRange))
       {
-        OutPt* op2 = AddOutPt(eNext, horzEdge->Bot);
+        OutPt * const op2 = AddOutPt(eNext, horzEdge->Bot);
         AddJoin(op1, op2, horzEdge->Top);
       }
     }
@@ -2824,7 +2822,7 @@ bool Clipper::ProcessIntersections(const cInt topY)
   if( !m_ActiveEdges ) return true;
   try {
     BuildIntersectList(topY);
-    size_t IlSize = m_IntersectList.size();
+    const size_t IlSize = m_IntersectList.size();
     if (IlSize == 0) return true;
     if (IlSize == 1 || FixupIntersectionOrder()) ProcessIntersectList();
     else return false;
@@ -2871,7 +2869,7 @@ void Clipper::BuildIntersectList(const cInt topY)
     e = m_SortedEdges;
     while( e->NextInSEL )
     {
-      TEdge *eNext = e->NextInSEL;
+      TEdge * const eNext = e->NextInSEL;
       IntPoint Pt;
       if(e->Curr.X > eNext->Curr.X)
       {
@@ -2932,7 +2930,7 @@ bool Clipper::FixupIntersectionOrder()
   //so to ensure this the order of intersections may need adjusting ...
   CopyAELToSEL();
   std::sort(m_IntersectList.begin(), m_IntersectList.end(), IntersectListSort);
-  size_t cnt = m_IntersectList.size();
+  const size_t cnt = m_IntersectList.size();
   for (size_t i = 0; i < cnt; ++i)
   {
     if (!EdgesAdjacent(*m_IntersectList[i]))
@@ -2950,7 +2948,7 @@ bool Clipper::FixupIntersectionOrder()
 
 void Clipper::DoMaxima(TEdge *e)
 {
-  TEdge* eMaxPair = GetMaximaPairEx(e);
+  TEdge * const eMaxPair = GetMaximaPairEx(e);
   if (!eMaxPair)
   {
     if (e->OutIdx >= 0)
@@ -3011,14 +3009,14 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
 
     if(IsMaximaEdge)
     {
-      TEdge* eMaxPair = GetMaximaPairEx(e);
+      TEdge * const eMaxPair = GetMaximaPairEx(e);
       IsMaximaEdge = (!eMaxPair || !IsHorizontal(*eMaxPair));
     }
 
     if(IsMaximaEdge)
     {
       if (m_StrictSimple) m_Maxima.push_back(e->Top.X);
-      TEdge* ePrev = e->PrevInAEL;
+      const TEdge * const ePrev = e->PrevInAEL;
       DoMaxima(e);
       if( !ePrev ) e = m_ActiveEdges;
       else e = ePrev->NextInAEL;
@@ -3046,16 +3044,16 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
       //make sure both edges have a vertex here ...
       if (m_StrictSimple)
       {
-        TEdge* ePrev = e->PrevInAEL;
+        TEdge * const ePrev = e->PrevInAEL;
         if ((e->OutIdx >= 0) && (e->WindDelta != 0) && ePrev && (ePrev->OutIdx >= 0) &&
           (ePrev->Curr.X == e->Curr.X) && (ePrev->WindDelta != 0))
         {
-          IntPoint pt = e->Curr;
+          const IntPoint pt = e->Curr;
 #ifdef use_xyz
           SetZ(pt, *ePrev, *e);
 #endif
-          OutPt* op = AddOutPt(ePrev, pt);
-          OutPt* op2 = AddOutPt(e, pt);
+          OutPt * const op = AddOutPt(ePrev, pt);
+          OutPt * const op2 = AddOutPt(e, pt);
           AddJoin(op, op2, pt); //StrictlySimple (type-3) join
         }
       }
@@ -3081,15 +3079,15 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
       UpdateEdgeIntoAEL(e);
 
       //if output polygons share an edge, they'll need joining later ...
-      TEdge* ePrev = e->PrevInAEL;
-      TEdge* eNext = e->NextInAEL;
+      TEdge * const ePrev = e->PrevInAEL;
+      TEdge * const eNext = e->NextInAEL;
       if (ePrev && ePrev->Curr.X == e->Bot.X &&
         ePrev->Curr.Y == e->Bot.Y && op &&
         ePrev->OutIdx >= 0 && ePrev->Curr.Y > ePrev->Top.Y &&
         SlopesEqual(e->Curr, e->Top, ePrev->Curr, ePrev->Top, m_UseFullRange) &&
         (e->WindDelta != 0) && (ePrev->WindDelta != 0))
       {
-        OutPt* op2 = AddOutPt(ePrev, e->Bot);
+        OutPt * const op2 = AddOutPt(ePrev, e->Bot);
         AddJoin(op, op2, e->Top);
       }
       else if (eNext && eNext->Curr.X == e->Bot.X &&
@@ -3098,7 +3096,7 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
         SlopesEqual(e->Curr, e->Top, eNext->Curr, eNext->Top, m_UseFullRange) &&
         (e->WindDelta != 0) && (eNext->WindDelta != 0))
       {
-        OutPt* op2 = AddOutPt(eNext, e->Bot);
+        OutPt * const op2 = AddOutPt(eNext, e->Bot);
         AddJoin(op, op2, e->Top);
       }
     }
@@ -3110,14 +3108,14 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY)
 void Clipper::FixupOutPolyline(OutRec &outrec)
 {
   OutPt *pp = outrec.Pts;
-  OutPt *lastPP = pp->Prev;
+  const OutPt * lastPP = pp->Prev;
   while (pp != lastPP)
   {
     pp = pp->Next;
     if (pp->Pt == pp->Prev->Pt)
     {
       if (pp == lastPP) lastPP = pp->Prev;
-      OutPt *tmpPP = pp->Prev;
+      OutPt * const tmpPP = pp->Prev;
       tmpPP->Next = pp->Next;
       pp->Next->Prev = tmpPP;
       delete pp;
@@ -3138,10 +3136,10 @@ void Clipper::FixupOutPolygon(OutRec &outrec)
 {
     //FixupOutPolygon() - removes duplicate points and simplifies consecutive
     //parallel edges by removing the middle vertex.
-    OutPt *lastOK = nullptr;
+    const OutPt * lastOK = nullptr;
     outrec.BottomPt = nullptr;
     OutPt *pp = outrec.Pts;
-    bool preserveCol = m_PreserveCollinear || m_StrictSimple;
+    const bool preserveCol = m_PreserveCollinear || m_StrictSimple;
 
     for (;;)
     {
@@ -3158,7 +3156,7 @@ void Clipper::FixupOutPolygon(OutRec &outrec)
             (!preserveCol || !Pt2IsBetweenPt1AndPt3(pp->Prev->Pt, pp->Pt, pp->Next->Pt))))
         {
             lastOK = nullptr;
-            OutPt *tmp = pp;
+            const OutPt * const tmp = pp;
             pp->Prev->Next = pp->Next;
             pp->Next->Prev = pp->Prev;
             pp = pp->Prev;
@@ -3179,7 +3177,7 @@ int PointCount(OutPt *Pts)
 {
     if (!Pts) return 0;
     int result = 0;
-    OutPt* p = Pts;
+    const OutPt * p = Pts;
     do
     {
         result++;
@@ -3198,7 +3196,7 @@ void Clipper::BuildResult(Paths &polys)
     if (!m_PolyOut->Pts) continue;
     Path pg;
     OutPt* p = m_PolyOut->Pts->Prev;
-    int cnt = PointCount(p);
+    const int cnt = PointCount(p);
     if (cnt < 2) continue;
     pg.reserve(cnt);
     for (int i = 0; i < cnt; ++i)
@@ -3218,22 +3216,23 @@ void Clipper::BuildResult2(PolyTree& polytree)
     //add each output polygon/contour to polytree ...
     for (auto outRec : m_PolyOuts)
     {
-        int cnt = PointCount(outRec->Pts);
-        if ((outRec->IsOpen && cnt < 2) || (!outRec->IsOpen && cnt < 3)) continue;
-        FixHoleLinkage(*outRec);
-        auto* pn = new PolyNode();
-        //nb: polytree takes ownership of all the PolyNodes
-        polytree.AllNodes.push_back(pn);
-        outRec->PolyNd = pn;
-        pn->Parent = nullptr;
-        pn->Index = 0;
-        pn->Contour.reserve(cnt);
-        OutPt *op = outRec->Pts->Prev;
-        for (int j = 0; j < cnt; j++)
-        {
-            pn->Contour.push_back(op->Pt);
-            op = op->Prev;
-        }
+      const int cnt = PointCount(outRec->Pts);
+      if ((outRec->IsOpen && cnt < 2) || (!outRec->IsOpen && cnt < 3))
+        continue;
+      FixHoleLinkage(*outRec);
+      auto * pn = new PolyNode();
+      // nb: polytree takes ownership of all the PolyNodes
+      polytree.AllNodes.push_back(pn);
+      outRec->PolyNd = pn;
+      pn->Parent = nullptr;
+      pn->Index = 0;
+      pn->Contour.reserve(cnt);
+      const OutPt * op = outRec->Pts->Prev;
+      for (int j = 0; j < cnt; j++)
+      {
+        pn->Contour.push_back(op->Pt);
+        op = op->Prev;
+      }
     }
 
     //fixup PolyNode links etc ...
@@ -3257,7 +3256,7 @@ void Clipper::BuildResult2(PolyTree& polytree)
 void SwapIntersectNodes(IntersectNode &int1, IntersectNode &int2)
 {
   //just swap the contents (because fIntersectNodes is a single-linked-list)
-  IntersectNode inode = int1; //gets a copy of Int1
+  const IntersectNode inode = int1; // gets a copy of Int1
   int1.Edge1 = int2.Edge1;
   int1.Edge2 = int2.Edge2;
   int1.Pt = int2.Pt;
@@ -3363,8 +3362,8 @@ OutPt* DupOutPt(OutPt* outPt, bool InsertAfter)
 bool JoinHorz(OutPt* op1, OutPt* op1b, OutPt* op2, OutPt* op2b,
   const IntPoint Pt, bool DiscardLeft)
 {
-  Direction Dir1 = (op1->Pt.X > op1b->Pt.X ? dRightToLeft : dLeftToRight);
-  Direction Dir2 = (op2->Pt.X > op2b->Pt.X ? dRightToLeft : dLeftToRight);
+  const Direction Dir1 = (op1->Pt.X > op1b->Pt.X ? dRightToLeft : dLeftToRight);
+  const Direction Dir2 = (op2->Pt.X > op2b->Pt.X ? dRightToLeft : dLeftToRight);
   if (Dir1 == Dir2) return false;
 
   //When DiscardLeft, we want Op1b to be on the Left of Op1, otherwise we
@@ -3459,7 +3458,7 @@ bool Clipper::JoinPoints(Join *j, OutRec* outRec1, OutRec* outRec2)
   //location at the Bottom of the overlapping segment (& Join.OffPt is above).
   //3. StrictSimple joins where edges touch but are not collinear and where
   //Join.OutPt1, Join.OutPt2 & Join.OffPt all share the same point.
-  bool isHorizontal = (j->OutPt1->Pt.Y == j->OffPt.Y);
+  const bool isHorizontal = (j->OutPt1->Pt.Y == j->OffPt.Y);
 
   if (isHorizontal  && (j->OffPt == j->OutPt1->Pt) &&
   (j->OffPt == j->OutPt2->Pt))
@@ -3469,11 +3468,11 @@ bool Clipper::JoinPoints(Join *j, OutRec* outRec1, OutRec* outRec2)
     op1b = j->OutPt1->Next;
     while (op1b != op1 && (op1b->Pt == j->OffPt))
       op1b = op1b->Next;
-    bool reverse1 = (op1b->Pt.Y > j->OffPt.Y);
+    const bool reverse1 = (op1b->Pt.Y > j->OffPt.Y);
     op2b = j->OutPt2->Next;
     while (op2b != op2 && (op2b->Pt == j->OffPt))
       op2b = op2b->Next;
-    bool reverse2 = (op2b->Pt.Y > j->OffPt.Y);
+    const bool reverse2 = (op2b->Pt.Y > j->OffPt.Y);
     if (reverse1 == reverse2) return false;
     if (reverse1)
     {
@@ -3555,8 +3554,7 @@ bool Clipper::JoinPoints(Join *j, OutRec* outRec1, OutRec* outRec2)
     //make sure the polygons are correctly oriented ...
     op1b = op1->Next;
     while ((op1b->Pt == op1->Pt) && (op1b != op1)) op1b = op1b->Next;
-    bool Reverse1 = ((op1b->Pt.Y > op1->Pt.Y) ||
-      !SlopesEqual(op1->Pt, op1b->Pt, j->OffPt, m_UseFullRange));
+    const bool Reverse1 = ((op1b->Pt.Y > op1->Pt.Y) || !SlopesEqual(op1->Pt, op1b->Pt, j->OffPt, m_UseFullRange));
     if (Reverse1)
     {
       op1b = op1->Prev;
@@ -3566,8 +3564,7 @@ bool Clipper::JoinPoints(Join *j, OutRec* outRec1, OutRec* outRec2)
     };
     op2b = op2->Next;
     while ((op2b->Pt == op2->Pt) && (op2b != op2))op2b = op2b->Next;
-    bool Reverse2 = ((op2b->Pt.Y > op2->Pt.Y) ||
-      !SlopesEqual(op2->Pt, op2b->Pt, j->OffPt, m_UseFullRange));
+    const bool Reverse2 = ((op2b->Pt.Y > op2->Pt.Y) || !SlopesEqual(op2->Pt, op2b->Pt, j->OffPt, m_UseFullRange));
     if (Reverse2)
     {
       op2b = op2->Prev;
@@ -3619,7 +3616,7 @@ void Clipper::FixupFirstLefts1(OutRec* OldOutRec, OutRec* NewOutRec)
   //tests if NewOutRec contains the polygon before reassigning FirstLeft
   for (auto outRec : m_PolyOuts)
   {
-    OutRec* firstLeft = ParseFirstLeft(outRec->FirstLeft);
+    const OutRec * const firstLeft = ParseFirstLeft(outRec->FirstLeft);
     if (outRec->Pts  && firstLeft == OldOutRec)
     {
       if (Poly2ContainsPoly1(outRec->Pts, NewOutRec->Pts))
@@ -3635,12 +3632,12 @@ void Clipper::FixupFirstLefts2(OutRec* InnerOutRec, OutRec* OuterOutRec)
   //It's possible that these polygons now wrap around other polygons, so check
   //every polygon that's also contained by OuterOutRec's FirstLeft container
   //(including 0) to see if they've become inner to the new inner polygon ...
-  OutRec* orfl = OuterOutRec->FirstLeft;
+  OutRec * const orfl = OuterOutRec->FirstLeft;
   for (auto outRec : m_PolyOuts)
   {
     if (!outRec->Pts || outRec == OuterOutRec || outRec == InnerOutRec)
       continue;
-    OutRec* firstLeft = ParseFirstLeft(outRec->FirstLeft);
+    const OutRec * const firstLeft = ParseFirstLeft(outRec->FirstLeft);
     if (firstLeft != orfl && firstLeft != InnerOutRec && firstLeft != OuterOutRec)
       continue;
     if (Poly2ContainsPoly1(outRec->Pts, InnerOutRec->Pts))
@@ -3657,7 +3654,7 @@ void Clipper::FixupFirstLefts3(OutRec* OldOutRec, OutRec* NewOutRec)
   //reassigns FirstLeft WITHOUT testing if NewOutRec contains the polygon
   for (auto outRec : m_PolyOuts)
   {
-    OutRec* firstLeft = ParseFirstLeft(outRec->FirstLeft);
+    const OutRec * const firstLeft = ParseFirstLeft(outRec->FirstLeft);
     if (outRec->Pts && firstLeft == OldOutRec)
       outRec->FirstLeft = NewOutRec;
   }
@@ -3668,7 +3665,7 @@ void Clipper::JoinCommonEdges()
 {
   for (auto join : m_Joins)
   {
-    OutRec *outRec1 = GetOutRec(join->OutPt1->Idx);
+    OutRec * const outRec1 = GetOutRec(join->OutPt1->Idx);
     OutRec *outRec2 = GetOutRec(join->OutPt2->Idx);
 
     if (!outRec1->Pts || !outRec2->Pts) continue;
@@ -3759,7 +3756,7 @@ DoublePoint GetUnitNormal(const IntPoint &pt1, const IntPoint &pt2)
 
   auto Dx = (double)(pt2.X - pt1.X);
   auto dy = (double)(pt2.Y - pt1.Y);
-  double f = 1 *1.0/ std::sqrt( Dx*Dx + dy*dy );
+  const double f = 1 * 1.0 / std::sqrt(Dx * Dx + dy * dy);
   Dx *= f;
   dy *= f;
   return {dy, -Dx};
@@ -3828,7 +3825,7 @@ void ClipperOffset::AddPath(const Path& path, JoinType joinType, EndType endType
     m_lowest = IntPoint(m_polyNodes.ChildCount() - 1, k);
   else
   {
-    IntPoint ip = m_polyNodes.Childs[(int)m_lowest.X]->Contour[(int)m_lowest.Y];
+    const IntPoint ip = m_polyNodes.Childs[(int)m_lowest.X]->Contour[(int)m_lowest.Y];
     if (newNode->Contour[k].Y > ip.Y ||
       (newNode->Contour[k].Y == ip.Y &&
       newNode->Contour[k].X < ip.X))
@@ -3885,7 +3882,7 @@ void ClipperOffset::Execute(Paths& solution, double delta)
   }
   else
   {
-    IntRect r = clpr.GetBounds();
+    const IntRect r = clpr.GetBounds();
     Path outer(4);
     outer[0] = IntPoint(r.left - 10, r.bottom + 10);
     outer[1] = IntPoint(r.right + 10, r.bottom + 10);
@@ -3915,7 +3912,7 @@ void ClipperOffset::Execute(PolyTree& solution, double delta)
   }
   else
   {
-    IntRect r = clpr.GetBounds();
+    const IntRect r = clpr.GetBounds();
     Path outer(4);
     outer[0] = IntPoint(r.left - 10, r.bottom + 10);
     outer[1] = IntPoint(r.right + 10, r.bottom + 10);
@@ -3928,7 +3925,7 @@ void ClipperOffset::Execute(PolyTree& solution, double delta)
     //remove the outer PolyNode rectangle ...
     if (solution.ChildCount() == 1 && solution.Childs[0]->ChildCount() > 0)
     {
-      PolyNode* outerNode = solution.Childs[0];
+      PolyNode * const outerNode = solution.Childs[0];
       solution.Childs.reserve(outerNode->ChildCount());
       solution.Childs[0] = outerNode->Childs[0];
       solution.Childs[0]->Parent = outerNode->Parent;
@@ -3952,7 +3949,7 @@ void ClipperOffset::DoOffset(double delta)
     m_destPolys.reserve(m_polyNodes.ChildCount());
     for (int i = 0; i < m_polyNodes.ChildCount(); i++)
     {
-      PolyNode& node = *m_polyNodes.Childs[i];
+      const PolyNode & node = *m_polyNodes.Childs[i];
       if (node.m_endtype == etClosedPolygon)
         m_destPolys.push_back(node.Contour);
     }
@@ -3980,10 +3977,10 @@ void ClipperOffset::DoOffset(double delta)
   m_destPolys.reserve(m_polyNodes.ChildCount() * 2);
   for (int i = 0; i < m_polyNodes.ChildCount(); i++)
   {
-    PolyNode& node = *m_polyNodes.Childs[i];
+    const PolyNode & node = *m_polyNodes.Childs[i];
     m_srcPoly = node.Contour;
 
-    int len = (int)m_srcPoly.size();
+    const int len = (int)m_srcPoly.size();
     if (len == 0 || (delta <= 0 && (len < 3 || node.m_endtype != etClosedPolygon)))
         continue;
 
@@ -3998,7 +3995,7 @@ void ClipperOffset::DoOffset(double delta)
           m_destPoly.push_back(IntPoint(
             Round(m_srcPoly[0].X + X * delta),
             Round(m_srcPoly[0].Y + Y * delta)));
-          double X2 = X;
+          const double X2 = X;
           X = X * m_cos - m_sin * Y;
           Y = X2 * m_sin + Y * m_cos;
         }
@@ -4044,7 +4041,7 @@ void ClipperOffset::DoOffset(double delta)
       m_destPolys.push_back(m_destPoly);
       m_destPoly.clear();
       //re-build m_normals ...
-      DoublePoint n = m_normals[len -1];
+      const DoublePoint n = m_normals[len - 1];
       for (int j = len - 1; j > 0; j--)
         m_normals[j] = DoublePoint(-m_normals[j - 1].X, -m_normals[j - 1].Y);
       m_normals[0] = DoublePoint(-n.X, -n.Y);
@@ -4062,7 +4059,7 @@ void ClipperOffset::DoOffset(double delta)
       IntPoint pt1;
       if (node.m_endtype == etOpenButt)
       {
-        int j = len - 1;
+        const int j = len - 1;
         pt1 = IntPoint((cInt)Round(m_srcPoly[j].X + m_normals[j].X *
           delta), (cInt)Round(m_srcPoly[j].Y + m_normals[j].Y * delta));
         m_destPoly.push_back(pt1);
@@ -4072,7 +4069,7 @@ void ClipperOffset::DoOffset(double delta)
       }
       else
       {
-        int j = len - 1;
+        const int j = len - 1;
         k = len - 2;
         m_sinA = 0;
         m_normals[j] = DoublePoint(-m_normals[j].X, -m_normals[j].Y);
@@ -4121,7 +4118,7 @@ void ClipperOffset::OffsetPoint(int j, int& k, JoinType jointype)
   if (std::fabs(m_sinA * m_delta) < 1.0)
   {
     //dot product ...
-    double cosA = (m_normals[k].X * m_normals[j].X + m_normals[j].Y * m_normals[k].Y );
+    const double cosA = (m_normals[k].X * m_normals[j].X + m_normals[j].Y * m_normals[k].Y);
     if (cosA > 0) // angle => 0 degrees
     {
       m_destPoly.push_back(IntPoint(Round(m_srcPoly[j].X + m_normals[k].X * m_delta),
@@ -4146,8 +4143,7 @@ void ClipperOffset::OffsetPoint(int j, int& k, JoinType jointype)
     {
       case jtMiter:
         {
-          double r = 1 + (m_normals[j].X * m_normals[k].X +
-            m_normals[j].Y * m_normals[k].Y);
+          const double r = 1 + (m_normals[j].X * m_normals[k].X + m_normals[j].Y * m_normals[k].Y);
           if (r >= m_miterLim) DoMiter(j, k, r); else DoSquare(j, k);
           break;
         }
@@ -4160,8 +4156,7 @@ void ClipperOffset::OffsetPoint(int j, int& k, JoinType jointype)
 
 void ClipperOffset::DoSquare(int j, int k)
 {
-  double dx = std::tan(std::atan2(m_sinA,
-      m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y) / 4);
+  const double dx = std::tan(std::atan2(m_sinA, m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y) / 4);
   m_destPoly.push_back(IntPoint(
       Round(m_srcPoly[j].X + m_delta * (m_normals[k].X - m_normals[k].Y * dx)),
       Round(m_srcPoly[j].Y + m_delta * (m_normals[k].Y + m_normals[k].X * dx))));
@@ -4173,7 +4168,7 @@ void ClipperOffset::DoSquare(int j, int k)
 
 void ClipperOffset::DoMiter(int j, int k, double r)
 {
-  double q = m_delta / r;
+  const double q = m_delta / r;
   m_destPoly.push_back(IntPoint(Round(m_srcPoly[j].X + (m_normals[k].X + m_normals[j].X) * q),
       Round(m_srcPoly[j].Y + (m_normals[k].Y + m_normals[j].Y) * q)));
 }
@@ -4181,9 +4176,8 @@ void ClipperOffset::DoMiter(int j, int k, double r)
 
 void ClipperOffset::DoRound(int j, int k)
 {
-  double a = std::atan2(m_sinA,
-  m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y);
-  int steps = std::max((int)Round(m_StepsPerRad * std::fabs(a)), 1);
+  const double a = std::atan2(m_sinA, m_normals[k].X * m_normals[j].X + m_normals[k].Y * m_normals[j].Y);
+  const int steps = std::max((int)Round(m_StepsPerRad * std::fabs(a)), 1);
 
   double X = m_normals[k].X, Y = m_normals[k].Y, X2;
   for (int i = 0; i < steps; ++i)
@@ -4209,7 +4203,7 @@ void Clipper::DoSimplePolygons()
   PolyOutList::size_type i = 0;
   while (i < m_PolyOuts.size())
   {
-    OutRec* outrec = m_PolyOuts[i++];
+    OutRec * const outrec = m_PolyOuts[i++];
     OutPt* op = outrec->Pts;
     if (!op || outrec->IsOpen) continue;
     do //for each Pt in Polygon until duplicate found do ...
@@ -4220,15 +4214,15 @@ void Clipper::DoSimplePolygons()
         if ((op->Pt == op2->Pt) && op2->Next != op && op2->Prev != op)
         {
           //split the polygon into two ...
-          OutPt* op3 = op->Prev;
-          OutPt* op4 = op2->Prev;
+          OutPt * const op3 = op->Prev;
+          OutPt * const op4 = op2->Prev;
           op->Prev = op4;
           op4->Next = op;
           op2->Prev = op3;
           op3->Next = op2;
 
           outrec->Pts = op;
-          OutRec* outrec2 = CreateOutRec();
+          OutRec * const outrec2 = CreateOutRec();
           outrec2->Pts = op2;
           UpdateOutPtIdxs(*outrec2);
           if (Poly2ContainsPoly1(outrec2->Pts, outrec->Pts))
@@ -4305,8 +4299,8 @@ void SimplifyPolygons(Paths &polys, PolyFillType fillType)
 
 inline double DistanceSqrd(const IntPoint& pt1, const IntPoint& pt2)
 {
-  double Dx = ((double)pt1.X - pt2.X);
-  double dy = ((double)pt1.Y - pt2.Y);
+  const double Dx = ((double)pt1.X - pt2.X);
+  const double dy = ((double)pt1.Y - pt2.Y);
   return (Dx*Dx + dy*dy);
 }
 //------------------------------------------------------------------------------
@@ -4357,15 +4351,15 @@ bool SlopesNearCollinear(const IntPoint& pt1,
 
 bool PointsAreClose(IntPoint pt1, IntPoint pt2, double distSqrd)
 {
-    double Dx = (double)pt1.X - pt2.X;
-    double dy = (double)pt1.Y - pt2.Y;
-    return ((Dx * Dx) + (dy * dy) <= distSqrd);
+  const double Dx = (double)pt1.X - pt2.X;
+  const double dy = (double)pt1.Y - pt2.Y;
+  return ((Dx * Dx) + (dy * dy) <= distSqrd);
 }
 //------------------------------------------------------------------------------
 
 OutPt* ExcludeOp(OutPt* op)
 {
-  OutPt* result = op->Prev;
+  OutPt * const result = op->Prev;
   result->Next = op->Next;
   op->Next->Prev = result;
   result->Idx = 0;
@@ -4395,7 +4389,7 @@ void CleanPolygon(const Path& in_poly, Path& out_poly, double distance)
     outPts[i].Idx = 0;
   }
 
-  double distSqrd = distance * distance;
+  const double distSqrd = distance * distance;
   OutPt* op = &outPts[0];
   while (op->Idx == 0 && op->Next != op->Prev)
   {
@@ -4456,9 +4450,9 @@ void CleanPolygons(Paths& polys, double distance)
 void Minkowski(const Path& poly, const Path& path,
   Paths& solution, bool isSum, bool isClosed)
 {
-  int delta = (isClosed ? 1 : 0);
-  size_t polyCnt = poly.size();
-  size_t pathCnt = path.size();
+  const int delta = (isClosed ? 1 : 0);
+  const size_t polyCnt = poly.size();
+  const size_t pathCnt = path.size();
   Paths pp;
   pp.reserve(pathCnt);
   if (isSum)
@@ -4595,7 +4589,7 @@ std::ostream& operator <<(std::ostream &s, const IntPoint &p)
 std::ostream& operator <<(std::ostream &s, const Path &p)
 {
   if (p.empty()) return s;
-  Path::size_type last = p.size() -1;
+  const Path::size_type last = p.size() - 1;
   for (Path::size_type i = 0; i < last; i++)
     s << "(" << p[i].X << "," << p[i].Y << "), ";
   s << "(" << p[last].X << "," << p[last].Y << ")\n";

--- a/v3p/netlib/linalg/lsmrBase.cxx
+++ b/v3p/netlib/linalg/lsmrBase.cxx
@@ -233,7 +233,7 @@ lsmrBase::D2Norm( double a, double b ) const
 void
 lsmrBase::Scale( unsigned int n, double factor, double *x ) const
 {
-  double * const xend = x + n;
+  const double * const xend = x + n;
   while( x != xend )
     {
       *x++ *= factor;

--- a/v3p/netlib/linalg/lsqrBase.cxx
+++ b/v3p/netlib/linalg/lsqrBase.cxx
@@ -223,7 +223,7 @@ lsqrBase::D2Norm( double a, double b ) const
 void
 lsqrBase::Scale( unsigned int n, double factor, double *x ) const
 {
-  double * const xend = x + n;
+  const double * const xend = x + n;
   while( x != xend )
     {
     *x++ *= factor;

--- a/vcl/tests/test_iostream.cxx
+++ b/vcl/tests/test_iostream.cxx
@@ -82,7 +82,7 @@ test_iostream_main(int /*argc*/, char * /*argv*/[])
   a = b;
   b = a; // quell warning about unused vars. compilers are sooo gullible.
 
-  std::streambuf * ptr = nullptr;
+  const std::streambuf * ptr = nullptr;
   if (ptr) // quell warning.
     ++ptr;
 

--- a/vcl/tests/test_memory.cxx
+++ b/vcl/tests/test_memory.cxx
@@ -59,12 +59,12 @@ test_memory_main(int /*argc*/, char * /*argv*/[])
     std::unique_ptr<A> pa2(new B());
     std::unique_ptr<A> pa3(std::move(pb1));
 
-    A * ptr = get_A(*pa1);
+    const A * ptr = get_A(*pa1);
     ASSERT(ptr == pa1.get(), "auto_ptr does not return correct object when dereferenced");
     ptr = pa1->self();
     ASSERT(ptr == pa1.get(), "auto_ptr does not return correct pointer from operator->");
 
-    A * before = pa0.get();
+    const A * before = pa0.get();
     pa0.reset(new A());
     ASSERT(pa0.get() && pa0.get() != before, "auto_ptr does not hold a new object after reset(new A())");
 
@@ -100,7 +100,7 @@ test_memory_main(int /*argc*/, char * /*argv*/[])
     const std::shared_ptr<A> spa3(spb1);
     const std::weak_ptr<A> wpa1(spa1);
 
-    A * ptr = get_A(*spa1);
+    const A * ptr = get_A(*spa1);
     ASSERT(ptr == spa1.get(), "shared_ptr does not return correct object when dereferenced");
     ptr = spa1->self();
     ASSERT(ptr == spa1.get(), "shared_ptr does not return correct pointer from operator->");


### PR DESCRIPTION
## Summary
- Add explicit `const` qualifiers where variables are not modified after initialization across 68 files in core/, v3p/, vcl/, and contrib/
- Replace direct use of `INT_MAX`/`INT_MIN` with `<climits>` includes for portability
- Fix const-correctness in `vpgl_io_camera` template to accept `const vpgl_camera<T>*` in `vsl_b_write`, propagating const through all `static_cast`s (the function only reads camera data)

## Test plan
- [x] `vpgl_test_camera_io` passes all 6 sub-tests
- [x] Full CTest run to verify no regressions from const additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)