### PR TITLE
ENH: vil_nitf2_field_sequence::get_map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 6.2.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
+    VERSION 6.3.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vil/file_formats/vil_nitf2_field_sequence.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_sequence.cxx
@@ -33,6 +33,18 @@ vil_nitf2_field_sequence::insert_field(const std::string & str, vil_nitf2_field 
   fields_vector.push_back(field);
 }
 
+int
+vil_nitf2_field_sequence::array_field_dimension(const std::string & tag) const
+{
+  vil_nitf2_field * field = get_field(tag);
+  vil_nitf2_array_field * array_field = field ? field->array_field() : nullptr;
+  if (!array_field)
+  {
+    return -1;
+  }
+  return array_field->next_dimension(vil_nitf2_index_vector());
+}
+
 bool
 vil_nitf2_field_sequence::create_array_fields(const vil_nitf2_field_definitions * field_defs, int num_dimensions)
 {
@@ -642,3 +654,48 @@ NITF_FIELD_SEQ_GET_VALUE(vil_nitf2_long)
 NITF_FIELD_SEQ_GET_ARRAY_VALUE(vil_nitf2_long)
 NITF_FIELD_SEQ_GET_VALUES(vil_nitf2_long)
 #endif
+
+
+// Macro to generate overloads of get_map() for scalar and vector of type "T"
+// return true if output contains at least one entry
+#define NITF_FIELD_SEQ_GET_MAP(T)                                                                           \
+  bool vil_nitf2_field_sequence::get_map(std::string tag, std::map<size_t, T> & out_map) const              \
+  {                                                                                                         \
+    out_map.clear();                                                                                        \
+    int dimension = array_field_dimension(tag);                                                             \
+    if (dimension <= 0)                                                                                     \
+    {                                                                                                       \
+      return false;                                                                                         \
+    }                                                                                                       \
+    for (int i = 0; i < dimension; i++)                                                                     \
+    {                                                                                                       \
+      T scalar;                                                                                             \
+      bool good = get_value(tag, vil_nitf2_index_vector(i), scalar);                                        \
+      if (good)                                                                                             \
+        out_map[i] = scalar;                                                                                \
+    }                                                                                                       \
+    return !out_map.empty();                                                                                \
+  }                                                                                                         \
+                                                                                                            \
+  bool vil_nitf2_field_sequence::get_map(std::string tag, std::map<size_t, std::vector<T>> & out_map) const \
+  {                                                                                                         \
+    out_map.clear();                                                                                        \
+    int dimension = array_field_dimension(tag);                                                             \
+    if (dimension <= 0)                                                                                     \
+    {                                                                                                       \
+      return false;                                                                                         \
+    }                                                                                                       \
+    for (int i = 0; i < dimension; i++)                                                                     \
+    {                                                                                                       \
+      std::vector<T> vector;                                                                                \
+      bool good = get_values(tag, vil_nitf2_index_vector(i), vector);                                       \
+      if (good && !vector.empty())                                                                          \
+        out_map[i] = vector;                                                                                \
+    }                                                                                                       \
+    return !out_map.empty();                                                                                \
+  }
+
+NITF_FIELD_SEQ_GET_MAP(int)
+NITF_FIELD_SEQ_GET_MAP(double)
+NITF_FIELD_SEQ_GET_MAP(char)
+NITF_FIELD_SEQ_GET_MAP(std::string)

--- a/core/vil/file_formats/vil_nitf2_field_sequence.h
+++ b/core/vil/file_formats/vil_nitf2_field_sequence.h
@@ -180,6 +180,28 @@ public:
   get_values(std::string tag, std::vector<vil_nitf2_long> & out_values) const;
 #endif
 
+  // Sets out_map to a std::map of index/value for the selected tag.
+  // This is useful for conditional repeated fields that may not have a value
+  // at every index.
+  bool
+  get_map(std::string tag, std::map<size_t, int> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, double> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, char> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::string> & out_map) const;
+
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<int>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<double>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<char>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<std::string>> & out_map) const;
+
+
 #if 0  // Not yet implemented.
   // Sets the value of the integer-valued field specified by tag to value.
   bool set_value(std::string tag, int value) { return false; }
