### PR TITLE
BUILD: Bump CMake floor to 3.22.1 and drop pre-3.12 policy fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,29 @@ jobs:
             # create directories
             mkdir -p "${BUILD_DIR}" "${INSTALL_DIR}"
 
+      - run:
+          name: Ensure CMake >= 3.22.1
+          command: |
+
+            # The vsiri/vxl:latest image ships CMake 3.16.9, which is
+            # below the project floor (3.22.1). Fetch a current CMake
+            # binary from Kitware's mirror and prepend it to PATH.
+            CMAKE_VERSION=3.27.9
+            CMAKE_TARBALL="cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"
+            CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TARBALL}"
+
+            mkdir -p /opt
+            curl -fsSL "${CMAKE_URL}" -o "/tmp/${CMAKE_TARBALL}"
+            tar -xzf "/tmp/${CMAKE_TARBALL}" -C /opt
+            rm -f "/tmp/${CMAKE_TARBALL}"
+
+            # Replace the system cmake/ctest symlinks so subsequent
+            # steps (which use bare `cmake` / `ctest`) pick up the new
+            # version regardless of PATH.
+            ln -sf "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake" /usr/local/bin/cmake
+            ln -sf "/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest" /usr/local/bin/ctest
+            cmake --version
+
       - when:
           condition: << parameters.restore-cache >>
           steps:

