### PR TITLE
DOC: Correct vnl_random::lrand32() Doxygen comments (#976)

### DIFF
--- a/core/vnl/vnl_random.h
+++ b/core/vnl/vnl_random.h
@@ -98,22 +98,35 @@ public:
   void
   restart();
 
-  //: Generates a random unsigned 32-bit number.
+  //: Generates a random unsigned 32-bit value in [0, 2^32 - 1].
+  // \note The return type is \c unsigned \c long for historical
+  //       (ABI-stable) reasons. The produced value is always masked
+  //       to 32 bits, so it fits in a \c uint32_t on every platform
+  //       even when \c unsigned \c long is 64 bits wide (LP64).
   unsigned long
   lrand32();
 
-  //: Generates a random unsigned long in [a,b]
+  //: Generates a random signed integer in the inclusive range [a, b].
+  // \pre \c a \c <= \c b
+  // \note Despite sharing the name \c lrand32, this overload returns
+  //       a signed \c int rather than the 32-bit unsigned value
+  //       produced by the no-argument \c lrand32(). The naming is
+  //       preserved for ABI stability; new code preferring strongly
+  //       typed RNG output should use \c <random> directly.
   int
   lrand32(int a, int b);
 
-  //: Generates a random unsigned long in [0,b]
+  //: Generates a random signed integer in the inclusive range [0, b].
+  // \pre \c 0 \c <= \c b
   int
   lrand32(int b)
   {
     return lrand32(0, b);
   }
 
-  //: Generates a random unsigned long in [a,b]
+  //: Generates a random signed integer in [a, b]; \c count returns
+  //  the number of underlying \c lrand32() draws taken (rejection
+  //  sampling is used to avoid modulo bias).
   int
   lrand32(int a, int b, int &);
 


### PR DESCRIPTION
Fixes the doc-comment mismatches reported in #976. ABI is preserved — only Doxygen text changes.

<details>
<summary>What changed and why</summary>

Issue #976 (Sean McBride) flagged four problems with the `lrand32()` overloads in `core/vnl/vnl_random.h`:

1. `unsigned long` is not a 32-bit type on LP64 platforms.
2. The four overloads share a name but have inconsistent return types.
3. **Comments do not match the actual signatures.**
4. One overload returns unsigned, the others return signed.

Hans's recommendation in the issue thread was a three-step path: (1) fix the comments, (2) deprecate, (3) provide `<random>`-based wrappers. This PR is **step 1 only** — a low-risk, ABI-preserving doc fix. Steps 2 and 3 are larger and can land separately.

The updated comments:
- Document that `lrand32()` always returns a value in `[0, 2^32 - 1]` (the implementation masks with `& 0xffffffff`).
- Note that `unsigned long` is preserved for ABI stability even where it is 64 bits wide.
- Correctly describe the int-returning overloads as signed.
- Document the `assert(a <= b)` precondition.
- Document the rejection-sampling `count` out-parameter on the 4-arg form.

Function signatures, behavior, and the test suite are unchanged.
</details>

<details>
<summary>ABI/scope justification</summary>

A grep across `core/` and `contrib/` finds 42 files calling `lrand32()`. Changing the return type or renaming the overloads would be an ABI break that ripples through the tree and downstream consumers. The doc-only fix directly addresses point (3) of the issue — the most actionable item — and clarifies points (1), (2), (4) by being explicit in the documentation.
</details>

<details>
<summary>Verification</summary>

- Built `cmake -G Ninja -DVXL_BUILD_CONTRIB=ON -DBUILD_TESTING=ON` from a clean build directory: **4385/4385** targets compile and link successfully.
- `ctest -R vnl_test_random` passes (0.38s).
</details>

<!--
provenance: claude-code session 2026-04-27
key_facts:
  - issue: vxl/vxl#976 (vnl_random.h lrand32() code smells, opened 2025-01-30)
  - file_changed: core/vnl/vnl_random.h
  - lines: 101-118 (Doxygen comments only)
  - abi_preserved: yes — no signature changes
  - callers_count: 42 files in core/ and contrib/
  - build_verified: build-contrib/ with VXL_BUILD_CONTRIB=ON, full tree (4385 targets)
  - test_verified: ctest -R vnl_test_random — 1/1 passed
post_merge_action: leave issue #976 open; Hans's deprecation+<random>-wrapper plan still applies as a follow-up
-->