### PR TITLE
COMP: Silence -Wstringop-overflow in vnl_vector_fixed::update

### DIFF
--- a/core/vnl/vnl_vector_fixed.hxx
+++ b/core/vnl/vnl_vector_fixed.hxx
@@ -87,10 +87,13 @@ template <class T, unsigned int n>
 vnl_vector_fixed<T, n> &
 vnl_vector_fixed<T, n>::update(const vnl_vector<T> & v, unsigned int start)
 {
-  const size_type stop = start + v.size();
-  assert(stop <= n);
-  for (size_type i = start; i < stop; i++)
-    this->data_[i] = v[i - start];
+  assert(start + v.size() <= n);
+  // Copy at most (n - start) elements so the optimizer can prove the
+  // write never exceeds data_[n-1]; this both silences GCC
+  // -Wstringop-overflow on small-N specializations and turns the
+  // would-be NDEBUG overrun into a defensive truncation.
+  const size_type count = std::min(v.size(), static_cast<size_type>(n - start));
+  std::copy_n(v.begin(), count, this->data_ + start);
   return *this;
 }
 


### PR DESCRIPTION
Fix the 18 GCC `-Wstringop-overflow` warnings on `core/vnl/vnl_vector_fixed.hxx:93` that fire on every dashboard build for the `vnl_vector_fixed<unsigned char, 2..10>` instantiations. Precondition for #1032 (which would otherwise turn the Ubuntu-24.04 GCC leg red on every PR).

<details>
<summary>Root cause</summary>

```cpp
template <class T, unsigned int n>
vnl_vector_fixed<T, n> &
vnl_vector_fixed<T, n>::update(const vnl_vector<T> & v, unsigned int start)
{
  const size_type stop = start + v.size();
  assert(stop <= n);                          // debug-only
  for (size_type i = start; i < stop; i++)
    this->data_[i] = v[i - start];            // line 93 — warning here
  return *this;
}
```

GCC's optimizer cannot see that `stop <= n` (the assert is a no-op in NDEBUG builds — which is what CI runs), so it warns that `data_[i]` could be written past the end of `data_`. For small `n` the static analyzer fully unrolls the loop and pinpoints concrete out-of-bounds offsets, producing one warning per template instantiation. For larger `n` the analyzer bails out and stays silent, but the same UB is technically possible.

</details>

<details>
<summary>Fix</summary>

Replace the explicit index loop with `std::copy_n` driven by an explicit `count = std::min(v.size(), n - start)` upper bound:

```cpp
assert(start + v.size() <= n);
const size_type count = std::min(v.size(), static_cast<size_type>(n - start));
std::copy_n(v.begin(), count, this->data_ + start);
```

This:

1. Makes the no-overflow property syntactically visible to GCC's static analyzer → warning disappears.
2. Provides a defensive runtime bound in NDEBUG builds where the existing `assert` is compiled out — a too-large input vector now silently truncates rather than overrunning `data_`.
3. Is at least as fast as the index loop at `-O2` because libstdc++ specializes `std::copy_n` to `memmove` for trivially-copyable T.

`<algorithm>` is already included on line 6 for the existing `std::swap` use on line 102.

</details>

<details>
<summary>Verification</summary>

- Local Apple-clang build: 91/91 vnl tests pass, no regressions
- Ubuntu-24.04 GCC leg of `VXL.Build` reports: `No build warnings or errors found.` (was 18 `-Wstringop-overflow` warnings on master)
- macOS-14 and Windows-2022 itk-core legs: green
- full-modules (Ubuntu-24.04): green
- CircleCI: green

</details>

<details>
<summary>Why this is a separate PR</summary>

#1032 flips the dashboard diagnostic gate to fail on warnings. Merging #1032 alone would turn the Ubuntu-24.04 GCC leg red on every PR (including #1029 and #1030) until these 18 warnings are silenced. Landing this PR first means #1032's gate flip is a non-event for green CI.

Recommended order: this PR → #1032 → ITK migration PR → #1029 → #1030.

</details>

<!--
provenance: claude-code session 2026-04-29
related_files: core/vnl/vnl_vector_fixed.hxx:93
unblocks_pr: #1032
verified_head: 80c4b3d4c4
-->