### PR TITLE
ENH: Deprecate vnl_random::lrand32 overloads (#976)

### DIFF
--- a/core/vnl/vnl_random.cxx
+++ b/core/vnl/vnl_random.cxx
@@ -9,6 +9,22 @@
 #include "vnl_random.h"
 #include <cassert>
 
+// next_uint32/next_int32 deliberately delegate to lrand32* to preserve
+// bitwise backward compatibility — the produced sequence is identical
+// for a given seed; only the public return type is corrected to fixed
+// width. A future refactor onto C++11 <random> would change the
+// sequence and is intentionally out of scope (separate effort).
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#endif
+
 unsigned long
 vnl_random::linear_congruential_lrand32()
 {
@@ -253,3 +269,11 @@ vnl_random::drand64(double lower, double upper)
            (upper - lower) +
          lower;
 }
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif

--- a/core/vnl/vnl_random.h
+++ b/core/vnl/vnl_random.h
@@ -5,6 +5,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cstdint>
+#include "vcl_compiler.h"
 #include "vnl/vnl_export.h"
 
 //:
@@ -100,25 +101,22 @@ public:
   restart();
 
   //: Generates a random unsigned 32-bit value in [0, 2^32 - 1].
-  // \note The return type is \c unsigned \c long for historical
-  //       (ABI-stable) reasons. The produced value is always masked
-  //       to 32 bits, so it fits in a \c uint32_t on every platform
-  //       even when \c unsigned \c long is 64 bits wide (LP64).
+  // \deprecated Use next_uint32() — fixed-width return type (issue #976).
+  VXL_DEPRECATED_MSG("Use next_uint32() - see vxl issue #976")
   unsigned long
   lrand32();
 
   //: Generates a random signed integer in the inclusive range [a, b].
+  // \deprecated Use next_int32(a, b) — fixed-width return type (issue #976).
   // \pre \c a \c <= \c b
-  // \note Despite sharing the name \c lrand32, this overload returns
-  //       a signed \c int rather than the 32-bit unsigned value
-  //       produced by the no-argument \c lrand32(). The naming is
-  //       preserved for ABI stability; new code preferring strongly
-  //       typed RNG output should use \c <random> directly.
+  VXL_DEPRECATED_MSG("Use next_int32(a, b) - see vxl issue #976")
   int
   lrand32(int a, int b);
 
   //: Generates a random signed integer in the inclusive range [0, b].
+  // \deprecated Use next_int32(b) — fixed-width return type (issue #976).
   // \pre \c 0 \c <= \c b
+  VXL_DEPRECATED_MSG("Use next_int32(b) - see vxl issue #976")
   int
   lrand32(int b)
   {
@@ -126,8 +124,10 @@ public:
   }
 
   //: Generates a random signed integer in [a, b]; \c count returns
-  //  the number of underlying \c lrand32() draws taken (rejection
-  //  sampling is used to avoid modulo bias).
+  //  the number of underlying draws taken (rejection sampling).
+  // \deprecated No fixed-width replacement; use std::uniform_int_distribution
+  //             over next_uint32() if a draw count is needed.
+  VXL_DEPRECATED_MSG("No direct replacement; use std::uniform_int_distribution over next_uint32()")
   int
   lrand32(int a, int b, int &);
 
@@ -169,7 +169,7 @@ public:
   unsigned long
   operator()(unsigned n)
   {
-    return lrand32(0, static_cast<int>(n) - 1);
+    return static_cast<unsigned long>(next_int32(static_cast<std::int32_t>(n) - 1));
   }
 
   //:  Generates a random double in the range 0 <= x <= b with 32 bit randomness.


### PR DESCRIPTION
Mark `vnl_random::lrand32` overloads with `VXL_DEPRECATED_MSG` pointing at the fixed-width-typed replacements `next_uint32()` / `next_int32()` from #976 (commit f976cbbe7f). Bitwise sequence behavior is preserved — only return types change.

<details>
<summary>Changes</summary>

**`core/vnl/vnl_random.h`**
- Added `VXL_DEPRECATED_MSG(...)` to all four `lrand32` overloads (no-arg, `(int,int)`, `(int)`, `(int,int,int&)`).
- Added `#include "vcl_compiler.h"` for the macro.
- Rerouted `operator()(unsigned n)` to delegate to `next_int32` so the header doesn't self-warn when included.

**`core/vnl/vnl_random.cxx`**
- Added `#pragma diagnostic push/pop` blocks (clang/GCC/MSVC) around the entire TU to suppress `-Wdeprecated-declarations` for the intentional internal delegations from `next_uint32`, `next_int32`, `drand32`, `drand64`, and `reseed`'s warm-up loop.
- Added a comment explaining that the delegation preserves bitwise backward compatibility for a given seed, and that a future `<random>`-based refactor (which would change the produced sequence) is intentionally out of scope.

</details>

<details>
<summary>Local verification</summary>

- Full vxl build: 125/125 targets, 0 warnings, 0 errors
- vnl test suite: 91/91 passing
- pre-commit: clean
- External-caller test (`-Wdeprecated-declarations`): 3 deprecation warnings fire on `lrand32` calls; `next_uint32` / `next_int32` are warning-free
- Each warning's message correctly points at its replacement and cites issue #976

</details>

<details>
<summary>Staged deprecation plan (per .devlocal/hints/itk-migrate-off-lrand32.md)</summary>

1. ✅ Doc-comment fix (PR #1026)
2. ✅ Add fixed-width replacement API (commit f976cbbe7f)
3. ⏳ Migrate ITK off `lrand32` (in flight)
4. ⏳ **This PR** — apply deprecation in vxl
5. (future) Wrap with `#if !VXL_LEGACY_FUTURE_REMOVE` for full removal in future-only builds

</details>

<!--
provenance: claude-code session 2026-04-29
related_files: core/vnl/vnl_random.h, core/vnl/vnl_random.cxx
gating_pr: ITK migration PR (in flight) — must merge before this PR
post_merge_action: open follow-up PR wrapping deprecated overloads in #if !VXL_LEGACY_FUTURE_REMOVE once downstreams have absorbed the deprecation warning cycle
issue_ref: vxl issue #976
-->