### PR TITLE
COMP: Fixed compiler errors

### DIFF
--- a/contrib/brl/b3p/expatpp/expatpp.h
+++ b/contrib/brl/b3p/expatpp/expatpp.h
@@ -354,6 +354,7 @@ expatpp::operator XML_Parser() const
 inline void
 expatppNesting::OwnedChildOrphansItself(expatppNesting* callingChild)
 {
+  (void) callingChild;
   assert(callingChild==mOwnedChild);
   mOwnedChild = nullptr;
 }

--- a/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.h
@@ -41,7 +41,7 @@ class acal_intertile_solver_lsqr : public vnl_least_squares_function
 {
  public:
   //: Default constructor, use to define variable for assignment
-  acal_intertile_solver_lsqr() : vnl_least_squares_function(0,0){}
+  acal_intertile_solver_lsqr() : vnl_least_squares_function(0, 0) {}
   //: Constructor
   acal_intertile_solver_lsqr(
     std::map<size_t, std::map<size_t, vpgl_affine_camera<double>>> const& tile_acams,
@@ -126,7 +126,7 @@ class acal_intertile_solver_lsqr : public vnl_least_squares_function
 //
 class acal_intertile_graph_solver {
 public:
- acal_intertile_graph_solver(): verbose_(false), cam_trans_penalty_(0.05) {}
+  acal_intertile_graph_solver() = default;
 
   acal_intertile_graph_solver(
     std::map<size_t, std::map<size_t, vpgl_affine_camera<double>>>tile_acams,
@@ -166,7 +166,7 @@ public:
                                               std::vector<size_t>& tile_indices);
   //members
   bool verbose_ = false;
-  double cam_trans_penalty_;
+  double cam_trans_penalty_ = 0.05;
   double max_tile_residual_;
   //vnl_levenberg_marquardt levmarq_;
 

--- a/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_intertile_graph_solver.h
@@ -30,6 +30,7 @@
 #include <vnl/vnl_least_squares_function.h>
 #include <bpgl/acal/acal_match_tree_solver.h>
 #include <bpgl/acal/acal_solution_error.h>
+
 //
 // the least squares cost function for the Levenberg-Marquardt solver. the function f(x, residuals)  evaluates a vector of residuals for the
 // current estimate of camera translations, x. There are two types of residuals: 1) the difference between a projected 3-d point coordinate
@@ -40,30 +41,34 @@ class acal_intertile_solver_lsqr : public vnl_least_squares_function
 {
  public:
   //: Default constructor, use to define variable for assignment
- acal_intertile_solver_lsqr() : vnl_least_squares_function(0,0){}
+  acal_intertile_solver_lsqr() : vnl_least_squares_function(0,0){}
   //: Constructor
-  //                              tile id         cam_id         camera
- acal_intertile_solver_lsqr(std::map<size_t, std::map<size_t, vpgl_affine_camera<double> > > const& tile_acams,
-                            //       tile id       track            cam_id     image corr
-                            std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double> > > > const& tracks,
-                            //       tile id      track idx           cam_id   residual indx
-                            std::map<size_t, std::map<size_t, std::map<size_t, size_t> > > tile_indices_to_residual_index,
-                            // unknown translations  total residuals    num projection error vectors
-                            size_t n_unknowns, size_t n_residuals, size_t n_proj_residuals,
-                            //   trans indx  cam id
-                            std::map<size_t, size_t>& trans_indx_to_cam_id,
-                            //    cam id    trans indx                   weight for camera translation residuals
-                            std::map<size_t, size_t>& cam_id_to_trans_indx, double cam_trans_penalty)
+  acal_intertile_solver_lsqr(
+    std::map<size_t, std::map<size_t, vpgl_affine_camera<double>>> const& tile_acams,
+    //      tile id           cam_id         camera
+    std::map<size_t, std::vector<std::map<size_t, vgl_point_2d<double>>>> const& tracks,
+    //       tile id       track          cam_id        image corr
+    std::map<size_t, std::map<size_t, std::map<size_t, size_t> > > tile_indices_to_residual_index,
+    //       tile id        track idx        cam_id   residual indx
+    size_t n_unknowns, size_t n_residuals, size_t n_proj_residuals,
+    // unknown translations  total residuals    num projection error vectors
+    std::map<size_t, size_t>& trans_indx_to_cam_id,
+    //    trans indx  cam id
+    std::map<size_t, size_t>& cam_id_to_trans_indx, double cam_trans_penalty
+    //    cam id    trans indx                   weight for camera translation residuals
+  )
    : vnl_least_squares_function(n_unknowns, n_residuals, vnl_least_squares_function::no_gradient),
-     tile_acams_(tile_acams), translated_tile_acams_(tile_acams), tracks_(tracks), tile_indices_to_residual_index_(tile_indices_to_residual_index),
-     verbose_(false), track_intersect_failure_(false),n_proj_residuals_(n_proj_residuals),
-     trans_indx_to_cam_id_(trans_indx_to_cam_id), cam_id_to_trans_indx_(cam_id_to_trans_indx),
-     cam_trans_penalty_(cam_trans_penalty){}
+     cam_trans_penalty_(cam_trans_penalty), n_proj_residuals_(n_proj_residuals),
+     tile_acams_(tile_acams), translated_tile_acams_(tile_acams), tracks_(tracks),
+     tile_indices_to_residual_index_(tile_indices_to_residual_index),
+     trans_indx_to_cam_id_(trans_indx_to_cam_id), cam_id_to_trans_indx_(cam_id_to_trans_indx) {}
 
   //: The main function.
   //  Given the parameter vector translations, compute the vector of residuals, projection errors
-  virtual void f(vnl_vector<double> const& translations,  // size is 2*n_nonseed cameras
-                 vnl_vector<double>& residuals);  // size is 2*(all_cams.size()*tracks.size()) + 2*n_nonseed_cameras
+  virtual void f(
+    vnl_vector<double> const& translations,  // size is 2*n_nonseed cameras
+    vnl_vector<double>& residuals // size is 2*(all_cams.size()*tracks.size()) + 2*n_nonseed_cameras
+  );
 
   void compute_residuals(vnl_vector<double> const& x, vnl_vector<double>& residuals);
 
@@ -78,9 +83,9 @@ class acal_intertile_solver_lsqr : public vnl_least_squares_function
     return translated_tile_acams_;
   }
  protected:
-  bool verbose_;
+  bool verbose_ = false;
   double cam_trans_penalty_;
-  bool track_intersect_failure_;
+  bool track_intersect_failure_ = false;
   size_t start_indx_cam_trans_residuals_;
   size_t n_proj_residuals_;
   size_t n_residuals_;
@@ -123,20 +128,21 @@ class acal_intertile_graph_solver {
 public:
  acal_intertile_graph_solver(): verbose_(false), cam_trans_penalty_(0.05) {}
 
-  //                                tile_id          cam_id       camera
- acal_intertile_graph_solver(std::map<size_t, std::map<size_t, vpgl_affine_camera<double> > >tile_acams,
-                             //       tile_id       track            cam_id        image corr
-                             std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double> > > > tracks,
-                             //       tile_id      non-seed cam_ids
-                             std::map<size_t, std::vector<size_t> >  nonseed_cam_ids,
-                             //  ids for seed cameras
-                             std::vector<size_t> seed_cam_ids, std::map<size_t, std::string> cam_inames,
-                             // residual penalty factor for cam offsets
-                             double cam_trans_penalty = 0.05,
-                             // max rms projection error for a tile
-                             double max_tile_residual = 0.5)
-   : tile_acams_(tile_acams), tracks_(tracks),seed_cam_ids_(seed_cam_ids), nonseed_cam_ids_(nonseed_cam_ids), cam_inames_(cam_inames),
-     cam_trans_penalty_(cam_trans_penalty), verbose_(false), max_tile_residual_(max_tile_residual){}
+  acal_intertile_graph_solver(
+    std::map<size_t, std::map<size_t, vpgl_affine_camera<double>>>tile_acams,
+    //       tile_id          cam_id       camera
+    std::map<size_t, std::vector< std::map<size_t, vgl_point_2d<double>>>> tracks,
+    //       tile_id       track          cam_id        image corr
+    std::map<size_t, std::vector<size_t>>  nonseed_cam_ids,
+    //       tile_id      non-seed cam_ids
+    std::vector<size_t> seed_cam_ids,         //  ids for seed cameras
+    std::map<size_t, std::string> cam_inames,
+    double cam_trans_penalty = 0.05,          // residual penalty factor for cam offsets
+    double max_tile_residual = 0.5            // max rms projection error for a tile
+  )
+   : cam_trans_penalty_(cam_trans_penalty),  max_tile_residual_(max_tile_residual),
+     cam_inames_(cam_inames), nonseed_cam_ids_(nonseed_cam_ids),
+     seed_cam_ids_(seed_cam_ids), tracks_(tracks), tile_acams_(tile_acams) {}
 
   void set_verbose(bool verbose) { verbose_ = verbose; }
   bool solve_least_squares_problem();
@@ -159,7 +165,7 @@ public:
   std::set<size_t> find_minimum_residual_set(std::vector<std::pair<double, std::pair<size_t, std::set<size_t> > > >& residual_cams,
                                               std::vector<size_t>& tile_indices);
   //members
-  bool verbose_;
+  bool verbose_ = false;
   double cam_trans_penalty_;
   double max_tile_residual_;
   //vnl_levenberg_marquardt levmarq_;

--- a/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_graph.h
@@ -100,7 +100,7 @@ class match_edge
              std::shared_ptr<match_vertex> v1,
              std::vector<acal_match_pair> const& matches,
              size_t id = 0)
-    : v0_(v0), v1_(v1), matches_(matches), id_(id)
+    : id_(id), matches_(matches), v0_(v0), v1_(v1)
   {
     v0_->add_edge(this);
     v1_->add_edge(this);

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
@@ -34,7 +34,7 @@ class acal_match_tree_lsqr : public vnl_least_squares_function
 {
  public:
   //: Default constructor, use to define variable for assignment
-  acal_match_tree_lsqr() : vnl_least_squares_function(0,0){}
+  acal_match_tree_lsqr() : vnl_least_squares_function(0, 0) {}
 
   //: Constructor
   acal_match_tree_lsqr(
@@ -43,8 +43,7 @@ class acal_match_tree_lsqr : public vnl_least_squares_function
     size_t n_residuals,  double cam_trans_penalty
   )
     : vnl_least_squares_function(2*tree_acams.size(), n_residuals, vnl_least_squares_function::use_gradient),
-      verbose_(false), cam_trans_penalty_(cam_trans_penalty),
-      track_intersect_failure_(false), tree_acams_(tree_acams),
+      cam_trans_penalty_(cam_trans_penalty), tree_acams_(tree_acams),
       trans_acams_(tree_acams), tracks_(tracks) {}
 
   //: The main function.
@@ -67,9 +66,9 @@ class acal_match_tree_lsqr : public vnl_least_squares_function
   std::map<size_t, vpgl_affine_camera<double> > trans_acams() {return trans_acams_;}
 
  protected:
-  bool verbose_;
+  bool verbose_ = false;
   double cam_trans_penalty_;
-  bool track_intersect_failure_;
+  bool track_intersect_failure_ = false;
   std::map<size_t, vpgl_affine_camera<double> > tree_acams_; //original affine cameras
   std::map<size_t, vpgl_affine_camera<double> > trans_acams_; //translated affine cameras
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks_;

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
@@ -131,7 +131,7 @@ public:
 
  private:
   bool verbose_ = false;
-  size_t conn_comp_index_ = -1;
+  size_t conn_comp_index_ = static_cast<size_t>(-1);
   double cam_trans_penalty_ = 0.05;
   acal_match_graph match_graph_;
   std::shared_ptr<acal_match_tree> match_tree_;

--- a/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_tree_solver.h
@@ -37,13 +37,15 @@ class acal_match_tree_lsqr : public vnl_least_squares_function
   acal_match_tree_lsqr() : vnl_least_squares_function(0,0){}
 
   //: Constructor
-  acal_match_tree_lsqr(std::map<size_t, vpgl_affine_camera<double> >& tree_acams,
-                        std::vector< std::map<size_t, vgl_point_2d<double> > > tracks,
-                        size_t n_residuals,  double cam_trans_penalty):
-    vnl_least_squares_function(2*tree_acams.size(), n_residuals, vnl_least_squares_function::use_gradient),
-    tree_acams_(tree_acams), trans_acams_(tree_acams), tracks_(tracks),
-    verbose_(false), track_intersect_failure_(false),
-    cam_trans_penalty_(cam_trans_penalty){}
+  acal_match_tree_lsqr(
+    std::map<size_t, vpgl_affine_camera<double>>& tree_acams,
+    std::vector< std::map<size_t, vgl_point_2d<double>>> tracks,
+    size_t n_residuals,  double cam_trans_penalty
+  )
+    : vnl_least_squares_function(2*tree_acams.size(), n_residuals, vnl_least_squares_function::use_gradient),
+      verbose_(false), cam_trans_penalty_(cam_trans_penalty),
+      track_intersect_failure_(false), tree_acams_(tree_acams),
+      trans_acams_(tree_acams), tracks_(tracks) {}
 
   //: The main function.
   //  Given the parameter vector translations, compute the vector of residuals, projection errors
@@ -79,11 +81,13 @@ class acal_match_tree_lsqr : public vnl_least_squares_function
 class acal_match_tree_solver
 {
 public:
-  acal_match_tree_solver(): verbose_(false), cam_trans_penalty_(0.05),conn_comp_index_(-1){}
+  acal_match_tree_solver() = default;
 
-  acal_match_tree_solver(acal_match_graph const& match_graph, size_t conn_comp_index, double cam_trans_penalty = 0.05):
-    match_graph_(match_graph), verbose_(false),
-    cam_trans_penalty_(cam_trans_penalty), conn_comp_index_(conn_comp_index)
+  acal_match_tree_solver(
+    acal_match_graph const& match_graph, size_t conn_comp_index, double cam_trans_penalty = 0.05
+  )
+    : conn_comp_index_(conn_comp_index), cam_trans_penalty_(cam_trans_penalty),
+      match_graph_(match_graph)
   {
     match_graph_.compute_match_trees();
     match_graph_.validate_match_trees_and_set_metric();
@@ -126,9 +130,9 @@ public:
   bool save_tree_in_dot_format(std::string path);
 
  private:
-  bool verbose_;
-  size_t conn_comp_index_;
-  double cam_trans_penalty_;
+  bool verbose_ = false;
+  size_t conn_comp_index_ = -1;
+  double cam_trans_penalty_ = 0.05;
   acal_match_graph match_graph_;
   std::shared_ptr<acal_match_tree> match_tree_;
   std::vector< std::map<size_t, vgl_point_2d<double> > > tracks_;

--- a/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_match_utils.h
@@ -28,12 +28,11 @@
 // a simple feature structure, just id and location
 struct acal_corr
 {
-  acal_corr() : id_(-1) { pt_.set(-1, -1); }
+  acal_corr() { pt_.set(-1, -1); }
   acal_corr(size_t id, vgl_point_2d<double> const& pt)
-    : id_(id), pt_(pt)
-  {}
+    : id_(id), pt_(pt) {}
 
-  size_t id_;
+  size_t id_ = static_cast<size_t>(-1);
   vgl_point_2d<double> pt_; // correspondence point
 
   bool operator==(acal_corr const& other) const {

--- a/contrib/brl/bbas/bpgl/acal/acal_metadata.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_metadata.h
@@ -190,7 +190,7 @@ void deserialize_tile_image_meta( Json::Value& root)
        tile_image_metadata tim;
        std::stringstream ss;
        ss << key;
-       size_t id = -1;
+       size_t id = static_cast<size_t>(-1);
        ss >> id;
        tim.image_id_ = id;
        tim.image_name_ = base_name;

--- a/contrib/brl/bbas/bpgl/acal/acal_planar_feature_matcher.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_planar_feature_matcher.h
@@ -26,31 +26,29 @@
 
 struct planar_feature_params
 {
-  planar_feature_params(): pt_spacing_(0.3), patch_radius_(6), coarse_search_radius_(20.0),
-                           coarse_search_increment_(2.0), fine_search_radius_(2.5),
-                           fine_search_increment_(0.25), max_n_solved_images_(10) {}
+  planar_feature_params() = default;
 
-  double pt_spacing_;
-  double patch_radius_;
-  double coarse_search_radius_;
-  double fine_search_radius_;
-  double coarse_search_increment_;
-  double fine_search_increment_;
-  size_t max_n_solved_images_;
+  double pt_spacing_ = 0.3;
+  double patch_radius_ = 6.0;
+  double coarse_search_radius_ = 20.0;
+  double fine_search_radius_ = 2.5;
+  double coarse_search_increment_ = 2.0;
+  double fine_search_increment_ = 0.25;
+  size_t max_n_solved_images_ = 10;
 };
 
 
 struct planar_match_score
 {
-  planar_match_score():mu_(0.67), sigma_(0.1), min_prob_(0.2) {}
+  planar_match_score() = default;
 
   double p(double s) {
     return 0.5*(1.0+erf((s-mu_)/(sqrt(2)*sigma_)));
   }
 
-  double mu_;
-  double sigma_;
-  double min_prob_;
+  double mu_ = 0.67;
+  double sigma_ = 0.1;
+  double min_prob_ = 0.2;
   double min_score_;
   double max_score_;
   double mean_score_;

--- a/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_single_track_solver.h
@@ -28,13 +28,19 @@
 #include "acal_match_tree.h"
 #include "acal_match_graph.h"
 #include "acal_solution_error.h"
+
 class acal_single_track_solver
 {
 public:
   acal_single_track_solver(): verbose_(false){}
 
- acal_single_track_solver(std::map<size_t, std::string> inames,std::map<size_t, vgl_point_2d<double> > track,std::map<size_t, vpgl_affine_camera<double> > const& acams):
-  inames_(inames), track_(track), track_acams_(acams),verbose_(false), use_covariance_(false){}
+  acal_single_track_solver(
+    std::map<size_t, std::string> inames,
+    std::map<size_t, vgl_point_2d<double>> track,
+    std::map<size_t, vpgl_affine_camera<double>> const& acams
+  )
+    : inames_(inames), track_(track), track_acams_(acams) {}
+  
   void set_verbose(bool verbose) { verbose_ = verbose; }
 
   // potentially condition the covariance matrix by adding a scaled identity matrix, s*I.
@@ -65,8 +71,8 @@ public:
  
 
  private:
-  bool verbose_;
-  bool use_covariance_;
+  bool verbose_ = false;
+  bool use_covariance_ = false;
   vnl_matrix<double> covar_plane_cs_;
   size_t large_track_size_;
   double max_sing_val_fraction_;

--- a/contrib/brl/bbas/bpgl/acal/acal_tile_data_manager.h
+++ b/contrib/brl/bbas/bpgl/acal/acal_tile_data_manager.h
@@ -30,36 +30,11 @@ class acal_tile_data_manager
 {
 public:
   //: default constructor
-  acal_tile_data_manager():
-    image_format_ext_(".tif"),
-    camera_format_ext_(".rpb"),
-    fmatches_fname_("fmatches_F_filt.txt"),
-    affine_cam_fname_("F_affine_cams.txt"),
-    match_matrix_fname_("match_matrix.jpg"),
-    affine_corrected_format_ext_("_affine_corrected.txt"),
-    F_identity_fname_("F_matrix_identity_pairs.txt"),
-    degen_ray_fname_("degenerate_ray_pairs.txt"),
-    image_metadata_path_("images.json"),
-    tile_metadata_path_("tiles.json"),
-    geo_corr_metadata_path_("geo_corr_metadata.json"),
-    tile_ptset_path_("dem_ptset.txt")
-    {}
+  acal_tile_data_manager() = default;
 
   //: constructor to specify just image type (image_format_ext = {.jpg, tif, .bmp, .gif, .png, .pnm, .psd})
   acal_tile_data_manager(std::string const& image_format_ext):
-   image_format_ext_(image_format_ext),
-   camera_format_ext_(".rpb"),
-   fmatches_fname_("fmatches_F_filt.txt"),
-   affine_cam_fname_("F_affine_cams.txt"),
-   match_matrix_fname_("match_matrix.jpg"),
-   affine_corrected_format_ext_("_affine_corrected.txt"),
-   F_identity_fname_("F_matrix_identity_pairs.txt"),
-   degen_ray_fname_("degenerate_ray_pairs.txt"),
-   image_metadata_path_("images.json"),
-   tile_metadata_path_("tiles.json"),
-   geo_corr_metadata_path_("geo_corr_metadata.json"),
-   tile_ptset_path_("dem_ptset.txt")
-   {}
+   image_format_ext_(image_format_ext) {}
 
   //: constructor to specify all type and path values
   // image_format_ext   - the image type extension to control the type of image to be loaded
@@ -73,22 +48,22 @@ public:
   //                               to store the corrected affine camera in ascii format
   // NEEDS UPDATE TO INCLUDE ALL PATHS -- FIXME!!!
   acal_tile_data_manager(
-      std::string const& image_format_ext, std::string const& camera_format_ext,
-      std::string const& fmatches_fname = "fmatches_F_filt.txt",
-      std::string const& affine_cam_fname = "F_affine_cams.txt",
-      std::string const& match_matrix_fname = "match_matrix.jpg",
-      std::string const& F_matrix_ident_pairs_fname = "F_matrix_identity_pairs.txt",
-      std::string const& degen_ray_pairs_fname = "degenerate_ray_pairs.txt",
-      std::string const& affine_corrected_format_ext = "_affine_corrected.txt"):
-    image_format_ext_(image_format_ext),
-    camera_format_ext_(camera_format_ext),
-    fmatches_fname_(fmatches_fname),
-    affine_cam_fname_(affine_cam_fname),
-    match_matrix_fname_(match_matrix_fname),
-    F_identity_fname_(F_matrix_ident_pairs_fname),
-    degen_ray_fname_(degen_ray_pairs_fname),
-    affine_corrected_format_ext_(affine_corrected_format_ext)
-    {}
+    std::string const& image_format_ext, std::string const& camera_format_ext,
+    std::string const& fmatches_fname = "fmatches_F_filt.txt",
+    std::string const& affine_cam_fname = "F_affine_cams.txt",
+    std::string const& match_matrix_fname = "match_matrix.jpg",
+    std::string const& F_matrix_ident_pairs_fname = "F_matrix_identity_pairs.txt",
+    std::string const& degen_ray_pairs_fname = "degenerate_ray_pairs.txt",
+    std::string const& affine_corrected_format_ext = "_affine_corrected.txt"
+  )
+    : fmatches_fname_(fmatches_fname)
+    , affine_cam_fname_(affine_cam_fname)
+    , match_matrix_fname_(match_matrix_fname)
+    , F_identity_fname_(F_matrix_ident_pairs_fname)
+    , degen_ray_fname_(degen_ray_pairs_fname)
+    , image_format_ext_(image_format_ext)
+    , camera_format_ext_(camera_format_ext)
+    , affine_corrected_format_ext_(affine_corrected_format_ext) {}
 
   //: alternative way to set image type  extension, e.g. ".tif"
   void set_image_format_ext(std::string const& format_ext){ image_format_ext_ = format_ext;}
@@ -102,20 +77,20 @@ public:
   //:members
   acal_metadata meta_;
   std::map<std::string, size_t> meta_img_names_to_id_;
-  std::string fmatches_fname_;
-  std::string affine_cam_fname_;
-  std::string match_matrix_fname_;
-  std::string F_identity_fname_;
-  std::string degen_ray_fname_;
+  std::string fmatches_fname_ = "fmatches_F_filt.txt";
+  std::string affine_cam_fname_ = "F_affine_cams.txt";
+  std::string match_matrix_fname_ = "match_matrix.jpg";
+  std::string F_identity_fname_ = "F_matrix_identity_pairs.txt";
+  std::string degen_ray_fname_ = "degenerate_ray_pairs.txt";
   std::string tile_dir_;
-  std::string image_format_ext_;
-  std::string camera_format_ext_;
-  std::string affine_corrected_format_ext_;
+  std::string image_format_ext_ = ".tif";
+  std::string camera_format_ext_ = ".rpb";
+  std::string affine_corrected_format_ext_ = "_affine_corrected.txt";
   std::string metadata_dir_;
-  std::string image_metadata_path_;
-  std::string tile_metadata_path_;
-  std::string geo_corr_metadata_path_;
-  std::string tile_ptset_path_;
+  std::string image_metadata_path_ = "images.json";
+  std::string tile_metadata_path_ = "tiles.json";
+  std::string geo_corr_metadata_path_ = "geo_corr_metadata.json";
+  std::string tile_ptset_path_ = "dem_ptset.txt";
 
   //       tile_id
   std::map<size_t, std::string> tile_dirs_;

--- a/contrib/brl/bbas/bpgl/bpgl_geotif_camera.h
+++ b/contrib/brl/bbas/bpgl/bpgl_geotif_camera.h
@@ -38,8 +38,10 @@ class bpgl_geotif_camera : vpgl_camera<T>
  public:
   //: default constructor - may want a container of cameras
   //  the default member values represent the most common case, e.g. a local_rational_camera
- bpgl_geotif_camera():has_lvcs_(true), gcam_has_wgs84_cs_(true),
-    elev_org_at_zero_(true), is_utm_(false), project_local_points_(true),scale_defined_(false), projection_enabled_(false){}
+ bpgl_geotif_camera()
+  : projection_enabled_(false), project_local_points_(true),
+    elev_org_at_zero_(true), has_lvcs_(true), gcam_has_wgs84_cs_(true),
+    scale_defined_(false), is_utm_(false) {}
 
   virtual ~bpgl_geotif_camera() = default;
 

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -33,7 +33,7 @@
 // a display of progress as a moving '+' symbol
 class reg_progress {
 public:
- reg_progress(size_t n_steps) : move_(1), pos_(1), n_(n_steps) {
+ reg_progress(size_t n_steps) : n_(n_steps) {
     display_ = std::string(n_+2,' ');
     display_[0]='['; display_[n_+1] = ']';
   }
@@ -54,8 +54,8 @@ public:
   }
 private:
   std::string display_;
-  int move_;
-  int pos_;
+  int move_ = 1;
+  int pos_ = 1;
   int n_;
 };
 template <class T>

--- a/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
+++ b/contrib/brl/bbas/bvgl/algo/bvgl_register_ptsets_3d_rigid.h
@@ -29,15 +29,16 @@
 #include <vgl/vgl_quadric_3d.h>
 #include <bvgl/bvgl_k_nearest_neighbors_3d.h>
 #include <vnl/vnl_random.h>
+
 // a display of progress as a moving '+' symbol
-class reg_progress{
+class reg_progress {
 public:
- reg_progress(size_t n_steps):n_(n_steps), move_(1), pos_(1){
+ reg_progress(size_t n_steps) : move_(1), pos_(1), n_(n_steps) {
     display_ = std::string(n_+2,' ');
     display_[0]='['; display_[n_+1] = ']';
   }
   void operator ()(){
-    for(size_t i = 1; i<=n_; ++i)
+    for(int i = 1; i <= n_; ++i)
       display_[i] = ' ';
     display_[pos_]='+';
     std::cout << '\r' << display_ << std::flush;
@@ -66,13 +67,12 @@ public:
   bvgl_register_ptsets_3d_rigid() = default;
 
   //: constructor with pointsets
- bvgl_register_ptsets_3d_rigid(vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable,
-                               size_t n_hypos = 100, double transform_fraction = 0.25) :
-  fixed_(fixed),
-    movable_(movable),
-    knn_fixed_(fixed),
-    n_hypos_(n_hypos),
-    transform_fraction_(transform_fraction)
+  bvgl_register_ptsets_3d_rigid(
+    vgl_pointset_3d<T> const& fixed, vgl_pointset_3d<T> const& movable,
+    size_t n_hypos = 100, double transform_fraction = 0.25
+  )
+    : transform_fraction_(transform_fraction), n_hypos_(n_hypos),
+      fixed_(fixed), knn_fixed_(fixed), movable_(movable)
   {
     // reduce the size of the movable pointset to reduce computation
     unsigned n = movable_.npts();

--- a/contrib/brl/bbas/bvgl/bvgl_grid_index_3d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_grid_index_3d.h
@@ -97,6 +97,7 @@ class bvgl_grid_index_3d{
   unsigned npts_;
   Type thresh_;
 };
+
 // implementation relatively short so include in the .h file
 template <class Type>
 //: compute 3-d grid index values from point coordinates
@@ -114,10 +115,15 @@ void bvgl_grid_index_3d<Type>::index(vgl_point_3d<Type> const& p, unsigned& ix, 
   if(izi<0) iz = 0;
   if(izi>=int(nz_)) iz = nz_-1;
 }
+
 //: constructors
 template <class Type>
-bvgl_grid_index_3d<Type>::bvgl_grid_index_3d(unsigned nx, unsigned ny, unsigned nz, vgl_pointset_3d<Type> ptset, Type thresh):
-nx_(nx), ny_(ny), nz_(nz), has_normals_(ptset.has_normals()), npts_(0), thresh_(thresh), has_scalars_(ptset.has_scalars()){
+bvgl_grid_index_3d<Type>::bvgl_grid_index_3d(
+  unsigned nx, unsigned ny, unsigned nz, vgl_pointset_3d<Type> ptset, Type thresh
+)
+  : has_scalars_(ptset.has_scalars()), has_normals_(ptset.has_normals()),
+    nx_(nx), ny_(ny), nz_(nz), npts_(0), thresh_(thresh)
+{
   p_grid_ = vbl_array_3d<std::vector<vgl_point_3d<Type> > >(nx, ny, nz);
   if(has_normals_)
     n_grid_ = vbl_array_3d<std::vector<vgl_vector_3d<Type> > >(nx, ny, nz);
@@ -148,9 +154,13 @@ nx_(nx), ny_(ny), nz_(nz), has_normals_(ptset.has_normals()), npts_(0), thresh_(
 }
 
 template <class Type>
-bvgl_grid_index_3d<Type>::bvgl_grid_index_3d(unsigned nx, unsigned ny, unsigned nz,
-                                             vgl_pointset_3d<Type> ptset, std::vector<Type> scalars, Type thresh):
-  nx_(nx), ny_(ny), nz_(nz), has_normals_(ptset.has_normals()), npts_(0), thresh_(thresh), has_scalars_(true){
+bvgl_grid_index_3d<Type>::bvgl_grid_index_3d(
+  unsigned nx, unsigned ny, unsigned nz, vgl_pointset_3d<Type> ptset,
+  std::vector<Type> scalars, Type thresh
+)
+  : has_scalars_(true), has_normals_(ptset.has_normals()),
+  nx_(nx), ny_(ny), nz_(nz), npts_(0), thresh_(thresh)
+{
   p_grid_ = vbl_array_3d<std::vector<vgl_point_3d<Type> > >(nx, ny, nz);
   s_grid_ = vbl_array_3d<std::vector<Type> >(nx, ny, nz);
   idx_grid_ = vbl_array_3d<std::vector<size_t> >(nx, ny, nz);

--- a/contrib/brl/bbas/bvgl/bvgl_grid_index_3d.h
+++ b/contrib/brl/bbas/bvgl/bvgl_grid_index_3d.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <map>
 #include <algorithm>
+#include <utility>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
 #endif
@@ -27,6 +28,7 @@
 #include <vgl/vgl_bounding_box.h>
 #include <vgl/vgl_line_3d_2_points.h>
 #include <vnl/vnl_vector.h>
+
 template <class Type>
 class bvgl_grid_index_3d{
  public:
@@ -359,22 +361,13 @@ std::vector<vgl_pointset_3d<Type> > bvgl_grid_index_3d<Type>::intersecting_cells
   unsigned ixs = ix_min, ixe = ix_max;
   unsigned iys = iy_min, iye = iy_max;
   unsigned izs = iz_min, ize = iz_max;
-  unsigned temp;
-  if(ixs>ixe){
-    temp = ixs;
-    ixs = ixe;
-    ixe = temp;
-  }
-  if(iys>iye){
-    temp = iys;
-    iys = iye;
-    iye = temp;
-  }
-  if(izs>ize){
-    temp = izs;
-    izs = ize;
-    ize = temp;
-  }
+  if(ixs > ixe)
+    std::swap(ixs, ixe);
+  if(iys > iye)
+    std::swap(iys, iye);
+  if(izs > ize)
+    std::swap(izs, ize);
+
   for(unsigned iz = izs; iz<=ize; ++iz)
     for(unsigned iy = iys; iy<=iye; ++iy)
       for(unsigned ix = ixs; ix<=ixe; ++ix){

--- a/contrib/brl/bbas/bwm/io/bwm_io_structs.h
+++ b/contrib/brl/bbas/bwm/io/bwm_io_structs.h
@@ -50,16 +50,13 @@ class bwm_io_tab_config
 {
  public:
   bwm_io_tab_config(std::string type, std::string tab_name, bool active_or_not)
-    : name(tab_name), type_name(type), status(active_or_not) {}
-
-  bwm_io_tab_config(bwm_io_tab_config const& t)
-    : name(t.name), type_name(t.type_name), status(t.status) {}
+    : name_(tab_name), type_name_(type), status_(active_or_not) {}
 
   virtual bwm_io_tab_config* clone()=0; // {return new bwm_io_tab_config(type_name, name, status); }
   virtual ~bwm_io_tab_config() {}
-  std::string name;
-  std::string type_name;
-  bool status;
+  std::string name_;
+  std::string type_name_;
+  bool status_;
 };
 
 struct bwm_io_tab_config_img : public bwm_io_tab_config {
@@ -68,7 +65,7 @@ struct bwm_io_tab_config_img : public bwm_io_tab_config {
   bwm_io_tab_config_img(bwm_io_tab_config_img const& t)
     : bwm_io_tab_config(t), img_path(t.img_path) {}
 
-  bwm_io_tab_config_img* clone() {return new bwm_io_tab_config_img(name, status, img_path); }
+  bwm_io_tab_config_img* clone() {return new bwm_io_tab_config_img(name_, status_, img_path); }
   std::string img_path;
 };
 
@@ -83,7 +80,7 @@ struct bwm_io_tab_config_cam : public bwm_io_tab_config {
   bwm_io_tab_config_cam(bwm_io_tab_config_cam const& t)
     : bwm_io_tab_config(t), img_path(t.img_path), cam_path(t.cam_path), cam_type(t.cam_type) {}
 
-  bwm_io_tab_config_cam* clone() {return new bwm_io_tab_config_cam(name, status, img_path, cam_path, cam_type); }
+  bwm_io_tab_config_cam* clone() {return new bwm_io_tab_config_cam(name_, status_, img_path, cam_path, cam_type); }
   std::string img_path;
   std::string cam_path;
   std::string cam_type;
@@ -99,7 +96,7 @@ struct bwm_io_tab_config_fiducial : public bwm_io_tab_config {
   bwm_io_tab_config_fiducial(bwm_io_tab_config_fiducial const& t)
     : bwm_io_tab_config(t), image_path(t.image_path), fid_path(t.fid_path) {}
 
-  bwm_io_tab_config_fiducial* clone() {return new bwm_io_tab_config_fiducial(name, status, image_path, fid_path); }
+  bwm_io_tab_config_fiducial* clone() {return new bwm_io_tab_config_fiducial(name_, status_, image_path, fid_path); }
   std::string image_path;
   std::string fid_path;
 };
@@ -109,7 +106,7 @@ struct bwm_io_tab_config_coin3d: public bwm_io_tab_config {
                            std::string c_path, std::string c_type)
     : bwm_io_tab_config(COIN3D_TABLEAU_TAG, name, status), cam_path(c_path), cam_type(c_type) {}
 
-  bwm_io_tab_config_coin3d* clone() {return new bwm_io_tab_config_coin3d(name, status, cam_path, cam_type); }
+  bwm_io_tab_config_coin3d* clone() {return new bwm_io_tab_config_coin3d(name_, status_, cam_path, cam_type); }
   std::string cam_path;
   std::string cam_type;
 };
@@ -121,7 +118,7 @@ struct bwm_io_tab_config_proj2d: public bwm_io_tab_config {
     : bwm_io_tab_config(PROJ2D_TABLEAU_TAG, name, status), cam_path(c_path),
       cam_type(c_type), proj2d_type(p_type), coin3d_tab_name(coin3d) {}
 
-  bwm_io_tab_config_proj2d* clone() { return new bwm_io_tab_config_proj2d(name, status, proj2d_type, cam_path, cam_type, coin3d_tab_name); }
+  bwm_io_tab_config_proj2d* clone() { return new bwm_io_tab_config_proj2d(name_, status_, proj2d_type, cam_path, cam_type, coin3d_tab_name); }
   std::string cam_path;
   std::string cam_type;
   std::string proj2d_type;
@@ -133,7 +130,7 @@ struct bwm_io_tab_config_video: public bwm_io_tab_config {
                           std::string frames,  std::string cameras)
     : bwm_io_tab_config(VIDEO_TABLEAU_TAG, name, status), video_path(frames), camera_glob(cameras) {}
 
-  bwm_io_tab_config_video* clone() { return new bwm_io_tab_config_video(name, status, video_path, camera_glob); }
+  bwm_io_tab_config_video* clone() { return new bwm_io_tab_config_video(name_, status_, video_path, camera_glob); }
   std::string video_path;
   std::string camera_glob;
 };

--- a/contrib/brl/bbas/vsph/vsph_spherical_coord.h
+++ b/contrib/brl/bbas/vsph/vsph_spherical_coord.h
@@ -37,13 +37,6 @@ class vsph_spherical_coord : public vbl_ref_count
   vsph_spherical_coord(vgl_point_3d<double> origin, double radius = 1.0)
   : radius_(radius), origin_(origin) {}
 
-  //: Copy constructor
-  vsph_spherical_coord(vsph_spherical_coord const& rhs)
-    : vbl_ref_count(), radius_(rhs.radius_), origin_(rhs.origin_) {}
-
-  // Destructor
-  ~vsph_spherical_coord() override = default;
-
   //***************************************************************************
   // Methods
   //***************************************************************************

--- a/contrib/brl/bbas/vsph/vsph_unit_sphere.cxx
+++ b/contrib/brl/bbas/vsph/vsph_unit_sphere.cxx
@@ -42,10 +42,10 @@ void vsph_unit_sphere::insert_edge(vsph_edge const&  e)
   edges_.push_back(e);
 }
 
-vsph_unit_sphere::vsph_unit_sphere(double point_angle,
-                                   double min_theta, double max_theta)
-: neighbors_valid_(false), point_angle_(point_angle),
-  min_theta_(min_theta), max_theta_(max_theta), verbose_(false)
+vsph_unit_sphere::vsph_unit_sphere(
+  double point_angle, double min_theta, double max_theta
+)
+  : point_angle_(point_angle), min_theta_(min_theta), max_theta_(max_theta)
 {
   if(verbose_)std::cout << "Start construction" << std::endl;
   add_uniform_views();

--- a/contrib/brl/bbas/vsph/vsph_unit_sphere.h
+++ b/contrib/brl/bbas/vsph/vsph_unit_sphere.h
@@ -54,7 +54,7 @@ class vsph_unit_sphere : public vbl_ref_count
 {
  public:
   //: default constructor
- vsph_unit_sphere() : point_angle_(0.0), min_theta_(0.0), max_theta_(0.0), verbose_(false) {}
+  vsph_unit_sphere() : verbose_(false), point_angle_(0.0), min_theta_(0.0), max_theta_(0.0) {}
   //: constructor, angles are in degrees
   // \p point_angle is the maximum angle between adjacent triangle vertices
   // \p min_theta and \p max_theta bound the points constructed on the sphere surface

--- a/contrib/brl/bbas/vsph/vsph_unit_sphere.h
+++ b/contrib/brl/bbas/vsph/vsph_unit_sphere.h
@@ -54,7 +54,7 @@ class vsph_unit_sphere : public vbl_ref_count
 {
  public:
   //: default constructor
-  vsph_unit_sphere() : verbose_(false), point_angle_(0.0), min_theta_(0.0), max_theta_(0.0) {}
+  vsph_unit_sphere() = default;
   //: constructor, angles are in degrees
   // \p point_angle is the maximum angle between adjacent triangle vertices
   // \p min_theta and \p max_theta bound the points constructed on the sphere surface
@@ -188,14 +188,14 @@ class vsph_unit_sphere : public vbl_ref_count
   std::vector<vsph_spherical_triangle> triangles_;
   vsph_grid_index_2d index_;
  private:
-  bool verbose_; // print debug statements
+  bool verbose_ = false; // print debug statements
   //: spherical coordinate system - default is unit sphere CS
   vsph_spherical_coord coord_sys_;
-  bool neighbors_valid_;
+  bool neighbors_valid_ = false;
   //: these angles are stored in degrees for convenient interpretation
-  double point_angle_;
-  double min_theta_;
-  double max_theta_;
+  double point_angle_ = 0.0;
+  double min_theta_ = 0.0;
+  double max_theta_ = 0.0;
   //: returns true if all the angles between vertices of a triangle are smaller than \a angle.
   bool min_angle(std::vector<vgl_vector_3d<double> > list, double angle_rad);
 };

--- a/contrib/gel/vdgl/vdgl_edgel.cxx
+++ b/contrib/gel/vdgl/vdgl_edgel.cxx
@@ -8,18 +8,7 @@
 #endif
 
 vdgl_edgel::vdgl_edgel( const double x, const double y, const double grad, const double theta )
-  : p_( x, y), grad_( grad), theta_( theta)
-{
-}
-
-vdgl_edgel& vdgl_edgel::operator=(const vdgl_edgel& that)
-{
-  p_    = vgl_point_2d<double>( that.get_x(), that.get_y());
-  grad_ = that.get_grad();
-  theta_= that.get_theta();
-
-  return *this;
-}
+  : p_( x, y), grad_( grad), theta_( theta) {}
 
 
 bool operator==( const vdgl_edgel &e1, const vdgl_edgel &e2)

--- a/contrib/gel/vdgl/vdgl_edgel.cxx
+++ b/contrib/gel/vdgl/vdgl_edgel.cxx
@@ -7,11 +7,11 @@
 #  include "vcl_msvc_warnings.h"
 #endif
 
-vdgl_edgel::vdgl_edgel( const double x, const double y, const double grad, const double theta )
-  : p_( x, y), grad_( grad), theta_( theta) {}
+vdgl_edgel::vdgl_edgel(const double x, const double y, const double grad, const double theta)
+  : p_(x, y), grad_( grad), theta_( theta) {}
 
 
-bool operator==( const vdgl_edgel &e1, const vdgl_edgel &e2)
+bool operator==(const vdgl_edgel &e1, const vdgl_edgel &e2)
 {
   return (( e1.p_.x()== e2.p_.x()) &&
           ( e1.p_.y()== e2.p_.y()) &&

--- a/contrib/gel/vdgl/vdgl_edgel.h
+++ b/contrib/gel/vdgl/vdgl_edgel.h
@@ -26,8 +26,6 @@ class vdgl_edgel
 
   // Operators-----------------------------------------------------------------
 
-  vdgl_edgel& operator=(const vdgl_edgel& that);
-
   friend bool operator==( const vdgl_edgel &e1, const vdgl_edgel &e2);
   friend std::ostream& operator<<(std::ostream& s, const vdgl_edgel& p);
 

--- a/contrib/gel/vdgl/vdgl_edgel_chain.h
+++ b/contrib/gel/vdgl/vdgl_edgel_chain.h
@@ -41,7 +41,7 @@ class vdgl_edgel_chain : public vbl_ref_count,
   vdgl_edgel_chain( const double x0, const double y0,
                     const double x1, const double y1);
   vdgl_edgel_chain(vdgl_edgel_chain const& x)
-    : vul_timestamp(), vbl_ref_count(), es_(x.es_) {}
+    : vbl_ref_count(), vul_timestamp(), es_(x.es_) {}
   ~vdgl_edgel_chain() override = default;
 
   // Operators----------------------------------------------------------------

--- a/contrib/gel/vdgl/vdgl_interpolator.h
+++ b/contrib/gel/vdgl/vdgl_interpolator.h
@@ -35,7 +35,7 @@ class vdgl_interpolator : public vbl_ref_count,
   vdgl_interpolator(vdgl_edgel_chain_sptr chain) : chain_(chain) {}
 
   vdgl_interpolator(vdgl_interpolator const& x)
-    : vul_timestamp(), vbl_ref_count(), chain_(x.chain_) {}
+    : vbl_ref_count(), vul_timestamp(), chain_(x.chain_) {}
 
   // Operators----------------------------------------------------------------
 

--- a/contrib/gel/vsol/vsol_point_2d.h
+++ b/contrib/gel/vsol/vsol_point_2d.h
@@ -209,7 +209,10 @@ class vsol_point_2d : public vsol_spatial_object_2d
   //---------------------------------------------------------------------------
   inline void describe(std::ostream &strm, int blanking=0) const override
   {
-    if (blanking < 0) blanking = 0; while (blanking--) strm << ' ';
+    if (blanking < 0)
+      blanking = 0;
+    while (blanking--)
+      strm << ' ';
     strm << '(' << x() << ' ' << y() << ')' << std::endl;
   }
 };

--- a/contrib/gel/vsol/vsol_point_3d.h
+++ b/contrib/gel/vsol/vsol_point_3d.h
@@ -215,7 +215,10 @@ class vsol_point_3d : public vsol_spatial_object_3d
   //---------------------------------------------------------------------------
   inline void describe(std::ostream &strm, int blanking=0) const override
   {
-    if (blanking < 0) blanking = 0; while (blanking--) strm << ' ';
+    if (blanking < 0)
+      blanking = 0;
+    while (blanking--)
+      strm << ' ';
     strm << '(' << x() << ' ' << y() << ' ' << z() << ')' << std::endl;
   }
 };

--- a/core/vgl/vgl_line_segment_2d.h
+++ b/core/vgl/vgl_line_segment_2d.h
@@ -31,20 +31,11 @@ public:
   //: Default constructor - does not initialise!
   inline vgl_line_segment_2d() = default;
 
-  //: Copy constructor
-  inline vgl_line_segment_2d(const vgl_line_segment_2d<Type> & l)
-    : point1_(l.point1_)
-    , point2_(l.point2_)
-  {}
-
   //: Construct from two end points
   inline vgl_line_segment_2d(const vgl_point_2d<Type> & p1, const vgl_point_2d<Type> & p2)
     : point1_(p1)
     , point2_(p2)
   {}
-
-  //: Destructor
-  inline ~vgl_line_segment_2d() = default;
 
   //: One end-point of the line segment.
   inline vgl_point_2d<Type>

--- a/core/vgl/vgl_point_2d.h
+++ b/core/vgl/vgl_point_2d.h
@@ -63,16 +63,6 @@ public:
     , y_(other.y())
   {}
 
-#if 0 // The compiler defaults for these are doing what they should do:
-  //: Copy constructor
-  inline vgl_point_2d(vgl_point_2d<Type> const& p) : x_(p.x()), y_(p.y()) {}
-  //: Destructor
-  inline ~vgl_point_2d () {}
-  //: Assignment
-  inline vgl_point_2d<Type>& operator=(const vgl_point_2d<Type>& p)
-  { x_ = p.x(); y_ = p.y(); return *this; }
-#endif
-
   //: Test for equality
   inline bool
   operator==(const vgl_point_2d<Type> & p) const

--- a/core/vgl/vgl_pointset_3d.h
+++ b/core/vgl/vgl_pointset_3d.h
@@ -459,7 +459,7 @@ operator>>(std::istream & istr, vgl_pointset_3d<Type> & ptset)
     std::stringstream isstr(buf_str);
     isstr >> std::noskipws; // accept spaces as separators
     // parse the line for point and normal values
-    Type x, y, z, nx, ny, nz, sc;
+    Type x, y, z, nx = 0, ny = 0, nz = 0, sc = 0;
     unsigned char c;
     isstr >> x >> c;
     if (!(c == ',' || c == ' '))
@@ -475,7 +475,7 @@ operator>>(std::istream & istr, vgl_pointset_3d<Type> & ptset)
     }
     if (!has_normals && !has_scalars)
       isstr >> z;
-    else if (has_normals || has_scalars)
+    else // has_normals || has_scalars
     {
       isstr >> z >> c;
       if (!(c == ',' || c == ' '))

--- a/core/vgl/vgl_polygon.h
+++ b/core/vgl/vgl_polygon.h
@@ -77,14 +77,6 @@ public:
     : sheets_(std::move(sheets))
   {}
 
-  // Copy constructor
-  vgl_polygon(const vgl_polygon & a)
-    : sheets_(a.sheets_)
-  {}
-
-  // Destructor
-  ~vgl_polygon() = default;
-
   //: Returns true if \a p(x,y) is inside the polygon, else false
   bool
   contains(const point_t & p) const

--- a/core/vil/file_formats/vil_nitf2_field_functor.cxx
+++ b/core/vil/file_formats/vil_nitf2_field_functor.cxx
@@ -12,16 +12,16 @@ vil_nitf2_field_specified::operator()(vil_nitf2_field_sequence * record,
                                       const vil_nitf2_index_vector & indexes,
                                       bool & result)
 {
-  if (!record->find_field_definition(tag))
+  if (!record->find_field_definition(tag_))
   {
     // Invalid tag
     return false;
   }
-  const vil_nitf2_field * const field = record->get_field(tag);
+  const vil_nitf2_field * const field = record->get_field(tag_);
   if (field != nullptr)
   {
     std::string value;
-    const bool is_string_value = record->get_value(tag, indexes, value, true);
+    const bool is_string_value = record->get_value(tag_, indexes, value, true);
     if (is_string_value)
     {
       // a blank std::string field actually yields a valid field value (an empty
@@ -49,10 +49,10 @@ vil_nitf2_max_field_value_plus_offset_and_threshold::operator()(vil_nitf2_field_
                                                                 int & value)
 {
   int value1 = 0;
-  const bool found = record->get_value(tag, indexes, value1, true);
-  value1 *= tag_factor;
-  value1 += offset;
-  value = (value1 < min_threshold) ? min_threshold : value1;
+  const bool found = record->get_value(tag_, indexes, value1, true);
+  value1 *= tag_factor_;
+  value1 += offset_;
+  value = (value1 < min_threshold_) ? min_threshold_ : value1;
   return found;
 }
 
@@ -62,8 +62,8 @@ vil_nitf2_multiply_field_values::operator()(vil_nitf2_field_sequence * record,
                                             int & value)
 {
   int value1 = 0, value2 = 0;
-  bool found = record->get_value(tag_1, indexes, value1, true);
-  found &= record->get_value(tag_2, indexes, value2, true);
+  bool found = record->get_value(tag_1_, indexes, value1, true);
+  found &= record->get_value(tag_2_, indexes, value2, true);
   if (found)
   {
     value = value1 * value2;
@@ -72,6 +72,6 @@ vil_nitf2_multiply_field_values::operator()(vil_nitf2_field_sequence * record,
   else
   {
     value = 0;
-    return use_zero_if_tag_not_found;
+    return use_zero_if_tag_not_found_;
   }
 }

--- a/core/vil/file_formats/vil_nitf2_field_functor.h
+++ b/core/vil/file_formats/vil_nitf2_field_functor.h
@@ -77,29 +77,29 @@ class vil_nitf2_field_value : public vil_nitf2_field_functor<T>
 {
 public:
   vil_nitf2_field_value(std::string tag)
-    : tag(std::move(tag))
+    : tag_(std::move(tag))
   {}
 
   vil_nitf2_field_value(std::string tag, std::map<T, T> overrideMap)
-    : tag(std::move(tag))
-    , overrides(std::move(overrideMap))
+    : tag_(std::move(tag))
+    , overrides_(std::move(overrideMap))
   {}
 
   vil_nitf2_field_functor<T> *
   copy() const override
   {
-    return new vil_nitf2_field_value(tag, overrides);
+    return new vil_nitf2_field_value(tag_, overrides_);
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, T & value) override
   {
-    bool success = record->get_value(tag, indexes, value, true);
+    bool success = record->get_value(tag_, indexes, value, true);
     if (success)
     {
       // check to see if this value is overridden or not
-      typename std::map<T, T>::const_iterator it = overrides.find(value);
-      if (it != overrides.end())
+      typename std::map<T, T>::const_iterator it = overrides_.find(value);
+      if (it != overrides_.end())
       {
         // found override, use it
         value = (*it).second;
@@ -109,8 +109,8 @@ public:
   }
 
 private:
-  std::string tag;
-  std::map<T, T> overrides;
+  std::string tag_;
+  std::map<T, T> overrides_;
 };
 
 //:
@@ -123,24 +123,24 @@ class vil_nitf2_multiply_field_values : public vil_nitf2_field_functor<int>
 {
 public:
   vil_nitf2_multiply_field_values(std::string tag_1, std::string tag_2, bool use_zero_if_tag_not_found = false)
-    : tag_1(std::move(tag_1))
-    , tag_2(std::move(tag_2))
-    , use_zero_if_tag_not_found(use_zero_if_tag_not_found)
+    : tag_1_(std::move(tag_1))
+    , tag_2_(std::move(tag_2))
+    , use_zero_if_tag_not_found_(use_zero_if_tag_not_found)
   {}
 
   vil_nitf2_field_functor<int> *
   copy() const override
   {
-    return new vil_nitf2_multiply_field_values(tag_1, tag_2, use_zero_if_tag_not_found);
+    return new vil_nitf2_multiply_field_values(tag_1_, tag_2_, use_zero_if_tag_not_found_);
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, int & value) override;
 
 private:
-  std::string tag_1;
-  std::string tag_2;
-  bool use_zero_if_tag_not_found;
+  std::string tag_1_;
+  std::string tag_2_;
+  bool use_zero_if_tag_not_found_;
 };
 
 //:
@@ -152,30 +152,29 @@ private:
 class vil_nitf2_max_field_value_plus_offset_and_threshold : public vil_nitf2_field_functor<int>
 {
 public:
-  vil_nitf2_max_field_value_plus_offset_and_threshold(std::string tag,
-                                                      int offset,
-                                                      int min_threshold = 0,
-                                                      int tag_factor = 1)
-    : tag(std::move(tag))
-    , offset(offset)
-    , min_threshold(min_threshold)
-    , tag_factor(tag_factor)
+  vil_nitf2_max_field_value_plus_offset_and_threshold(
+    std::string tag, int offset, int min_threshold = 0, int tag_factor = 1
+  )
+    : tag_(std::move(tag))
+    , offset_(offset)
+    , min_threshold_(min_threshold)
+    , tag_factor_(tag_factor)
   {}
 
   vil_nitf2_field_functor<int> *
   copy() const override
   {
-    return new vil_nitf2_max_field_value_plus_offset_and_threshold(tag, offset, min_threshold, tag_factor);
+    return new vil_nitf2_max_field_value_plus_offset_and_threshold(tag_, offset_, min_threshold_, tag_factor_);
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, int & value) override;
 
 private:
-  std::string tag;
-  int offset;
-  int min_threshold;
-  int tag_factor;
+  std::string tag_;
+  int offset_;
+  int min_threshold_;
+  int tag_factor_;
 };
 
 //:
@@ -189,23 +188,23 @@ class vil_nitf2_field_value_greater_than : public vil_nitf2_field_functor<bool>
 {
 public:
   vil_nitf2_field_value_greater_than(std::string tag, T threshold)
-    : tag(std::move(tag))
-    , threshold(threshold)
+    : tag_(std::move(tag))
+    , threshold_(threshold)
   {}
 
   vil_nitf2_field_functor<bool> *
   copy() const override
   {
-    return new vil_nitf2_field_value_greater_than(tag, threshold);
+    return new vil_nitf2_field_value_greater_than(tag_, threshold_);
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, bool & result) override
   {
     T value;
-    if (record->get_value(tag, indexes, value, true))
+    if (record->get_value(tag_, indexes, value, true))
     {
-      result = value > threshold;
+      result = value > threshold_;
       return true;
     }
     else
@@ -215,8 +214,8 @@ public:
   }
 
 private:
-  std::string tag;
-  T threshold;
+  std::string tag_;
+  T threshold_;
 };
 
 //:
@@ -227,20 +226,20 @@ class vil_nitf2_field_specified : public vil_nitf2_field_functor<bool>
 {
 public:
   vil_nitf2_field_specified(std::string tag)
-    : tag(std::move(tag))
+    : tag_(std::move(tag))
   {}
 
   vil_nitf2_field_functor<bool> *
   copy() const override
   {
-    return new vil_nitf2_field_specified(tag);
+    return new vil_nitf2_field_specified(tag_);
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, bool & result) override;
 
 private:
-  std::string tag;
+  std::string tag_;
 };
 
 //:
@@ -254,20 +253,20 @@ class vil_nitf2_field_value_one_of : public vil_nitf2_field_functor<bool>
 public:
   /// Constructor to specify a std::vector of acceptable values
   vil_nitf2_field_value_one_of(std::string tag, std::vector<T> acceptable_values)
-    : tag(std::move(tag))
-    , acceptable_values(std::move(acceptable_values))
+    : tag_(std::move(tag))
+    , acceptable_values_(std::move(acceptable_values))
   {}
 
   /// Constructor to specify only one acceptable value
   vil_nitf2_field_value_one_of(std::string tag, T acceptable_value)
-    : tag(std::move(tag))
-    , acceptable_values(1, acceptable_value)
+    : tag_(std::move(tag))
+    , acceptable_values_(1, acceptable_value)
   {}
 
   vil_nitf2_field_functor<bool> *
   copy() const override
   {
-    return new vil_nitf2_field_value_one_of(tag, acceptable_values);
+    return new vil_nitf2_field_value_one_of(tag_, acceptable_values_);
   }
 
   bool
@@ -275,10 +274,10 @@ public:
   {
     result = false;
     T val;
-    if (record->get_value(tag, indexes, val, true))
+    if (record->get_value(tag_, indexes, val, true))
     {
       typename std::vector<T>::iterator it;
-      for (it = acceptable_values.begin(); it != acceptable_values.end(); ++it)
+      for (it = acceptable_values_.begin(); it != acceptable_values_.end(); ++it)
       {
         if ((*it) == val)
         {
@@ -293,8 +292,8 @@ public:
   }
 
 protected:
-  std::string tag;
-  std::vector<T> acceptable_values;
+  std::string tag_;
+  std::vector<T> acceptable_values_;
 };
 
 //:
@@ -312,42 +311,42 @@ public:
   vil_nitf2_choose_field_value(std::string tag_1,
                                std::string tag_2,
                                vil_nitf2_field_functor<bool> * choose_tag_1_predicate)
-    : tag_1(std::move(tag_1))
-    , tag_2(std::move(tag_2))
-    , choose_tag_1_predicate(choose_tag_1_predicate)
+    : tag_1_(std::move(tag_1))
+    , tag_2_(std::move(tag_2))
+    , choose_tag_1_predicate_(choose_tag_1_predicate)
   {}
 
   vil_nitf2_field_functor<T> *
   copy() const override
   {
-    return new vil_nitf2_choose_field_value(tag_1, tag_2, choose_tag_1_predicate->copy());
+    return new vil_nitf2_choose_field_value(tag_1_, tag_2_, choose_tag_1_predicate_->copy());
   }
 
   ~vil_nitf2_choose_field_value() override
   {
-    if (choose_tag_1_predicate)
-      delete choose_tag_1_predicate;
+    if (choose_tag_1_predicate_)
+      delete choose_tag_1_predicate_;
   }
 
   bool
   operator()(vil_nitf2_field_sequence * record, const vil_nitf2_index_vector & indexes, T & value) override
   {
     bool choose_tag_1;
-    if ((*choose_tag_1_predicate)(record, indexes, choose_tag_1))
+    if ((*choose_tag_1_predicate_)(record, indexes, choose_tag_1))
     {
       if (choose_tag_1)
-        return record->get_value(tag_1, indexes, value, true);
+        return record->get_value(tag_1_, indexes, value, true);
       else
-        return record->get_value(tag_2, indexes, value, true);
+        return record->get_value(tag_2_, indexes, value, true);
     }
     else
       return false;
   }
 
 private:
-  std::string tag_1;
-  std::string tag_2;
-  vil_nitf2_field_functor<bool> * choose_tag_1_predicate;
+  std::string tag_1_;
+  std::string tag_2_;
+  vil_nitf2_field_functor<bool> * choose_tag_1_predicate_;
 };
 
 // Functor vil_nitf2_constant_functor defines a function that sets its

--- a/core/vpgl/file_formats/vpgl_geo_camera.cxx
+++ b/core/vpgl/file_formats/vpgl_geo_camera.cxx
@@ -35,18 +35,6 @@ vpgl_geo_camera::vpgl_geo_camera()
   trans_matrix_.fill_diagonal(1);
 }
 
-vpgl_geo_camera::vpgl_geo_camera(const vpgl_geo_camera & rhs)
-  : vpgl_camera<double>(rhs)
-  , trans_matrix_(rhs.trans_matrix_)
-  , is_utm_(rhs.is_utm_)
-  , utm_zone_(rhs.utm_zone_)
-  , northing_(rhs.northing_)
-  , scale_tag_(rhs.scale_tag_)
-{
-  this->set_lvcs(rhs.lvcs_);
-  rhs.pixel_spacing(sx_, sy_);
-}
-
 
 // camera initialization requiring GEOTIFF capabilities
 #if HAS_GEOTIFF

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -39,11 +39,11 @@ public:
 
   //: if scale tag is false be sure that trans_matrix[0][0] and trans_matrix[1][1] is 1.0 otherwise set it to true
   vpgl_geo_camera(vnl_matrix<double> trans_matrix, vpgl_lvcs_sptr lvcs)
-    : trans_matrix_(std::move(trans_matrix))
-    , is_utm_(false)
-    , scale_tag_(false)
-    , sx_(0.0)
-    , sy_(0.0)
+    : sx_(0.0),
+      sy_(0.0),
+      trans_matrix_(std::move(trans_matrix)),
+      is_utm_(false),
+      scale_tag_(false)
   {
     if (lvcs)
       this->set_lvcs(lvcs);

--- a/core/vpgl/file_formats/vpgl_geo_camera.h
+++ b/core/vpgl/file_formats/vpgl_geo_camera.h
@@ -49,9 +49,6 @@ public:
       this->set_lvcs(lvcs);
   }
 
-  // copy constructor
-  vpgl_geo_camera(const vpgl_geo_camera & rhs);
-
   vpgl_geo_camera(const vpgl_camera<double> & rhs);
 
 #if HAS_GEOTIFF
@@ -118,7 +115,6 @@ public:
     vpgl_lvcs_sptr lvcs = nullptr;
     return init_geo_camera(tfw_name, lvcs, utm_zone, northing, camera);
   }
-  ~vpgl_geo_camera() override = default;
 
   std::string
   type_name() const override

--- a/core/vpgl/vpgl_RSM_camera.h
+++ b/core/vpgl/vpgl_RSM_camera.h
@@ -133,58 +133,33 @@ template <class T>
 class vpgl_region_selector
 {
 public:
-  vpgl_region_selector()
-    : rnis_(1)
-    , cnis_(1)
-    , tnis_(0)
-    , minr_(0)
-    , maxr_(0)
-    , minc_(0)
-    , maxc_(0)
-    , rssiz_(0.0)
-    , cssiz_(0.0)
-  {
+  vpgl_region_selector() {
     row_coefs_.resize(10);
     col_coefs_.resize(10);
   }
 
-  vpgl_region_selector(std::vector<T> row_coefs,
-                       std::vector<T> col_coefs,
-                       size_t minr,
-                       size_t maxr,
-                       size_t minc,
-                       size_t maxc,
-                       size_t rnis,
-                       size_t cnis,
-                       size_t tnis,
-                       size_t rssiz,
-                       size_t cssiz)
-    : row_coefs_(row_coefs)
-    , col_coefs_(col_coefs)
-    , minr_(minr)
-    , maxr_(maxr)
-    , minc_(minc)
-    , maxc_(maxc)
-    , rnis_(rnis)
-    , cnis_(cnis)
-    , tnis_(tnis)
-    , rssiz_(rssiz)
-    , cssiz_(cssiz)
-  {}
+  vpgl_region_selector(
+    std::vector<T> row_coefs, std::vector<T> col_coefs,
+    size_t minr, size_t maxr, size_t minc, size_t maxc,
+    size_t rnis, size_t cnis, size_t tnis, size_t rssiz, size_t cssiz
+  )
+    : row_coefs_(row_coefs), col_coefs_(col_coefs), minr_(minr), maxr_(maxr)
+    , minc_(minc), maxc_(maxc), rnis_(rnis), cnis_(cnis), tnis_(tnis)
+    , rssiz_(rssiz), cssiz_(cssiz) {}
 
-  void
-  select(T X, T Y, T Z, size_t & region_row, size_t & region_col) const;
+  void select(T X, T Y, T Z, size_t & region_row, size_t & region_col) const;
+
   std::vector<T> row_coefs_;
   std::vector<T> col_coefs_;
-  size_t minr_;
-  size_t maxr_;
-  size_t minc_;
-  size_t maxc_;
-  size_t rnis_;
-  size_t cnis_;
-  size_t tnis_;
-  T rssiz_;
-  T cssiz_;
+  size_t minr_ = 0;
+  size_t maxr_ = 0;
+  size_t minc_ = 0;
+  size_t maxc_ = 0;
+  size_t rnis_ = 1;
+  size_t cnis_ = 1;
+  size_t tnis_ = 0;
+  T rssiz_ = 0.0;
+  T cssiz_ = 0.0;
 };
 
 

--- a/core/vpgl/vpgl_rational_camera.h
+++ b/core/vpgl/vpgl_rational_camera.h
@@ -353,37 +353,37 @@ public:
 
   //: set a specific scale value
   void
-  set_scale(const coor_index coor_index, const T scale)
+  set_scale(const coor_index coor_index_, const T scale)
   {
-    scale_offsets_[coor_index].set_scale(scale);
+    scale_offsets_[coor_index_].set_scale(scale);
   }
 
   //: set a specific offset value
   void
-  set_offset(const coor_index coor_index, const T offset)
+  set_offset(const coor_index coor_index_, const T offset)
   {
-    scale_offsets_[coor_index].set_offset(offset);
+    scale_offsets_[coor_index_].set_offset(offset);
   }
 
   //: get a specific scale value
   T
-  scale(const coor_index coor_index) const
+  scale(const coor_index coor_index_) const
   {
-    return scale_offsets_[coor_index].scale();
+    return scale_offsets_[coor_index_].scale();
   }
 
   //: get a specific offset value
   T
-  offset(const coor_index coor_index) const
+  offset(const coor_index coor_index_) const
   {
-    return scale_offsets_[coor_index].offset();
+    return scale_offsets_[coor_index_].offset();
   }
 
   //: get a specific scale_offset
   vpgl_scale_offset<T>
-  scl_off(const coor_index coor_index) const
+  scl_off(const coor_index coor_index_) const
   {
-    return scale_offsets_[coor_index];
+    return scale_offsets_[coor_index_];
   }
 
   // --- Often useful for adjusting the camera ---


### PR DESCRIPTION
Provides fixes for compiler warnings generated when explicitly enabled for gcc or MSVC:
* Fixed instantiation order of fields of various classes to match the order they are defined (and therefore instantiated in) within the class definition: `vpgl_geo_camera`, `vsph_unit_sphere`, `vdgl_edgel_chain`, `vdgl_interpolator`, `bpgl_geotif_camera`, `vsph_spherical_coord`, `reg_progress`, `bvgl_grid_index_3d`, `bvgl_register_ptsets_3d_rigid`, `acal_tile_data_manager`, `match_edge`, `acal_match_tree_lsqr`, `acal_match_tree_solver`, `acal_intertile_solver_lsqr`, `acal_intertile_graph_solver`, `vpgl_region_selector`, `planar_feature_params`, `planar_match_score`, `acal_single_track_solver`
* Removed user-defined `vdgl_edgel::operator=`, as it appears [identical to the default copy assignment operator](https://stackoverflow.com/a/3278636) C++ generates. If a user-defined copy assignment operator is provided, then C++ assumes it has some logic that the default copy assignment operator can't handle. Thus, most likely [a user-defined copy constructor is also needed, and so the default copy constructor is marked as deprecated if it is used](https://stackoverflow.com/a/51864979), and similarly for the default destructor.
  * Similar fix for `bwm_io_tab_config`, `vgl_polygon`, `vgl_line_segment_2d`, and `vpgl_geo_camera`, regarding their copy constructors (`vpgl_geo_camera`'s user-defined copy constructor was additionally buggy, setting parameters in the reverse direction).

Other fixes in order of appearance:
* `contrib/brl/b3p/expatpp/expatpp.h`: Fixes unused parameter warning for `expatppNesting::OwnedChildOrphansItself` when building in Release mode, as the parameter is only used in an `assert` statement which compiles down to nothing if not in Debug mode.
* `contrib/brl/bbas/bpgl/acal/acal_{match_utils, metadata}.h`: Fix conversion issue with default value for field `id_` in `acal_corr` and default value for variable `id` in `acal_metadata`.
* `contrib/brl/bbas/bvgl/bvgl_grid_index_3d.h`: Shadowing declarations of `temp` in `bvgl_grid_index_3d::intersecting_cells`; one was used for swapping variables, replaced it with `std::swap`.
* `contrib/brl/bbas/bwm/io/bwm_io_structs.h` Fixed shadowing warnings for fields/parameters of `bwm_io_tab_config` by adding `_` to each field name.
* `contrib/gel/vsol/vsol_point_{2, 3}d.h`: Fixed ambiguous indentation in `vsol_point_2d::describe` and `vsol_point_3d::describe`
* `core/vgl/vgl_pointset_3d.h`: Fixed uninitialized variable warnings in `vgl_pointset_3d`'s `operator>>`
* `core/vil/file_formats/vil_nitf2_field_functor.{h, cxx}`: Fixed shadowing warnings for field/parameters by adding `_` to each field name.
* `core/vpgl/vpgl_rational_camera.h`: Fixed shadowing warnings for parameters that shadowed a class `enum`, by adding `_` to each parameter name.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
