### PR TITLE
ENH: Add GitHub Actions CI workflow with CDash submission

### DIFF
--- a/.github/dashboard/report_build_diagnostics.py
+++ b/.github/dashboard/report_build_diagnostics.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Extract and print build warnings/errors from CTest Build.xml.
+
+ctest_build() writes compiler diagnostics to Build.xml for CDash but does
+not print them to stdout. This script reads Build.xml from the most recent
+test run and prints the <Text> content of every <Warning> and <Error>
+element so diagnostics appear directly in CI logs without inflating the
+log with full per-target compile output.
+
+Usage:
+    python report_build_diagnostics.py <build-directory>
+
+Adapted from ITK's Testing/ContinuousIntegration/report_build_diagnostics.py.
+Uses defusedxml to harden against XXE / billion-laughs attacks even though
+the input is CTest-generated and trusted; the workflow installs defusedxml
+before running this script.
+"""
+
+import os
+import sys
+
+# Use defusedxml for XXE-safe parsing. The GitHub Actions workflow installs
+# this package before invoking the script.
+from defusedxml import ElementTree as ET
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <build-directory>", file=sys.stderr)
+        return 1
+
+    build_dir = sys.argv[1]
+
+    tag_file = os.path.join(build_dir, "Testing", "TAG")
+    if not os.path.isfile(tag_file):
+        print(f"No TAG file found at {tag_file} - skipping.", file=sys.stderr)
+        return 0
+
+    with open(tag_file) as f:
+        tag_dir = f.readline().strip()
+
+    build_xml = os.path.join(build_dir, "Testing", tag_dir, "Build.xml")
+    if not os.path.isfile(build_xml):
+        print(f"No Build.xml found at {build_xml} - skipping.", file=sys.stderr)
+        return 0
+
+    tree = ET.parse(build_xml)
+    root = tree.getroot()
+
+    warnings = []
+    errors = []
+    for build_elem in root.iter("Build"):
+        for warning in build_elem.findall("Warning"):
+            text = warning.findtext("Text", "").strip()
+            src = warning.findtext("SourceFile", "").strip()
+            line = warning.findtext("SourceLineNumber", "").strip()
+            if text:
+                warnings.append((src, line, text))
+        for error in build_elem.findall("Error"):
+            text = error.findtext("Text", "").strip()
+            src = error.findtext("SourceFile", "").strip()
+            line = error.findtext("SourceLineNumber", "").strip()
+            if text:
+                errors.append((src, line, text))
+
+    if not warnings and not errors:
+        print("No build warnings or errors found.")
+        return 0
+
+    if errors:
+        print(f"========== BUILD ERRORS ({len(errors)}) ==========")
+        for src, line, text in errors:
+            loc = f"{src}:{line}" if src and line else (src or "")
+            prefix = f"  [{loc}] " if loc else "  "
+            print(f"{prefix}{text}")
+        print()
+
+    if warnings:
+        print(f"========== BUILD WARNINGS ({len(warnings)}) ==========")
+        for src, line, text in warnings:
+            loc = f"{src}:{line}" if src and line else (src or "")
+            prefix = f"  [{loc}] " if loc else "  "
+            print(f"{prefix}{text}")
+        print()
+
+    print("====================================================")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/dashboard/vxl_github_dashboard.cmake
+++ b/.github/dashboard/vxl_github_dashboard.cmake
@@ -1,0 +1,122 @@
+#---------------------------------------------------------------------
+# VXL CTest dashboard script for GitHub Actions
+#---------------------------------------------------------------------
+#
+# Driven by environment variables set in .github/workflows/build.yml.
+# Performs configure → build → test → submit-to-CDash in one ctest -S
+# invocation. Output is kept minimal: build/test diagnostics live in
+# CTest's XML files (which CDash consumes); only the summary lines
+# reach the GitHub Actions log. The companion report_build_diagnostics.py
+# script extracts the warning/error text from Build.xml after the run.
+#
+# Required environment variables:
+#   CTEST_SOURCE_DIRECTORY  - source checkout root
+#   CTEST_BINARY_DIRECTORY  - out-of-source build dir
+#   CTEST_BUILD_NAME        - distinct CDash build identifier
+#   CTEST_SITE              - CDash site label (usually github-actions)
+#   DASHBOARD_MODEL         - Experimental | Continuous | Nightly
+#   DASHBOARD_CACHE         - newline-separated CMake cache entries
+#
+# Optional:
+#   CTEST_BUILD_CONFIGURATION   - default Release
+#   CTEST_CMAKE_GENERATOR       - default Ninja
+#   CTEST_BUILD_FLAGS           - default empty (e.g. "-j4")
+#   CTEST_TEST_ARGS             - default "--output-on-failure --schedule-random"
+#   DASHBOARD_DO_SUBMIT         - default 1 (set to 0 to skip ctest_submit)
+#---------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+# ----- Required env vars ---------------------------------------------
+foreach(_var IN ITEMS
+    CTEST_SOURCE_DIRECTORY
+    CTEST_BINARY_DIRECTORY
+    CTEST_BUILD_NAME
+    CTEST_SITE
+    DASHBOARD_MODEL
+)
+  if(NOT DEFINED ENV{${_var}} OR "$ENV{${_var}}" STREQUAL "")
+    message(FATAL_ERROR "Required environment variable ${_var} is not set.")
+  endif()
+  set(${_var} "$ENV{${_var}}")
+endforeach()
+
+# ----- Optional env vars with defaults -------------------------------
+if(DEFINED ENV{CTEST_BUILD_CONFIGURATION} AND NOT "$ENV{CTEST_BUILD_CONFIGURATION}" STREQUAL "")
+  set(CTEST_BUILD_CONFIGURATION "$ENV{CTEST_BUILD_CONFIGURATION}")
+else()
+  set(CTEST_BUILD_CONFIGURATION "Release")
+endif()
+set(CTEST_CONFIGURATION_TYPE "${CTEST_BUILD_CONFIGURATION}")
+
+if(DEFINED ENV{CTEST_CMAKE_GENERATOR} AND NOT "$ENV{CTEST_CMAKE_GENERATOR}" STREQUAL "")
+  set(CTEST_CMAKE_GENERATOR "$ENV{CTEST_CMAKE_GENERATOR}")
+else()
+  set(CTEST_CMAKE_GENERATOR "Ninja")
+endif()
+
+if(DEFINED ENV{CTEST_BUILD_FLAGS})
+  set(CTEST_BUILD_FLAGS "$ENV{CTEST_BUILD_FLAGS}")
+endif()
+
+if(DEFINED ENV{DASHBOARD_DO_SUBMIT} AND "$ENV{DASHBOARD_DO_SUBMIT}" STREQUAL "0")
+  set(_do_submit FALSE)
+else()
+  set(_do_submit TRUE)
+endif()
+
+# ----- Initial cache --------------------------------------------------
+# DASHBOARD_CACHE is one cache entry per line. Pass through verbatim.
+set(CTEST_INITIAL_CACHE "$ENV{DASHBOARD_CACHE}")
+file(WRITE "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" "${CTEST_INITIAL_CACHE}")
+
+# ----- Run dashboard --------------------------------------------------
+ctest_start("${DASHBOARD_MODEL}")
+
+ctest_configure(
+  BUILD   "${CTEST_BINARY_DIRECTORY}"
+  SOURCE  "${CTEST_SOURCE_DIRECTORY}"
+  RETURN_VALUE _configure_rc
+  CAPTURE_CMAKE_ERROR _configure_capture
+)
+
+if(_configure_rc EQUAL 0 AND _configure_capture EQUAL 0)
+  ctest_build(
+    BUILD             "${CTEST_BINARY_DIRECTORY}"
+    CONFIGURATION     "${CTEST_BUILD_CONFIGURATION}"
+    NUMBER_WARNINGS   _build_warnings
+    NUMBER_ERRORS     _build_errors
+    RETURN_VALUE      _build_rc
+    CAPTURE_CMAKE_ERROR _build_capture
+  )
+  message(STATUS "ctest_build: errors=${_build_errors} warnings=${_build_warnings} rc=${_build_rc}")
+
+  if(_build_errors EQUAL 0 AND _build_rc EQUAL 0)
+    ctest_test(
+      BUILD               "${CTEST_BINARY_DIRECTORY}"
+      RETURN_VALUE        _test_rc
+      CAPTURE_CMAKE_ERROR _test_capture
+      PARALLEL_LEVEL      $ENV{CTEST_PARALLEL_LEVEL}
+    )
+    message(STATUS "ctest_test: rc=${_test_rc}")
+  endif()
+endif()
+
+if(_do_submit)
+  ctest_submit(RETURN_VALUE _submit_rc CAPTURE_CMAKE_ERROR _submit_capture)
+  message(STATUS "ctest_submit: rc=${_submit_rc}")
+endif()
+
+# ----- Final exit status ---------------------------------------------
+# Hard-fail on configure or build errors so the GitHub job is red.
+# Test failures are reported via CDash; the workflow does not turn red
+# on a flaky test (matching ITK's CI behavior).
+if(NOT _configure_rc EQUAL 0 OR NOT _configure_capture EQUAL 0)
+  message(FATAL_ERROR "Configure step failed (rc=${_configure_rc} capture=${_configure_capture}).")
+endif()
+if(DEFINED _build_errors AND NOT _build_errors EQUAL 0)
+  message(FATAL_ERROR "Build reported ${_build_errors} errors.")
+endif()
+if(DEFINED _build_rc AND NOT _build_rc EQUAL 0)
+  message(FATAL_ERROR "Build returned non-zero (rc=${_build_rc}).")
+endif()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,361 @@
+# GitHub Actions CI for VXL with CDash submission.
+#
+# Coverage:
+#   * itk-core: Build only the libraries ITK vendors from VXL
+#     (vnl + testlib + their dependencies via VXL_BUILD_CORE_NUMERICS_ONLY=ON).
+#     Runs on ubuntu-24.04, macos-14, windows-2022.
+#   * full-modules: Ubuntu 24.04 only. Builds full core + every contrib
+#     module that compiles cleanly with VXL_BUILD_NONDEPRECATED_ONLY=ON
+#     using the system packages available in the GitHub Actions runner
+#     image. Optional dependencies that need rare libraries (DCMTK,
+#     FFmpeg, Qt/VGUI, OpenCL) are intentionally left off.
+#
+# Output minimization (modeled on ITK's arm.yml):
+#   * ctest -S drives configure/build/test/submit; per-target output stays
+#     in Build.xml / Test.xml and is consumed by CDash, not echoed to the
+#     job log.
+#   * report_build_diagnostics.py extracts warning/error text from Build.xml
+#     after the run so that diagnostics appear inline in the GitHub log
+#     without dumping every -DCMAKE_VERBOSE_MAKEFILE line.
+#   * ccache is restored from a cross-run cache to avoid full rebuilds.
+#   * paths-ignore skips the workflow on docs-only changes.
+#
+# Submissions go to https://open.cdash.org/index.php?project=vxl
+# (matches CTestConfig.cmake at the repo root).
+#
+# Workflow injection hardening: any GitHub-derived metadata
+# (ref_name, sha, PR number, head_ref) is exposed to scripts only via
+# env: blocks, never interpolated directly into a `run:` body.
+
+name: VXL.Build
+
+on:
+  push:
+    branches:
+      - master
+      - 'release*'
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - 'scripts/**'
+      - '.circleci/**'
+      - '.travis.yml'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - 'scripts/**'
+      - '.circleci/**'
+      - '.travis.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  CMAKE_VERSION: "3.30.5"
+
+jobs:
+
+  itk-core:
+    name: itk-core (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            name: Ubuntu-24.04
+            generator: Ninja
+            parallel-level: 4
+            shell: bash
+          - os: macos-14
+            name: macOS-14
+            generator: Ninja
+            parallel-level: 3
+            shell: bash
+          - os: windows-2022
+            name: Windows-2022
+            generator: Ninja
+            parallel-level: 4
+            shell: bash
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 5
+          clean: true
+
+      - name: Install ccache (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y ccache ninja-build python3-defusedxml
+          else
+            brew install ccache ninja
+            python3 -m pip install --upgrade defusedxml
+          fi
+          echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+          echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
+          echo "CCACHE_NOHASHDIR=true" >> "$GITHUB_ENV"
+          echo "CCACHE_SLOPPINESS=pch_defines,time_macros" >> "$GITHUB_ENV"
+          echo "CCACHE_DIR=${RUNNER_TEMP}/ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=2G" >> "$GITHUB_ENV"
+
+      - name: Install build deps (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y --no-progress ccache ninja
+          python -m pip install --upgrade defusedxml
+          echo "CCACHE_DIR=${RUNNER_TEMP}/ccache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=2G" >> $GITHUB_ENV
+
+      - name: Set up MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-itk-core-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-itk-core-${{ matrix.name }}-
+
+      - name: Reset ccache stats
+        run: ccache --zero-stats
+
+      - name: Get CMake / Ninja
+        uses: lukka/get-cmake@v4.0.1
+        with:
+          cmakeVersion: ~${{ env.CMAKE_VERSION }}
+          ninjaVersion: latest
+
+      - name: Configure dashboard env
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_PARALLEL_LEVEL: ${{ matrix.parallel-level }}
+          GH_SHA: ${{ github.sha }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GH_SHA:0:7}"
+          if [ "$GH_EVENT_NAME" = "pull_request" ]; then
+            REF_LABEL="PR-${GH_PR_NUMBER}"
+          else
+            # ref_name is GitHub-validated; sanitize defensively to [A-Za-z0-9._-].
+            REF_LABEL=$(printf '%s' "$GH_REF_NAME" | tr -c 'A-Za-z0-9._-' '_')
+          fi
+          BUILD_NAME="itk-core_${MATRIX_NAME}_${REF_LABEL}_${SHORT_SHA}"
+          if [ "$GH_EVENT_NAME" = "push" ] && [ "$GH_REF_NAME" = "master" ]; then
+            DASHBOARD_MODEL="Continuous"
+          else
+            DASHBOARD_MODEL="Experimental"
+          fi
+          {
+            echo "CTEST_SOURCE_DIRECTORY=${GITHUB_WORKSPACE}"
+            echo "CTEST_BINARY_DIRECTORY=${GITHUB_WORKSPACE}/build"
+            echo "CTEST_BUILD_NAME=${BUILD_NAME}"
+            echo "CTEST_SITE=github-actions"
+            echo "DASHBOARD_MODEL=${DASHBOARD_MODEL}"
+            echo "CTEST_PARALLEL_LEVEL=${MATRIX_PARALLEL_LEVEL}"
+          } >> "$GITHUB_ENV"
+          mkdir -p "${GITHUB_WORKSPACE}/build"
+
+      - name: Configure dashboard cache (itk-core)
+        run: |
+          # VXL_BUILD_CORE_NUMERICS_ONLY=ON disables every core component
+          # except numerics — this matches what ITK vendors under
+          # Modules/ThirdParty/VNL/src/vxl/.
+          {
+            echo 'DASHBOARD_CACHE<<DC_EOF'
+            echo 'CMAKE_BUILD_TYPE:STRING=Release'
+            echo 'CMAKE_C_STANDARD:STRING=11'
+            echo 'CMAKE_CXX_STANDARD:STRING=17'
+            echo 'CMAKE_C_COMPILER_LAUNCHER:STRING=ccache'
+            echo 'CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache'
+            echo 'BUILD_TESTING:BOOL=ON'
+            echo 'BUILD_SHARED_LIBS:BOOL=OFF'
+            echo 'VXL_BUILD_CORE_NUMERICS_ONLY:BOOL=ON'
+            echo 'VXL_BUILD_CONTRIB:BOOL=OFF'
+            echo 'VXL_BUILD_VGUI:BOOL=OFF'
+            echo 'VXL_BUILD_CORE_VIDEO:BOOL=OFF'
+            echo 'VXL_BUILD_NONDEPRECATED_ONLY:BOOL=ON'
+            echo 'VXL_BUILD_EXAMPLES:BOOL=OFF'
+            echo 'DC_EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Build, test, and submit to CDash
+        run: |
+          ctest -S "${GITHUB_WORKSPACE}/.github/dashboard/vxl_github_dashboard.cmake" -V
+
+      - name: Report build diagnostics
+        if: always()
+        run: |
+          python3 "${GITHUB_WORKSPACE}/.github/dashboard/report_build_diagnostics.py" "${GITHUB_WORKSPACE}/build" || true
+
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats || true
+
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-itk-core-${{ matrix.name }}-${{ github.sha }}
+
+  full-modules:
+    name: full-modules (Ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    needs: itk-core
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 5
+          clean: true
+
+      - name: Install build & contrib system deps
+        run: |
+          # Packages chosen for breadth: every external library that any
+          # non-deprecated VXL contrib module can use, where the package
+          # exists in the noble (24.04) main/universe repos.
+          # DCMTK, FFmpeg, Qt/VGUI, OpenCL are intentionally NOT installed
+          # because they pull in either deprecated paths or large
+          # additional toolchains. Re-evaluate if those modules are
+          # needed downstream.
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            ccache ninja-build python3-defusedxml \
+            libtiff-dev libgeotiff-dev libpng-dev libjpeg-turbo8-dev \
+            libexpat1-dev zlib1g-dev libbz2-dev \
+            libxml2-dev libxslt1-dev \
+            libopenjp2-7-dev \
+            liblapack-dev libblas-dev \
+            libtbb-dev
+          {
+            echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}"
+            echo "CCACHE_COMPILERCHECK=content"
+            echo "CCACHE_NOHASHDIR=true"
+            echo "CCACHE_SLOPPINESS=pch_defines,time_macros"
+            echo "CCACHE_DIR=${RUNNER_TEMP}/ccache"
+            echo "CCACHE_MAXSIZE=4G"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-full-modules-${{ github.sha }}
+          restore-keys: |
+            ccache-full-modules-
+
+      - name: Reset ccache stats
+        run: ccache --zero-stats
+
+      - name: Get CMake / Ninja
+        uses: lukka/get-cmake@v4.0.1
+        with:
+          cmakeVersion: ~${{ env.CMAKE_VERSION }}
+          ninjaVersion: latest
+
+      - name: Configure dashboard env
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GH_SHA:0:7}"
+          if [ "$GH_EVENT_NAME" = "pull_request" ]; then
+            REF_LABEL="PR-${GH_PR_NUMBER}"
+          else
+            REF_LABEL=$(printf '%s' "$GH_REF_NAME" | tr -c 'A-Za-z0-9._-' '_')
+          fi
+          BUILD_NAME="full-modules_Ubuntu-24.04_${REF_LABEL}_${SHORT_SHA}"
+          if [ "$GH_EVENT_NAME" = "push" ] && [ "$GH_REF_NAME" = "master" ]; then
+            DASHBOARD_MODEL="Continuous"
+          else
+            DASHBOARD_MODEL="Experimental"
+          fi
+          {
+            echo "CTEST_SOURCE_DIRECTORY=${GITHUB_WORKSPACE}"
+            echo "CTEST_BINARY_DIRECTORY=${GITHUB_WORKSPACE}/build"
+            echo "CTEST_BUILD_NAME=${BUILD_NAME}"
+            echo "CTEST_SITE=github-actions"
+            echo "DASHBOARD_MODEL=${DASHBOARD_MODEL}"
+            echo "CTEST_PARALLEL_LEVEL=4"
+          } >> "$GITHUB_ENV"
+          mkdir -p "${GITHUB_WORKSPACE}/build"
+
+      - name: Configure dashboard cache (full-modules)
+        run: |
+          # Full core + every contrib module that VXL_BUILD_NONDEPRECATED_ONLY
+          # leaves enabled. We do NOT enable: VGUI (Qt/X11 headache),
+          # CORE_VIDEO (FFmpeg API drift, see vxl/vxl#515), DCMTK module,
+          # OpenCL. Adjust here when more system packages become reliable.
+          {
+            echo 'DASHBOARD_CACHE<<DC_EOF'
+            echo 'CMAKE_BUILD_TYPE:STRING=Release'
+            echo 'CMAKE_C_STANDARD:STRING=11'
+            echo 'CMAKE_CXX_STANDARD:STRING=17'
+            echo 'CMAKE_C_COMPILER_LAUNCHER:STRING=ccache'
+            echo 'CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache'
+            echo 'BUILD_TESTING:BOOL=ON'
+            echo 'BUILD_SHARED_LIBS:BOOL=OFF'
+            echo 'VXL_BUILD_CORE_NUMERICS_ONLY:BOOL=OFF'
+            echo 'VXL_BUILD_CORE_NUMERICS:BOOL=ON'
+            echo 'VXL_BUILD_CORE_GEOMETRY:BOOL=ON'
+            echo 'VXL_BUILD_CORE_IMAGING:BOOL=ON'
+            echo 'VXL_BUILD_CORE_PROBABILITY:BOOL=ON'
+            echo 'VXL_BUILD_CORE_SERIALISATION:BOOL=ON'
+            echo 'VXL_BUILD_CORE_UTILITIES:BOOL=ON'
+            echo 'VXL_BUILD_CORE_VIDEO:BOOL=OFF'
+            echo 'VXL_BUILD_CONTRIB:BOOL=ON'
+            echo 'VXL_BUILD_VGUI:BOOL=OFF'
+            echo 'VXL_BUILD_DCMTK:BOOL=OFF'
+            echo 'VXL_BUILD_NONDEPRECATED_ONLY:BOOL=ON'
+            echo 'VXL_BUILD_EXAMPLES:BOOL=ON'
+            echo 'VXL_USE_GEOTIFF:BOOL=ON'
+            echo 'DC_EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Build, test, and submit to CDash
+        run: |
+          ctest -S "${GITHUB_WORKSPACE}/.github/dashboard/vxl_github_dashboard.cmake" -V
+
+      - name: Report build diagnostics
+        if: always()
+        run: |
+          python3 "${GITHUB_WORKSPACE}/.github/dashboard/report_build_diagnostics.py" "${GITHUB_WORKSPACE}/build" || true
+
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats || true
+
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-full-modules-${{ github.sha }}


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that builds VXL on Linux/macOS/Windows and submits to https://open.cdash.org/index.php?project=vxl. Patterned after ITK's `arm.yml` for output minimization and ccache reuse.

<details>
<summary>Job matrix</summary>

| Job | Runner | Configuration | Why |
|---|---|---|---|
| `itk-core` | `ubuntu-24.04` | `VXL_BUILD_CORE_NUMERICS_ONLY=ON` | Mirrors what ITK actually vendors (`Modules/ThirdParty/VNL/src/vxl/`). Catches breakage of the ITK snapshot at PR time. |
| `itk-core` | `macos-14` | same | Same, on Apple Silicon. |
| `itk-core` | `windows-2022` | same, MSVC + Ninja | Same, on Windows. |
| `full-modules` | `ubuntu-24.04` | full core + every non-deprecated contrib that compiles against ubuntu-noble system packages | Broadest coverage on the cheapest runner. |

`full-modules` installs TIFF, GeoTIFF, PNG, JPEG, OpenJPEG2, Expat, zlib, bzip2, libxml2/xslt, LAPACK/BLAS, TBB. VGUI / CORE_VIDEO / DCMTK / OpenCL stay off — those require deprecated paths or large additional toolchains (see e.g. #515 for FFmpeg drift).
</details>

<details>
<summary>Output minimization (learned from ITK arm.yml)</summary>

- `ctest -S` drives configure → build → test → submit. Per-target compile output stays in `Build.xml` / `Test.xml`; the GitHub log only sees ctest summary lines.
- `.github/dashboard/report_build_diagnostics.py` parses `Build.xml` at the end of each run and prints any warnings/errors inline. Uses `defusedxml` for XXE-safe parsing per the secure-defaults guidance.
- ccache (2 GB itk-core / 4 GB full-modules) is restored across runs, so reruns and PR pushes don't pay full rebuild cost.
- `paths-ignore` skips the workflow on docs-only changes; the concurrency group cancels stale PR runs.
</details>

<details>
<summary>Workflow-injection hardening</summary>

All GitHub-derived metadata (`ref_name`, `sha`, PR number, `head_ref`) is exposed to scripts only via `env:` blocks and is sanitized to `[A-Za-z0-9._-]` before being interpolated into shell strings or CDash build names. No `${{ github.event.* }}` is expanded directly inside a `run:` body — see https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/ for the threat model.
</details>

<details>
<summary>CDash submission groups</summary>

| Trigger | Group |
|---|---|
| `push` to `master` | `Continuous` |
| `pull_request` | `Experimental` |
| `workflow_dispatch` | `Experimental` |

Build name format: `<job>_<platform>_<ref-or-PR>_<sha7>`, e.g. `itk-core_Ubuntu-24.04_PR-1042_a1b2c3d`. The CDash project (`vxl`) and drop site (`open.cdash.org`) come from the existing `CTestConfig.cmake` at the repo root, so no CDash-side configuration changes are required.
</details>

<details>
<summary>Files added</summary>

- `.github/workflows/ci.yml` — workflow (named `ci.yml` rather than `build.yml` because the repo's top-level `.gitignore` excludes `build*`)
- `.github/dashboard/vxl_github_dashboard.cmake` — `ctest -S` driver
- `.github/dashboard/report_build_diagnostics.py` — Build.xml summarizer
</details>

<!--
provenance: claude-code session 2026-04-27
key_facts:
  - CDash drop: open.cdash.org project=vxl (from CTestConfig.cmake, unchanged)
  - itk-core covers vnl/testlib/v3p/vcl on linux/mac/win
  - full-modules covers core + non-deprecated contrib on ubuntu-24.04
  - Inspired by InsightSoftwareConsortium/ITK .github/workflows/arm.yml
  - Workflow-file renamed to ci.yml to dodge the .gitignore "build*" rule
post_merge_action: confirm first run on master populates the CDash dashboard correctly; tune system-package list and contrib flags if specific modules fail
-->