@@ -233,6 +255,10 @@ public:
 private:
   void
   insert_field(const std::string & str, vil_nitf2_field * field);
+
+  // primary dimension of array field
+  int
+  array_field_dimension(const std::string & tag) const;
 
   // Map of fields, indexed by field name
   typedef std::map<std::string, vil_nitf2_field *> field_map;

--- a/core/vil/file_formats/vil_nitf2_tagged_record.cxx
+++ b/core/vil/file_formats/vil_nitf2_tagged_record.cxx
@@ -278,6 +278,23 @@ VIL_NITF2_TAGGED_RECORD_GET_VALUES(vil_nitf2_date_time);
 VIL_NITF2_TAGGED_RECORD_GET_VALUES(vil_nitf2_long);
 #endif
 
+// Macro to define overloads of get_map()
+#define VIL_NITF2_TAGGED_RECORD_GET_MAP(T)                                                    \
+  bool vil_nitf2_tagged_record::get_map(std::string tag, std::map<size_t, T> & out_map) const \
+  {                                                                                           \
+    return m_field_sequence->get_map(tag, out_map);                                           \
+  }
+
+VIL_NITF2_TAGGED_RECORD_GET_MAP(int);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(double);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(char);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(std::string);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(std::vector<int>);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(std::vector<double>);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(std::vector<char>);
+VIL_NITF2_TAGGED_RECORD_GET_MAP(std::vector<std::string>);
+
+
 vil_nitf2_tagged_record::vil_nitf2_tagged_record()
 
   = default;

--- a/core/vil/file_formats/vil_nitf2_tagged_record.h
+++ b/core/vil/file_formats/vil_nitf2_tagged_record.h
@@ -310,6 +310,27 @@ public:
   get_values(std::string tag, std::vector<vil_nitf2_long> & out_values) const;
 #endif
 
+  // Sets out_map to a std::map of index/value for the selected tag.
+  // This is useful for conditional repeated fields that may not have a value
+  // at every index.
+  bool
+  get_map(std::string tag, std::map<size_t, int> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, double> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, char> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::string> & out_map) const;
+
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<int>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<double>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<char>> & out_map) const;
+  bool
+  get_map(std::string tag, std::map<size_t, std::vector<std::string>> & out_map) const;
+
   virtual vil_nitf2_field::field_tree *
   get_tree() const;
 

--- a/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.cxx
+++ b/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.cxx
@@ -1938,7 +1938,7 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
       }
 
       if (type == "RSMECB")
-      { // looking for "RSMDCB..."
+      { // looking for "RSMECB..."
         // =======================================
         const nitf_tre<std::string> nt("RSMECB", tre_str);
         // =========================================
@@ -2290,32 +2290,32 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
           nt42.get(tres_itr, n_opg);
         }
 
-
-        std::vector<std::string> errcvg_svals;
-        nitf_tre<std::string> nt43("ERRCVG", "vector", opt, false);
+        std::map<size_t, std::vector<std::string>> ERRCVG_str;
+        nitf_tre<std::string> nt43("ERRCVG", "map-vector", opt, false);
         nt43.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt43.get(tres_itr, errcvg_svals);
-          size_t idx = 0;
+          nt43.get(tres_itr, ERRCVG_str);
           for (size_t ig = 0; ig < n_indpb; ++ig)
           {
-            const size_t covar_dim = n_opg[ig];
+            const size_t covar_dim = n_opg.at(ig);
             vnl_matrix<double> cvar(covar_dim, covar_dim, 0.0);
+
+            size_t idx = 0;
             for (size_t r = 0; r < covar_dim; ++r)
+            {
               for (size_t c = r; c < covar_dim; ++c)
               {
-                double val = NAN;
-                ASC_double(errcvg_svals[idx], val);
+                double val = ASC_double(ERRCVG_str.at(ig).at(idx));
                 cvar[r][c] = val;
                 if (r != c)
                   cvar[c][r] = val;
                 idx++;
-              } // r,c
+              }
+            } // r,c
             apdata.independent_covar_[ig] = cvar;
           } // ig
         } // opt
