### PR TITLE
DOC: Add top-level LICENSE file (resolves #752)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,40 @@
+VXL is distributed under the 3-clause BSD license reproduced below.
+
+Files in the contrib/ subtree may carry additional copyright notices
+or alternate license terms from their original authors (Oxford VGG,
+University of Western Australia, Brown University, and others).
+Refer to the per-file headers in those subdirectories for the
+applicable terms.
+
+------------------------------------------------------------------------
+
+Copyright 2000-2013 VXL Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of their
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ applicable terms.
 
 ------------------------------------------------------------------------
 
-Copyright 2000-2013 VXL Contributors
+Copyright 2000-2026 VXL Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/core/vxl_copyright.h
+++ b/core/vxl_copyright.h
@@ -1,7 +1,7 @@
 #ifndef vxl_copyright_h_
 #define vxl_copyright_h_
 
-// Copyright 2000-2013 VXL Contributors
+// Copyright 2000-2026 VXL Contributors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Adds a top-level `LICENSE` file containing the 3-clause BSD text that vxl has shipped under since 2000, and bumps the copyright end date to 2026. Two commits: (1) add LICENSE verbatim from `core/vxl_copyright.h`, (2) update the copyright span everywhere it appears.

Resolves #752.

<details>
<summary>Why a top-level LICENSE matters</summary>

The license text has lived only inside `core/vxl_copyright.h` since 2013. Distribution packagers (Fedora, FreeBSD, Debian, vcpkg) expect a top-level `LICENSE` or `COPYING` file and have repeatedly tripped on its absence — see the original issue.

The file added here is the same BSD-3 text already in `core/vxl_copyright.h`, lifted verbatim into a path that `setuptools` / `dpkg` / `rpmlint` / `pkg-config` / vcpkg's `cmake_install` machinery already look for.

A short header notes that `contrib/` subdirectories may carry additional copyright notices or alternate license terms from their original authors (Oxford VGG, University of Western Australia, Brown University, and others); the per-file headers under `contrib/` continue to be authoritative for those.

</details>

<details>
<summary>Commit 2 scope</summary>

Bumps `Copyright 2000-2013 VXL Contributors` to `Copyright 2000-2026 VXL Contributors` in the two carriers of the copyright statement: the new `LICENSE` and `core/vxl_copyright.h`. No other files in the tree carry the literal `Copyright 2000-2013 VXL Contributors` string.

</details>

<!--
provenance: claude-code session 2026-05-07 (add-license)
related_files:
  - LICENSE (new)
  - core/vxl_copyright.h
post_merge_action: close #752
-->
