### PR TITLE
STYLE: Replace C-array members and signatures in vnl_random with std::array

### DIFF
--- a/core/vnl/vnl_random.cxx
+++ b/core/vnl/vnl_random.cxx
@@ -2,10 +2,9 @@
 //:
 //  \file
 
+#include <algorithm>
 #include <cmath>
-
 #include <ctime>
-#include <cmath>
 #include "vnl_random.h"
 #include <cassert>
 
@@ -41,33 +40,36 @@ vnl_random::vnl_random(unsigned long seed)
 }
 
 //: Construct with seed
-vnl_random::vnl_random(unsigned long seed[vnl_random_array_size]) { reseed(seed); }
+vnl_random::vnl_random(const std::array<unsigned long, vnl_random_array_size> & seed) { reseed(seed); }
+
+// Deprecated C-array seed constructor (VXL_DEPRECATED_MSG in header):
+// copies into std::array and forwards to the std::array overload.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+vnl_random::vnl_random(const unsigned long seed[vnl_random_array_size])
+{
+  std::array<unsigned long, vnl_random_array_size> tmp{};
+  std::copy_n(seed, vnl_random_array_size, tmp.begin());
+  reseed(tmp);
+}
 
 vnl_random::vnl_random(const vnl_random & r)
   : linear_congruential_previous(r.linear_congruential_previous)
+  , mz_seed_array(r.mz_seed_array)
+  , mz_array(r.mz_array)
   , mz_array_position(r.mz_array_position)
   , mz_borrow(r.mz_borrow)
   , mz_previous_normal_flag(r.mz_previous_normal_flag)
-{
-  for (unsigned int i = 0; i < vnl_random_array_size; ++i)
-  {
-    mz_seed_array[i] = r.mz_seed_array[i];
-    mz_array[i] = r.mz_array[i];
-  }
-}
+{}
 
 vnl_random &
 vnl_random::operator=(const vnl_random & r)
 {
   linear_congruential_previous = r.linear_congruential_previous;
+  mz_seed_array = r.mz_seed_array;
+  mz_array = r.mz_array;
   mz_array_position = r.mz_array_position;
   mz_borrow = r.mz_borrow;
   mz_previous_normal_flag = r.mz_previous_normal_flag;
-  for (unsigned int i = 0; i < vnl_random_array_size; ++i)
-  {
-    mz_seed_array[i] = r.mz_seed_array[i];
-    mz_array[i] = r.mz_array[i];
-  }
   return *this;
 }
 
@@ -75,11 +77,8 @@ vnl_random::vnl_random() { reseed(); }
 
 vnl_random::~vnl_random()
 {
-  for (unsigned int i = 0; i < vnl_random_array_size; ++i)
-  {
-    mz_seed_array[i] = 0;
-    mz_array[i] = 0;
-  }
+  mz_seed_array.fill(0);
+  mz_array.fill(0);
 }
 
 void
@@ -108,16 +107,23 @@ vnl_random::reseed(unsigned long seed)
 }
 
 void
-vnl_random::reseed(const unsigned long seed[vnl_random_array_size])
+vnl_random::reseed(const std::array<unsigned long, vnl_random_array_size> & seed)
 {
   mz_array_position = 0UL;
   mz_borrow = 0L;
+  mz_seed_array = seed;
+  mz_array = seed;
+}
 
-  for (unsigned int i = 0; i < vnl_random_array_size; ++i)
-  {
-    mz_array[i] = seed[i];
-    mz_seed_array[i] = seed[i];
-  }
+// Deprecated C-array reseed (VXL_DEPRECATED_MSG in header): copies into
+// std::array and forwards to the std::array overload.
+void
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+vnl_random::reseed(const unsigned long seed[vnl_random_array_size])
+{
+  std::array<unsigned long, vnl_random_array_size> tmp{};
+  std::copy_n(seed, vnl_random_array_size, tmp.begin());
+  reseed(tmp);
 }
 
 void

--- a/core/vnl/vnl_random.cxx
+++ b/core/vnl/vnl_random.cxx
@@ -9,6 +9,22 @@
 #include "vnl_random.h"
 #include <cassert>
 