-
 
         std::vector<int> domain_flags;
         nitf_tre<int> nt44("TCDF", "vector", opt, false);
@@ -2327,139 +2327,107 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
             apdata.correlation_domain_flags_[ig] = domain_flags[ig];
         }
 
-        std::vector<std::string> acsmc;
-        std::vector<bool> use_function;
+        std::vector<std::string> ACSMC;
         nitf_tre<std::string> nt45("ACSMC", "vector", opt, false);
         nt45.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt45.get(tres_itr, acsmc);
-          use_function.resize(n_indpb);
-          for (size_t ig = 0; ig < n_indpb; ++ig)
-            use_function[ig] = (acsmc[ig] == "Y");
+          nt45.get(tres_itr, ACSMC);
         }
 
-
-        std::vector<int> ncsegb;
-        nitf_tre<int> nt46("NCSEG", "vector", opt, false);
-        nt46.get_append(tres_itr, tre_str, v);
+        std::map<size_t, int> NCSEG;
+        nitf_tre<int> nt46("NCSEG", "map", opt, false);
+        nt46.get_append(tres_itr, tre_str, true);
         if (!opt)
         {
-          nt46.get(tres_itr, ncsegb);
+          nt46.get(tres_itr, NCSEG);
         }
 
-        std::vector<std::string> corsegs;
-        std::vector<double> corseg_vals;
-        nitf_tre<std::string> nt47("CORSEG", "vector", opt, false);
+        std::map<size_t, std::vector<std::string>> CORSEG_str;
+        std::map<size_t, std::vector<double>> CORSEG;
+        nitf_tre<std::string> nt47("CORSEG", "map-vector", opt, false);
         nt47.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt47.get(tres_itr, corsegs);
-          for (const auto & corseg : corsegs)
-          {
-            double val = NAN;
-            ASC_double(corseg, val);
-            corseg_vals.push_back(val);
-          }
+          nt47.get(tres_itr, CORSEG_str);
+          for (const auto & item : CORSEG_str)
+            CORSEG[item.first] = ASC_vector_double(item.second);
         }
 
-        std::vector<std::string> tausegs;
-        std::vector<double> tauseg_vals;
-        nitf_tre<std::string> nt48("TAUSEG", "vector", opt, false);
+        std::map<size_t, std::vector<std::string>> TAUSEG_str;
+        std::map<size_t, std::vector<double>> TAUSEG;
+        nitf_tre<std::string> nt48("TAUSEG", "map-vector", opt, false);
         nt48.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt48.get(tres_itr, tausegs);
-          for (const auto & tauseg : tausegs)
-          {
-            double val = NAN;
-            ASC_double(tauseg, val);
-            tauseg_vals.push_back(val);
-          }
+          nt48.get(tres_itr, TAUSEG_str);
+          for (const auto & item : TAUSEG_str)
+            TAUSEG[item.first] = ASC_vector_double(item.second);
         }
-        std::vector<std::string> Acs;
-        std::vector<double> Acoef_vals;
-        nitf_tre<std::string> nt49("AC", "vector", opt, false);
+
+        std::map<size_t, std::string> AC_str;
+        std::map<size_t, double> AC;
+        nitf_tre<std::string> nt49("AC", "map", opt, false);
         nt49.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt49.get(tres_itr, Acs);
-          for (const auto & Ac : Acs)
-          {
-            double val = NAN;
-            ASC_double(Ac, val);
-            Acoef_vals.push_back(val);
-          }
+          nt49.get(tres_itr, AC_str);
+          for (const auto & item : AC_str)
+            AC[item.first] = ASC_double(item.second);
         }
