### PR TITLE
COMP: Fix macOS-14 CI failure from PEP-668 pip install block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,9 @@ jobs:
             sudo apt-get install -y ccache ninja-build python3-defusedxml
           else
             brew install ccache ninja
-            python3 -m pip install --upgrade defusedxml
+            # macOS runner Python is PEP-668 "externally-managed"; CI runners are
+            # ephemeral so --break-system-packages is the documented escape hatch.
+            python3 -m pip install --upgrade --break-system-packages defusedxml
           fi
           echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
           echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"


### PR DESCRIPTION
The macOS-14 leg of `VXL.Build` fails on every PR with `error: externally-managed-environment` before any vxl source is configured (observed on #1029, blocks all macOS CI feedback). Fixed by adding `--break-system-packages` to the macOS `python3 -m pip install` invocation.

<details>
<summary>Root cause</summary>

GitHub's macOS-14 runner ships a Python install marked [PEP-668](https://peps.python.org/pep-0668/) "externally-managed". The current ccache-install step at `.github/workflows/ci.yml:108` runs:

```bash
python3 -m pip install --upgrade defusedxml
```

unqualified, which pip refuses with:

```
error: externally-managed-environment
× This environment is externally managed
```

CI runners are ephemeral, so the "break the system Python" warning that PEP-668 is guarding against does not apply — the entire VM is destroyed at job end. `--break-system-packages` is the [documented pip escape hatch](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-break-system-packages) for exactly this case.

</details>

<details>
<summary>Why the other legs were unaffected</summary>

- **Linux:** uses `sudo apt-get install -y python3-defusedxml` — system package, no pip invocation.
- **Windows:** the Chocolatey/GitHub Actions Windows Python install does not carry an `EXTERNALLY-MANAGED` marker file, so pip installs into site-packages without complaint.

</details>

<details>
<summary>Failed run reference</summary>

PR #1029 macOS-14 build: https://github.com/vxl/vxl/actions/runs/25113428707/job/73593595101
- Step "Install ccache (Linux/macOS)" exits 1 at `python3 -m pip install` line.

</details>

<!--
provenance: claude-code session 2026-04-29
related_files: .github/workflows/ci.yml:108
unblocks_pr: #1029, #1030, and any future PR that hits the macOS-14 leg
-->