+// next_uint32/next_int32 deliberately delegate to lrand32* to preserve
+// bitwise backward compatibility — the produced sequence is identical
+// for a given seed; only the public return type is corrected to fixed
+// width. A future refactor onto C++11 <random> would change the
+// sequence and is intentionally out of scope (separate effort).
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#endif
+
 unsigned long
 vnl_random::linear_congruential_lrand32()
 {
@@ -253,3 +269,11 @@ vnl_random::drand64(double lower, double upper)
            (upper - lower) +
          lower;
 }
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif

--- a/core/vnl/vnl_random.h
+++ b/core/vnl/vnl_random.h
@@ -4,6 +4,7 @@
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
+#include <array>
 #include <cstdint>
 #include "vcl_compiler.h"
 #include "vnl/vnl_export.h"
@@ -32,8 +33,8 @@ class VNL_EXPORT vnl_random
     mz_previous1 = 24
   };
   unsigned long linear_congruential_previous;
-  unsigned long mz_seed_array[vnl_random_array_size];
-  unsigned long mz_array[vnl_random_array_size];
+  std::array<unsigned long, vnl_random_array_size> mz_seed_array{};
+  std::array<unsigned long, vnl_random_array_size> mz_array{};
   unsigned int mz_array_position{ 0UL };
   int mz_borrow{ 0 };
   unsigned long
@@ -66,7 +67,12 @@ public:
   //  Initializes the random number generator deterministically
   //  using 37 ulongs as the 'seed'. The same seed will
   //  produce the same series of random numbers.
-  vnl_random(unsigned long seed[vnl_random_array_size]);
+  vnl_random(const std::array<unsigned long, vnl_random_array_size> & seed);
+
+  //: Construct with C-array seed (deprecated; use std::array overload).
+  VXL_DEPRECATED_MSG("Pass std::array<unsigned long, vnl_random_array_size> instead")
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  vnl_random(const unsigned long seed[vnl_random_array_size]);
 
   //: Copy constructor.
   //  Initializes/sets the random number generator to exactly
@@ -91,7 +97,13 @@ public:
 
   //: Starts a new deterministic sequence from an already declared generator using the provided seed.
   void
-  reseed(const unsigned long[vnl_random_array_size]);
+  reseed(const std::array<unsigned long, vnl_random_array_size> & seed);
+
+  //: Reseed from C-array (deprecated; use std::array overload).
+  VXL_DEPRECATED_MSG("Pass std::array<unsigned long, vnl_random_array_size> instead")
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  void
+  reseed(const unsigned long seed[vnl_random_array_size]);
 
   //: This restarts the sequence of random numbers.
   //  Restarts so that it repeats

--- a/core/vnl/vnl_random.h
+++ b/core/vnl/vnl_random.h
@@ -5,6 +5,7 @@
 #  include <vcl_msvc_warnings.h>
 #endif
 #include <cstdint>
+#include "vcl_compiler.h"
 #include "vnl/vnl_export.h"
 
 //:
@@ -100,25 +101,22 @@ public:
   restart();
 
   //: Generates a random unsigned 32-bit value in [0, 2^32 - 1].
-  // \note The return type is \c unsigned \c long for historical
-  //       (ABI-stable) reasons. The produced value is always masked
-  //       to 32 bits, so it fits in a \c uint32_t on every platform
-  //       even when \c unsigned \c long is 64 bits wide (LP64).
+  // \deprecated Use next_uint32() — fixed-width return type (issue #976).
+  VXL_DEPRECATED_MSG("Use next_uint32() - see vxl issue #976")
   unsigned long
   lrand32();
 
   //: Generates a random signed integer in the inclusive range [a, b].
+  // \deprecated Use next_int32(a, b) — fixed-width return type (issue #976).
   // \pre \c a \c <= \c b
-  // \note Despite sharing the name \c lrand32, this overload returns
-  //       a signed \c int rather than the 32-bit unsigned value
-  //       produced by the no-argument \c lrand32(). The naming is
-  //       preserved for ABI stability; new code preferring strongly
-  //       typed RNG output should use \c <random> directly.
+  VXL_DEPRECATED_MSG("Use next_int32(a, b) - see vxl issue #976")
   int
   lrand32(int a, int b);
 
   //: Generates a random signed integer in the inclusive range [0, b].