-        std::vector<std::string> alphs;
-        std::vector<double> alpha_vals;
-        nitf_tre<std::string> nt50("ALPC", "vector", opt, false);
+
+        std::map<size_t, std::string> ALPC_str;
+        std::map<size_t, double> ALPC;
+        nitf_tre<std::string> nt50("ALPC", "map", opt, false);
         nt50.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt50.get(tres_itr, alphs);
-          for (const auto & alph : alphs)
-          {
-            double val = NAN;
-            ASC_double(alph, val);
-            alpha_vals.push_back(val);
-          }
+          nt50.get(tres_itr, ALPC_str);
+          for (const auto & item : ALPC_str)
+            ALPC[item.first] = ASC_double(item.second);
         }
 
-        std::vector<std::string> bets;
-        std::vector<double> beta_vals;
-        nitf_tre<std::string> nt51("BETC", "vector", opt, false);
+        std::map<size_t, std::string> BETC_str;
+        std::map<size_t, double> BETC;
+        nitf_tre<std::string> nt51("BETC", "map", opt, false);
         nt51.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt51.get(tres_itr, bets);
-          for (const auto & bet : bets)
-          {
-            double val = NAN;
-            ASC_double(bet, val);
-            beta_vals.push_back(val);
-          }
+          nt51.get(tres_itr, BETC_str);
+          for (const auto & item : BETC_str)
+            BETC[item.first] = ASC_double(item.second);
         }
 
-        std::vector<std::string> Tcs;
-        std::vector<double> T_vals;
-        nitf_tre<std::string> nt52("TC", "vector", opt, false);
+        std::map<size_t, std::string> TC_str;
+        std::map<size_t, double> TC;
+        nitf_tre<std::string> nt52("TC", "map", opt, false);
         nt52.get_append(tres_itr, tre_str, v);
         if (!opt)
         {
-          nt52.get(tres_itr, Tcs);
-          for (const auto & Tc : Tcs)
-          {
-            double val = NAN;
-            ASC_double(Tc, val);
-            T_vals.push_back(val);
-          }
+          nt52.get(tres_itr, TC_str);
+          for (const auto & item : TC_str)
+            TC[item.first] = ASC_double(item.second);
         }
+
         // Encode time correlation functions for each independent group
         for (size_t ig = 0; ig < n_indpb; ++ig)
         {
-          // use functional form of time correlation
-          int func_idx = 0, piecewise_idx = 0;
-          if (use_function[ig])
+          // functional form of time correlation
+          int piecewise_idx = 0;
+          if (ACSMC[ig] == "Y")
           {
-            const double Ac = Acoef_vals[func_idx];
-            const double alpha = alpha_vals[func_idx];
-            const double beta = beta_vals[func_idx];
-            const double Tc = T_vals[func_idx];
-            const std::tuple<double, double, double, double> func(Ac, alpha, beta, Tc);
-            apdata.corr_analytic_functions_[ig] = func;
-            func_idx++;
-            continue;
+            apdata.corr_analytic_functions_[ig] = std::make_tuple(AC.at(ig), ALPC.at(ig), BETC.at(ig), TC.at(ig));
           }
-          // else use piecewise linear form for correlation function
-          const int n_segments = ncsegb[piecewise_idx];
-          std::vector<std::pair<double, double>> segments;
-          segments.reserve(n_segments);
-          for (size_t s = 0; s < n_segments; ++s)
-            segments.emplace_back(corseg_vals[s], tauseg_vals[s]);
-
-          const std::tuple<size_t, std::vector<std::pair<double, double>>> temp(n_segments, segments);
-          apdata.corr_piecewise_functions_[ig] = temp;
+          // piecewise linear form for correlation function
+          else
+          {
+            int n_segments = NCSEG.at(ig);
+            std::vector<std::pair<double, double>> segments;
+            segments.reserve(n_segments);
+            for (size_t s = 0; s < n_segments; ++s)
+              segments.emplace_back(CORSEG.at(ig).at(s), TAUSEG.at(ig).at(s));
+            apdata.corr_piecewise_functions_[ig] = std::make_tuple(n_segments, segments);
+          }
         }
 
         std::vector<std::string> Mvals;