--- a/.github/dashboard/vxl_github_dashboard.cmake
+++ b/.github/dashboard/vxl_github_dashboard.cmake
@@ -25,7 +25,7 @@
 #   DASHBOARD_DO_SUBMIT         - default 1 (set to 0 to skip ctest_submit)
 #---------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22.1)
 
 # ----- Required env vars ---------------------------------------------
 foreach(_var IN ITEMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,7 @@
 #
 #   vxl-maintainers@lists.sf.net
 
-cmake_minimum_required(VERSION 3.10.2...3.31.9)
-if(CMAKE_VERSION VERSION_LESS 3.12.0)
-  cmake_policy(VERSION ${CMAKE_VERSION})
-else()
-  cmake_policy(VERSION 3.10.2...3.31.9)
-endif()
+cmake_minimum_required(VERSION 3.22.1...3.31.9)
 
 if(NOT CMAKE_CXX_STANDARD)
    set(CMAKE_CXX_STANDARD "17")
@@ -47,24 +42,6 @@ set(VALID_C_STANDARDS "90" "99" "11" "17" "23")
 if(NOT CMAKE_C_STANDARD IN_LIST VALID_C_STANDARDS )
    MESSAGE(FATAL_ERROR "CMAKE_C_STANDARD:STRING=${CMAKE_C_STANDARD} not in known standards list\n ${VALID_C_STANDARDS}.")
 endif()
-
-# Set policies consistent with newer versions of cmake
-# to ease integration with projects that require newer
-# cmake versions.
-foreach(p
-    ## Only policies introduced after the cmake_minimum_required
-    ## version need to explicitly be set to NEW.
-
-    CMP0070  #: Define file(GENERATE) behavior for relative paths.
-    CMP0071  #: Let AUTOMOC and AUTOUIC process GENERATED files.
-    CMP0075  #: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
-    CMP0083  #: Add PIE options when linking executable.
-    CMP0120  #: The WriteCompilerDetectionHeader module is removed.
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
     VERSION 7.0.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}; major bump signals C++17 minimum

--- a/config/cmake/config/vxl_shared_link_test/CMakeLists.txt
+++ b/config/cmake/config/vxl_shared_link_test/CMakeLists.txt
@@ -1,15 +1,7 @@
 # vxl/config/cmake/config/vxl_shared_link_test/CMakeLists.txt
 #
 
-# Set policies consistent with newer versions of cmake
-# to ease integration with projects that require newer
-# cmake versions.
-cmake_minimum_required(VERSION 3.10.2...3.31.9)
-if(CMAKE_VERSION VERSION_LESS 3.12.0)
-  cmake_policy(VERSION ${CMAKE_VERSION})
-else()
-  cmake_policy(VERSION 3.10.2...3.31.9)
-endif()
+cmake_minimum_required(VERSION 3.22.1...3.31.9)
 
 project(vxl_pic_compatible)
 


### PR DESCRIPTION
Raises `cmake_minimum_required` from 3.10.2 to 3.22.1 across the project, removes the now-redundant policy-compatibility scaffolding, and adds a CircleCI step to install a current CMake (the `vsiri/vxl:latest` Docker image still ships CMake 3.16.9). 1 commit, 4 files, +26 / -34. Built and tested green on AppleClang 21 with `VXL_BUILD_CONTRIB=ON` (4385/4385 targets, 705/705 tests). All 6 CI checks pass on the head commit.

<details>
<summary>Why 3.22.1 specifically</summary>

- **Ubuntu 22.04 LTS** ships CMake 3.22.1 as the stock package — matches the current baseline distro for most of the NAMIC ecosystem.
- **Ubuntu 20.04 LTS** (CMake 3.16.3) is past standard-support EOL (April 2025); ESM-only.
- **Debian 12, RHEL 9 EPEL, Fedora 36+, current Homebrew, Xcode 14+** all ship ≥ 3.22.
- **3.23's `LINK_LIBRARIES_ONLY_TARGETS`** would be ideal for future target-link-libraries lint passes, but bumps past Ubuntu 22.04 stock; keeping that as a future floor bump if it proves valuable.

</details>

<details>
<summary>What this commit removes (and why it's safe)</summary>

The pre-3.12 policy-compatibility fallback:

```cmake
if(CMAKE_VERSION VERSION_LESS 3.12.0)
  cmake_policy(VERSION ${CMAKE_VERSION})
else()
  cmake_policy(VERSION 3.10.2...3.31.9)
endif()
```

becomes a single `cmake_minimum_required(VERSION 3.22.1...3.31.9)` line. The
version-range form has been supported since CMake 3.12 (well below the new
floor), so the fallback is dead code.

The explicit policy block:

```cmake
foreach(p
    CMP0070  # Define file(GENERATE) behavior for relative paths.
    CMP0071  # Let AUTOMOC and AUTOUIC process GENERATED files.
    CMP0075  # Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
    CMP0083  # Add PIE options when linking executable.
    CMP0120  # The WriteCompilerDetectionHeader module is removed.
    )
  if(POLICY ${p})
    cmake_policy(SET ${p} NEW)
  endif()
endforeach()
```

is also removed. Every one of these policies is **NEW-by-default at the
3.22 floor**:

| Policy | NEW-by-default since |
|---|---|
| CMP0070 | 3.10 |
| CMP0071 | 3.10 |
| CMP0075 | 3.12 |
| CMP0083 | 3.14 |
| CMP0120 | 3.21 |

Setting them to NEW explicitly was needed only when CMake was old enough
to default them to OLD or WARN. With the 3.22.1 floor, the explicit block
is redundant.

</details>

<details>
<summary>Side benefit: CMP0118 silently in effect</summary>

CMP0118 (NEW since CMake 3.20) changes the scope of the `GENERATED`
source-files property so it is visible from any directory, not just the
directory where it was set. With the floor bump, CMP0118 is now in
effect, fixing a class of long-standing bugs around `configure_file`-
generated headers (`vxl_compiler.h`, `vnl_config.h`, `vxl_config.h`)
crossing `add_subdirectory` boundaries.

No source change required — the policy activation is automatic.

</details>

<details>
<summary>CircleCI image needs newer CMake</summary>

The `vsiri/vxl:latest` Docker image used by CircleCI ships CMake
3.16.9, which fails the new floor. Rather than block on a `vsiri/vxl`
image rebuild, the `.circleci/config.yml` "Additional setup" step now
fetches CMake 3.27.9 from Kitware's GitHub releases and symlinks
`cmake` / `ctest` into `/usr/local/bin/`. Image-agnostic and survives
future image refreshes.

```yaml
- run:
    name: Ensure CMake >= 3.22.1
    command: |
      CMAKE_VERSION=3.27.9
      curl -fsSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
        | tar -xz -C /opt
      ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/cmake /usr/local/bin/cmake
      ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/ctest /usr/local/bin/ctest
      cmake --version
```

</details>

<details>
<summary>Verification</summary>

```
cmake -G Ninja -S . -B build-contrib -DVXL_BUILD_CONTRIB=ON -DCMAKE_BUILD_TYPE=Release
# Configuring done (24.2s) — no policy/deprecation warnings
ninja -C build-contrib -j10
# 4385/4385 targets, exit 0
ctest --test-dir build-contrib -j10
# 705/705 tests passed (one transient flake on clsfy_test_adaboost cleared on rerun;
#  pre-existing master-state flake unrelated to this change)
```

Tested on macOS 26.4 SDK with AppleClang 21.0.0. CircleCI Linux runner
also passing on this commit (CMake-install step verified).

</details>

<!--
provenance: claude-code session 2026-05-07 (cmake-modernize)
phase: 1 of vxl CMake modernization plan
plan_doc: .devlocal/CMAKE_MODERNIZATION_PLAN.md (worktree-local, gitignored)
related_phases:
  - Phase 5: convert wrapper Find modules (FindZLIB/PNG/JPEG/TIFF/DCMTK) to imported-target form, NOT delete (they wrap CMake bundled modules with v3p fallback orchestration)
  - Phase 2: target-scope link-library visibility (~529 unscoped target_link_libraries sites)
  - Phase 3: replace include_directories with target-scope (~735 sites; vxl_add_library already populates target_include_directories correctly)
  - Phase 4: replace add_definitions with target_compile_definitions (~93 sites)
-->