+  // \deprecated Use next_int32(b) — fixed-width return type (issue #976).
   // \pre \c 0 \c <= \c b
+  VXL_DEPRECATED_MSG("Use next_int32(b) - see vxl issue #976")
   int
   lrand32(int b)
   {
@@ -126,8 +124,10 @@ public:
   }
 
   //: Generates a random signed integer in [a, b]; \c count returns
-  //  the number of underlying \c lrand32() draws taken (rejection
-  //  sampling is used to avoid modulo bias).
+  //  the number of underlying draws taken (rejection sampling).
+  // \deprecated No fixed-width replacement; use std::uniform_int_distribution
+  //             over next_uint32() if a draw count is needed.
+  VXL_DEPRECATED_MSG("No direct replacement; use std::uniform_int_distribution over next_uint32()")
   int
   lrand32(int a, int b, int &);
 
@@ -169,7 +169,7 @@ public:
   unsigned long
   operator()(unsigned n)
   {
-    return lrand32(0, static_cast<int>(n) - 1);
+    return static_cast<unsigned long>(next_int32(static_cast<std::int32_t>(n) - 1));
   }
 
   //:  Generates a random double in the range 0 <= x <= b with 32 bit randomness.


### PR DESCRIPTION
Replace C-array members (`mz_seed_array`, `mz_array`) and array-form constructor / `reseed` signatures in `vnl_random` with `std::array<unsigned long, vnl_random_array_size>`. Clears all four `modernize-avoid-c-arrays` diagnostics on `vnl_random.h` while preserving the public API via deprecated C-array shim overloads.

> [!IMPORTANT]
> **Stacked on #1029.** This PR contains the deprecation work from #1029 plus this branch's `STYLE:` commit. Review only the top commit; once #1029 merges, GitHub will reduce this PR to a single-commit diff. Do not merge this before #1029.

<details>
<summary>Changes (top commit only)</summary>

- `mz_seed_array` and `mz_array` → `std::array<unsigned long, vnl_random_array_size>` with `{}` default-initialization (replaces "uninitialized + cleared in destructor" pattern).
- `vnl_random(unsigned long[37])` → `vnl_random(const std::array<unsigned long, 37> &)`.
- `reseed(const unsigned long[37])` → `reseed(const std::array<unsigned long, 37> &)`.
- Copy ctor / `operator=` / destructor: replaced manual element-by-element loops with whole-object `std::array` operations (`= seed`, `.fill(0)`).
- Added deprecated C-array overloads (constructor + `reseed`) annotated with `VXL_DEPRECATED_MSG` that copy the input into a `std::array` and forward, preserving ABI/source compatibility for any external caller passing a raw C array.

</details>

<details>
<summary>Local verification</summary>

- Full vxl build: 127/127 targets, 0 warnings, 0 errors
- vnl test suite: 91/91 passing (includes `test_random` sequence regression)
- pre-commit: clean
- Backwards-compat external-caller test: C-array form fires `Pass std::array<...> instead` deprecation warning; `std::array` form is warning-free
- All four `modernize-avoid-c-arrays` diagnostics on `vnl_random.h` cleared

</details>

<details>
<summary>API/ABI impact</summary>

- **Zero in-tree callers** (vxl + contrib) use the array-form constructor or array-form `reseed`. All `reseed()` callsites in the project pass a scalar `unsigned long`.
- **External callers** passing a raw C array still compile via the deprecated shim, with a deprecation warning suggesting the std::array form. Migration is a one-line wrap.
- **Type-level enforcement upgrade:** the std::array overload requires exactly 37 elements at compile time, which the original `unsigned long[37]` signature could not enforce (it silently decayed to `unsigned long *`).

</details>

<!--
provenance: claude-code session 2026-04-29
related_files: core/vnl/vnl_random.h, core/vnl/vnl_random.cxx
stacked_on: PR #1029 (hjmjohnson:deprecate-vnl-random-lrand32)
post_merge_action: after #1029 merges and master is rebased here, this becomes a single-commit STYLE PR; ITK migration PR is independent of this one (this PR doesn't touch lrand32)
-->