@@ -2479,35 +2447,22 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
               idx++;
             }
         }
+
         // Unmodeled Error
         opt = !UCreq;
-        double urr = NAN;
+
         nitf_tre<std::string> nt54("URR", opt, false);
         nt54.get_append(tres_itr, tre_str, v);
-        if (!opt)
-        {
-          std::string urrs;
-          nt54.get(tres_itr, urrs);
-          ASC_double(urrs, urr);
-        }
-        double ucc = NAN;
+        double urr = opt ? NAN : TRE_string_as_double(nt54, tres_itr);
+
         nitf_tre<std::string> nt55("UCC", opt, false);
         nt55.get_append(tres_itr, tre_str, v);
-        if (!opt)
-        {
-          std::string uccs;
-          nt55.get(tres_itr, uccs);
-          ASC_double(uccs, ucc);
-        }
-        double urc = NAN;
+        double ucc = opt ? NAN : TRE_string_as_double(nt55, tres_itr);
+
         nitf_tre<std::string> nt56("URC", opt, false);
         nt56.get_append(tres_itr, tre_str, v);
-        if (!opt)
-        {
-          std::string urcs;
-          nt56.get(tres_itr, urcs);
-          ASC_double(urcs, urc);
-        }
+        double urc = opt ? NAN : TRE_string_as_double(nt56, tres_itr);
+
         apdata.unmodeled_row_variance_ = urr;
         apdata.unmodeled_col_variance_ = ucc;
         apdata.unmodeled_row_col_variance_ = urc;
@@ -2521,96 +2476,56 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
           nt57.get(tres_itr, usamc);
           apdata.unmodeled_analytic_ = (usamc == "Y");
         }
+
         if (apdata.unmodeled_analytic_)
         {
-          double uA_r = NAN;
-          nitf_tre<std::string> nt58("UACR", "vector", opt, false);
+          nitf_tre<std::string> nt58("UACR", opt, false);
           nt58.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> uacrs;
-            nt58.get(tres_itr, uacrs);
-            ASC_double(uacrs[0], uA_r);
-          }
-          double alpha_r = NAN;
-          nitf_tre<std::string> nt59("UALPCR", "vector", opt, false);
+          double UACR = opt ? NAN : TRE_string_as_double(nt58, tres_itr);
+
+          nitf_tre<std::string> nt59("UALPCR", opt, false);
           nt59.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> ualpcrs;
-            nt59.get(tres_itr, ualpcrs);
-            ASC_double(ualpcrs[0], alpha_r);
-          }
-          double beta_r = NAN;
-          nitf_tre<std::string> nt60("UBETCR", "vector", opt, false);
+          double UALPCR = opt ? NAN : TRE_string_as_double(nt59, tres_itr);
+
+          nitf_tre<std::string> nt60("UBETCR", opt, false);
           nt60.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> ubetcrs;
-            nt60.get(tres_itr, ubetcrs);
-            ASC_double(ubetcrs[0], beta_r);
-          }
-          double T_r = NAN;
-          nitf_tre<std::string> nt61("UTCR", "vector", opt, false);
+          double UBETCR = opt ? NAN : TRE_string_as_double(nt60, tres_itr);
+
+          nitf_tre<std::string> nt61("UTCR", opt, false);
           nt61.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> utcrs;
-            nt61.get(tres_itr, utcrs);
-            ASC_double(utcrs[0], T_r);
-          }
-          double uA_c = NAN;
-          nitf_tre<std::string> nt62("UACC", "vector", opt, false);
+          double UTCR = opt ? NAN : TRE_string_as_double(nt61, tres_itr);
+
+          nitf_tre<std::string> nt62("UACC", opt, false);
           nt62.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> uaccs;
-            nt62.get(tres_itr, uaccs);
-            ASC_double(uaccs[0], uA_c);
-          }
-          double alpha_c = NAN;
-          nitf_tre<std::string> nt63("UALPCC", "vector", opt, false);
+          double UACC = opt ? NAN : TRE_string_as_double(nt62, tres_itr);
+
+          nitf_tre<std::string> nt63("UALPCC", opt, false);
           nt63.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> ualpccs;
-            nt63.get(tres_itr, ualpccs);
-            ASC_double(ualpccs[0], alpha_c);
-          }
-          double beta_c = NAN;
-          nitf_tre<std::string> nt64("UBETCC", "vector", opt, false);
+          double UALPCC = opt ? NAN : TRE_string_as_double(nt63, tres_itr);
+
+          nitf_tre<std::string> nt64("UBETCC", opt, false);
           nt64.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> ubetccs;
-            nt64.get(tres_itr, ubetccs);
-            ASC_double(ubetccs[0], beta_c);
-          }
-          double T_c = NAN;
-          nitf_tre<std::string> nt65("UTCC", "vector", opt, false);
+          double UBETCC = opt ? NAN : TRE_string_as_double(nt64, tres_itr);
+
+          nitf_tre<std::string> nt65("UTCC", opt, false);
           nt65.get_append(tres_itr, tre_str, v);
-          if (!opt)
-          {
-            std::vector<std::string> utccs;
-            nt65.get(tres_itr, utccs);
-            ASC_double(utccs[0], T_c);
-          }
-          const std::tuple<double, double, double, double> row_func(uA_r, alpha_r, beta_r, T_r);
-          const std::tuple<double, double, double, double> col_func(uA_c, alpha_c, beta_c, T_c);
-          apdata.unmodeled_row_analytic_function_ = row_func;
-          apdata.unmodeled_col_analytic_function_ = col_func;
+          double UTCC = opt ? NAN : TRE_string_as_double(nt65, tres_itr);
+
+          apdata.unmodeled_row_analytic_function_ = std::make_tuple(UACR, UALPCR, UBETCR, UTCR);
+          apdata.unmodeled_col_analytic_function_ = std::make_tuple(UACC, UALPCC, UBETCC, UTCC);
         }
+
+        // piecewise correlation functions
         else
-        { // piecewise correlation functions
+        {
           int n_row_seg_u = 0;
-          nitf_tre<int> nt66("UNCSR", "vector", opt, false);
+          nitf_tre<int> nt66("UNCSR", opt, false);
           nt66.get_append(tres_itr, tre_str, v);
           if (!opt)
           {
-            std::vector<int> uncsr;
-            nt66.get(tres_itr, uncsr);
-            n_row_seg_u = uncsr[0];
+            nt66.get(tres_itr, n_row_seg_u);
           }
+
           std::vector<double> ucorsr;
           std::vector<std::string> ucorsrs;
           nitf_tre<std::string> nt67("UCORSR", "vector", opt, false);
@@ -2625,6 +2540,7 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
               ucorsr.push_back(val);
             }
           }
+
           std::vector<double> utausr;
           std::vector<std::string> utausrs;
           nitf_tre<std::string> nt68("UTAUSR", "vector", opt, false);
@@ -2639,15 +2555,15 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
               utausr.push_back(val);
             }
           }
+
           int n_col_seg_u = 0;
-          nitf_tre<int> nt69("UNCSC", "vector", opt, false);
+          nitf_tre<int> nt69("UNCSC", opt, false);
           nt69.get_append(tres_itr, tre_str, v);
           if (!opt)
           {
-            std::vector<int> uncsc;
-            nt69.get(tres_itr, uncsc);
-            n_col_seg_u = uncsc[0];
+            nt69.get(tres_itr, n_col_seg_u);
           }
+
           std::vector<double> ucorsc;
           std::vector<std::string> ucorscs;
           nitf_tre<std::string> nt70("UCORSC", "vector", opt, false);
@@ -2662,6 +2578,7 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
               ucorsc.push_back(val);
             }
           }
+
           std::vector<double> utausc;
           std::vector<std::string> utauscs;
           nitf_tre<std::string> nt71("UTAUSC", "vector", opt, false);
@@ -2676,6 +2593,7 @@ vpgl_nitf_RSM_camera_extractor::scan_for_RSM_data(bool verbose)
               utausc.push_back(val);
             }
           }
+
           std::vector<std::pair<double, double>> temp_r, temp_c;
           for (size_t s = 0; s < n_row_seg_u; ++s)
             temp_r.emplace_back(ucorsr[s], utausr[s]);

--- a/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.h
+++ b/core/vpgl/file_formats/vpgl_nitf_RSM_camera_extractor.h
@@ -351,20 +351,81 @@ public:
 
 private:
   // internal functions
+
   // convert a string to an integer
   void
-  ASC_int(std::string str, int & ival)
+  ASC_int(std::string str, int & ival) const
   {
-    std::stringstream ss(str);
-    ss >> ival;
+    ival = ASC_int(str);
   }
+  int
+  ASC_int(std::string str) const
+  {
+    try {
+      return std::stoi(str);
+    }
+    catch (const std::invalid_argument& e) {
+      return 0;
+    }
+    catch (const std::out_of_range& e) {
+      return 0;
+    }
+  }
+
   // convert a string to a double
   void
-  ASC_double(std::string str, double & dval)
+  ASC_double(std::string str, double & dval) const
   {
-    std::stringstream ss(str);
-    ss >> dval;
+    dval = ASC_double(str);
   }
+  double
+  ASC_double(std::string str) const
+  {
+    try {
+      return std::stod(str);
+    }
+    catch (const std::invalid_argument& e) {
+      return NAN;
+    }
+    catch (const std::out_of_range& e) {
+      return NAN;
+    }
+  }
+
+  // convert a vector of strings
+  std::vector<int>
+  ASC_vector_int(const std::vector<std::string> & src) const
+  {
+    std::vector<int> result;
+    for (const auto & item : src)
+      result.push_back(ASC_int(item));
+    return result;
+  }
+  std::vector<double>
+  ASC_vector_double(const std::vector<std::string> & src) const
+  {
+    std::vector<double> result;
+    for (const auto & item : src)
+      result.push_back(ASC_double(item));
+    return result;
+  }
+
+  // generic operations for nitf_tre<std::string>
+  int
+  TRE_string_as_int(nitf_tre<std::string> & tre, vil_nitf2_tagged_record_sequence::const_iterator & itr) const
+  {
+    std::string str;
+    tre.get(itr, str);
+    return ASC_int(str);
+  }
+  double
+  TRE_string_as_double(nitf_tre<std::string> & tre, vil_nitf2_tagged_record_sequence::const_iterator & itr) const
+  {
+    std::string str;
+    tre.get(itr, str);
+    return ASC_double(str);
+  }
+
   // parse the image header tres for required information
   bool
   determine_header_status(vil_nitf2_image_subheader * header_ptr,

--- a/core/vpgl/file_formats/vpgl_replacement_sensor_model_tres.h
+++ b/core/vpgl/file_formats/vpgl_replacement_sensor_model_tres.h
@@ -14,6 +14,7 @@
 #endif
 #include <vil/file_formats/vil_nitf2_image.h>
 #include <iostream>
+
 template <class T>
 struct nitf_tre
 {
@@ -42,12 +43,22 @@ struct nitf_tre
 
   bool
   get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, bool verbose = false);
+
   bool
   get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, T & value);
+
   bool
   get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::vector<T> & values);
+
+  bool
+  get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::map<size_t, T> & result);
+
+  bool
+  get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::map<size_t, std::vector<T>> & result);
+
   bool
   append(std::ostream & ostr);
+
   bool
   get_append(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::ostream & os, bool verbose = false)
   {
@@ -78,7 +89,10 @@ struct nitf_tre
   std::string blank_;
   T value_;
   std::vector<T> values_;
+  std::map<size_t, T> map_;
+  std::map<size_t, std::vector<T>> map_vector_;
 };
+
 class vpgl_replacement_sensor_model_tres
 {
 public:
@@ -124,6 +138,7 @@ private:
   vpgl_replacement_sensor_model_tres();
   ~vpgl_replacement_sensor_model_tres();
 };
+
 template <class T>
 bool
 nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, T & value)
@@ -133,6 +148,7 @@ nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, T 
     value = value_;
   return good;
 }
+
 template <class T>
 bool
 nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::vector<T> & values)
@@ -150,6 +166,34 @@ nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, st
 
 template <class T>
 bool
+nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::map<size_t, T> & result)
+{
+  result.clear();
+  bool good = get(tres_itr);
+  if (good)
+  {
+    result = map_;
+    return true;
+  }
+  return false;
+}
+
+template <class T>
+bool
+nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, std::map<size_t, std::vector<T>> & result)
+{
+  result.clear();
+  bool good = get(tres_itr);
+  if (good)
+  {
+    result = map_vector_;
+    return true;
+  }
+  return false;
+}
+
+template <class T>
+bool
 nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, bool verbose)
 {
   bool ret = true;
@@ -158,6 +202,14 @@ nitf_tre<T>::get(vil_nitf2_tagged_record_sequence::const_iterator & tres_itr, bo
   else if (type_ == "vector")
   {
     ret = (*tres_itr)->get_values(tag_, values_);
+  }
+  else if (type_ == "map")
+  {
+    ret = (*tres_itr)->get_map(tag_, map_);
+  }
+  else if (type_ == "map-vector")
+  {
+    ret = (*tres_itr)->get_map(tag_, map_vector_);
   }
   if (ret)
   {
@@ -198,6 +250,23 @@ nitf_tre<T>::append(std::ostream & ostr)
     size_t n = values_.size();
     for (size_t i = 0; i < n; ++i)
       ostr << tag_ + " index " << i << ' ' << values_[i] << std::endl;
+    return true;
+  }
+  else if (type_ == "map" && valid_)
+  {
+    for (const auto & item : map_)
+      ostr << tag_ << " index " << item.first << " " << item.second << std::endl;
+    return true;
+  }
+  else if (type_ == "map-vector" && valid_)
+  {
+    for (const auto & item : map_vector_)
+    {
+      ostr << tag_ << " index " << item.first << " (";
+      for (const auto & val : item.second)
+        ostr << val << " ";
+      ostr << ")" << std::endl;
+    }
     return true;
   }
   else if (type_ == "scalar" && possibly_blank_ && is_blank_)


### PR DESCRIPTION
Regarding the parsing of complex conditional NITF headers as introduced in https://github.com/vxl/vxl/pull/988.  This followon PR adds `vil_nitf2_field_sequence::get_map` to better represent conditional repeated NITF header fields.

Repeated conditional fields better correspond to a `std::map` object (rather than a `std::vector`) as the condition likely results in an object without a value for every repeated loop index.  For example, the conditional repeated fields `A` and `B` in the following NITF header definition correspond to `std::map` objects with valid indices defined by `CHOOSE` values.  
```
.repeat("N_TIMES", vil_nitf2_field_definitions()
  .field("CHOOSE", "Choose A or B", NITF_STR_BCS(1))
  .condition(CHOOSE_A, vil_nitf2_field_definitions()
    .field("A", "A Values", NITF_STR_BCS(21))
  )
  .condition(CHOOSE_B, vil_nitf2_field_definitions()
    .field("B", "B Values", NITF_STR_BCS(21))
  )
)
```

This PR introduces `vil_nitf2_field_sequence::get_map` and the corresponding `vil_nitf2_tagged_record::get_map` to populate `std::map` objects from conditional repeated fields. The new capabilities are then used in the `vpgl_nitf_RSM_camera_extractor` to improve NITF header parsing.

@decrispell 

## PR Checklist

- ❌ Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- ✅  Makes design changes to existing vxl/core\* API that requires semantic versioning increase
- ❌  Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- ❌ Adds tests and baseline comparison (quantitative).
- ❌ Adds Documentation.

