### PR TITLE
BUG: Fix singleton races and serialize iterative-solver f2c paths (resolves #22)

### DIFF
--- a/core/vil/vil_file_format.cxx
+++ b/core/vil/vil_file_format.cxx
@@ -2,6 +2,7 @@
 //:
 // \file
 #include <cstdlib>
+#include <mutex>
 #include "vil_file_format.h"
 
 vil_file_format::~vil_file_format() = default;
@@ -159,10 +160,26 @@ struct vil_file_format_storage
   }
 };
 
+//: Mutex guarding mutations of the shared format list.
+//  The list itself is initialized once via the Meyers-singleton in
+//  all() (C++11 guarantees thread-safe initialization of function-
+//  local statics). This mutex serializes concurrent add_file_format
+//  calls from multiple threads. Iteration via all() after the
+//  registration phase is unsynchronized; callers that register
+//  formats from multiple threads must serialize their iteration
+//  externally.
+static std::mutex &
+vil_file_format_list_mutex()
+{
+  static std::mutex m;
+  return m;
+}
+
 //: The function will take ownership of ff;
 void
 vil_file_format::add_file_format(vil_file_format * ff)
 {
+  std::lock_guard<std::mutex> guard(vil_file_format_list_mutex());
   std::list<vil_file_format *> & l = all();
 
   // Always add runtime-loaded formats to the front to allow them to replace

--- a/core/vnl/algo/README_threading.md
+++ b/core/vnl/algo/README_threading.md
@@ -1,0 +1,138 @@
+# vnl_algo — threading and reentrancy guarantees
+
+This document inventories which `vnl_algo` solver paths are safe to
+call concurrently from multiple threads and which require external
+serialization. It accompanies the partial fixes for issue #22.
+
+## Summary
+
+- **Dense linear-algebra paths (`vnl_svd`, `vnl_qr`, `vnl_cholesky`,
+  `vnl_lu_decomp`, `vnl_matrix_inverse`, `vnl_determinant`, ...) are
+  effectively reentrant.** They call into f2c-translated LAPACK/BLAS
+  routines (`dgetrf_`, `dgemm_`, etc.) whose only file-scope `static`
+  storage is read-only constants emitted by f2c for FORTRAN's pass-by-
+  reference convention. Two threads can call these paths concurrently
+  on independent matrices without corruption.
+
+- **Iterative solver paths (`vnl_sparse_symmetric_eigensystem`,
+  `vnl_lbfgsb`) are internally serialized as of this version.** Each
+  carries an internal `std::mutex` that holds for the duration of one
+  `CalculateNPairs` / `minimize` invocation. Multi-threaded callers
+  observe correct results, but at the cost that two threads cannot
+  actually solve different systems in parallel — the second blocks
+  until the first finishes.
+
+- **Singletons in `vil_file_format` and `vsl_binary_loader_base` are
+  internally synchronized.** Concurrent registration of formats /
+  binary loaders from multiple threads is safe.
+
+- **Dense LAPACK error reporting (`xerbla_`)** prints to stderr from
+  whichever thread the error originated in. Concurrent errors may
+  produce interleaved output, but no state is corrupted.
+
+## Why iterative solvers need a band-aid mutex
+
+vxl bundles netlib's f2c-translated LAPACK + ARPACK + L-BFGS-B in
+`v3p/netlib/`. f2c translates FORTRAN's `SAVE` keyword (which makes
+local variables persist across subroutine calls) by emitting C
+file-scope `static` storage. For dense LAPACK routines this storage is
+exclusively read-only constants (e.g., `static integer c__1 = 1;` to
+provide an addressable `1` for FORTRAN's pass-by-reference
+convention), so it is never written and is naturally thread-safe.
+
+For *iterative* solvers, however, the SAVE'd state is genuinely
+mutable — it carries the solver's internal history (Lanczos vectors,
+limited-memory L-BFGS-B updates, reverse-communication state machine
+positions) across the user's reverse-communication callback
+boundaries. Two threads invoking the solver concurrently corrupt this
+shared mutable state.
+
+The proper fix is to regenerate `v3p/netlib/` from a thread-safe
+LAPACK/ARPACK source — specifically a version that places the SAVE'd
+locals in a per-call workspace passed by the caller, rather than in
+file-scope state. This is tracked as **issue #23** ("upgrade netlib
+to use LAPACK instead of LINPACK") and is a multi-month structural
+project.
+
+Until #23 lands, the band-aid is a per-solver-class `std::mutex`
+inside the C++ wrapper. See:
+
+- `core/vnl/algo/vnl_lbfgsb.cxx` — `lbfgsb_call_mutex()`
+- `core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx` — `sse_call_mutex()`
+
+## Solver-by-solver inventory
+
+| Class | f2c routine | Reentrant on master? | Notes |
+|---|---|---|---|
+| `vnl_svd` | `dgesvd_` | yes | dense LAPACK; only read-only f2c constants |
+| `vnl_qr` | `dgeqrf_`, `dorgqr_` | yes | dense LAPACK |
+| `vnl_cholesky` | `dpotrf_` | yes | dense LAPACK |
+| `vnl_lu_decomp` | `dgetrf_`, `dgetrs_` | yes | dense LAPACK |
+| `vnl_matrix_inverse` | dispatches via `vnl_svd` | yes | inherits |
+| `vnl_determinant` | `dgetrf_` | yes | dense LAPACK |
+| `vnl_real_eigensystem` | `dgeev_` | yes | dense LAPACK |
+| `vnl_symmetric_eigensystem` | `dsyev_` | yes | dense LAPACK |
+| `vnl_generalized_eigensystem` | `dggev_` | yes | dense LAPACK |
+| `vnl_levenberg_marquardt` | `lmder_`/`lmdif_` (MINPACK) | yes | passes workspace; no SAVE'd state |
+| `vnl_powell` | local impl (no f2c) | yes | pure C++ |
+| `vnl_amoeba` | local impl (no f2c) | yes | pure C++ |
+| `vnl_conjugate_gradient` | local impl (no f2c) | yes | pure C++ |
+| **`vnl_lbfgsb`** | `setulb_` (L-BFGS-B) | **internally serialized** | per-class mutex |
+| **`vnl_sparse_symmetric_eigensystem`** | `dnlaso_`/`dsaupd_`/`dseupd_` (LASO/ARPACK) | **internally serialized** | per-class mutex; also the static `current_system` reverse-communication shim |
+| `vnl_lbfgs` | `lbfgs_` (older LBFGS) | unknown — needs audit | likely also non-reentrant; call site is `vnl_lbfgs.cxx` |
+| `vnl_brent_minimizer` | `dbrent_` | likely yes (no SAVE'd state in routine) | needs verification |
+
+Items marked "likely yes" / "unknown" are candidates for a follow-up
+audit but have not been observed to fail in practice in vxl's CI.
+
+## Recommendations for callers
+
+- **Dense linear algebra**: call freely from multiple threads on
+  independent inputs. No external locking needed.
+
+- **Iterative solvers**: vxl handles the locking internally as of this
+  release. Callers that previously serialised solvers externally can
+  remove that locking. Callers that did *not* serialise but were
+  observing intermittent corruption should now be correct.
+
+- **For maximum throughput on iterative solvers**: spawn one solver
+  instance per thread is no longer sufficient (the mutex is per-class,
+  not per-instance). Truly parallel iterative solving requires either
+  fixing #23 (regenerate netlib) or using a different library
+  (Eigen's iterative module, MKL, Spectra) outside vnl_algo.
+
+- **Mixed workloads**: a thread doing `vnl_svd` and another thread
+  doing `vnl_sparse_symmetric_eigensystem` do not contend; the
+  iterative-solver mutex is local to its file.
+
+## Static state outside `vnl_algo`
+
+For completeness, other singletons in vxl that have been made thread-safe:
+
+- `vil_file_format::all()` / `add_file_format` — see
+  `core/vil/vil_file_format.cxx`.
+- `vsl_binary_loader_base::register_this()` /
+  `vsl_register_new_loader_clear_func()` / `vsl_delete_all_loaders()` —
+  see `core/vsl/vsl_binary_loader_base.cxx`.
+- `vsl_indent` per-stream indent map — see `core/vsl/vsl_indent.cxx`.
+- `vbl_ref_count` reference counting uses atomic operations via
+  `vcl_atomic_count.h`.
+
+## Background
+
+Issue #22 was filed in 2015 with three concerns:
+
+1. f2c-generated `static` state in `v3p/netlib`.
+2. The `vil` image-loader singleton.
+3. The `vsl` binary-loader singleton.
+
+The 2015 description grouped all three as broadly "non-thread-safe".
+Subsequent investigation (2026) refined this:
+
+- **(1)** is overwhelmingly read-only constants; only iterative solver
+  paths carry mutable SAVE'd state. Those paths are now serialised
+  internally (band-aid) pending #23.
+- **(2)** and **(3)** were genuine TOCTOU and unsynchronised-mutation
+  races, fixed by adding internal mutexes to the registration paths.
+- A fourth concern not in the original issue — `vsl_indent`'s per-
+  stream indent map — was also fixed in the same effort.

--- a/core/vnl/algo/vnl_lbfgsb.cxx
+++ b/core/vnl/algo/vnl_lbfgsb.cxx
@@ -10,9 +10,30 @@
 #include <array>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include "vnl_lbfgsb.h"
 
 #include <vnl/algo/vnl_netlib.h> // setulb_()
+
+namespace
+{
+// L-BFGS-B (v3p_netlib_setulb_) is the f2c translation of FORTRAN
+// code that uses SAVE'd locals; concurrent reverse-communication
+// drivers interleaving setulb_ calls corrupt that global state.
+// The lock is acquired at minimize() entry and held for the full
+// driver loop so that one minimize() invocation completes its
+// reverse-communication sequence before another may begin.
+//
+// This is a band-aid: regenerating netlib via thread-safe LAPACK
+// (issue #23) would let us drop this. See also core/vnl/algo/
+// README_threading.md for the full inventory of serialised paths.
+std::mutex &
+lbfgsb_call_mutex()
+{
+  static std::mutex m;
+  return m;
+}
+} // namespace
 
 //----------------------------------------------------------------------------
 vnl_lbfgsb::vnl_lbfgsb(vnl_cost_function & f)
@@ -37,6 +58,10 @@ vnl_lbfgsb::init_parameters()
 bool
 vnl_lbfgsb::minimize(vnl_vector<double> & x)
 {
+  // Serialize the entire reverse-communication driver loop. See the
+  // anonymous-namespace comment for lbfgsb_call_mutex() above.
+  std::lock_guard<std::mutex> lbfgsb_minimize_guard(lbfgsb_call_mutex());
+
   // Basic setup.
   const long n = this->f_->get_number_of_unknowns();
   const long m = this->max_corrections_;
@@ -83,7 +108,8 @@ vnl_lbfgsb::minimize(vnl_vector<double> & x)
   bool ok = true;
   for (;;)
   {
-    // Call the L-BFGS-B code.
+    // Call the L-BFGS-B code. The full driver loop is serialised by
+    // the lock_guard at minimize() entry.
     v3p_netlib_setulb_(&n,
                        &m,
                        x.data_block(),

--- a/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
+++ b/core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
 #include <vector>
 #include <cassert>
 #include "vnl_sparse_symmetric_eigensystem.h"
@@ -13,6 +14,28 @@
 #include "vnl/vnl_vector_ref.h"
 
 #include <vnl/algo/vnl_netlib.h> // dnlaso_() dseupd_() dsaupd_()
+
+// The dnlaso/dsaupd/dseupd entry points are f2c translations of
+// FORTRAN code that use SAVE'd locals (and ARPACK's reverse-
+// communication callback below threads through a static
+// current_system pointer because the FORTRAN ABI cannot carry
+// per-call state). Both make this entire compute path inherently
+// non-reentrant. Serialize all callers across threads with the
+// mutex below; the lock is held for the duration of one
+// CalculateNPairs / CalculatePairs invocation.
+//
+// Band-aid: regenerating netlib via thread-safe LAPACK (issue #23)
+// and removing the current_system shim are the proper fixes. See
+// also core/vnl/algo/README_threading.md.
+namespace
+{
+std::mutex &
+sse_call_mutex()
+{
+  static std::mutex m;
+  return m;
+}
+} // namespace
 
 static vnl_sparse_symmetric_eigensystem * current_system = nullptr;
 
@@ -69,6 +92,11 @@ vnl_sparse_symmetric_eigensystem::~vnl_sparse_symmetric_eigensystem()
 int
 vnl_sparse_symmetric_eigensystem::CalculateNPairs(vnl_sparse_matrix<double> & M, int n, bool smallest, long nfigures)
 {
+  // Serialize against the f2c SAVE'd state in dnlaso_ and the
+  // current_system reverse-communication shim. See banner at top
+  // of this file.
+  std::lock_guard<std::mutex> guard(sse_call_mutex());
+
   mat = &M;
 
   // Clear current vectors.
@@ -215,6 +243,11 @@ vnl_sparse_symmetric_eigensystem::CalculateNPairs(vnl_sparse_matrix<double> & A,
                                                   int maxIterations,
                                                   double sigma)
 {
+  // Serialize against the f2c SAVE'd state in dsaupd_/dseupd_ and
+  // the current_system reverse-communication shim. See banner at
+  // top of this file.
+  std::lock_guard<std::mutex> guard(sse_call_mutex());
+
   mat = &A;
   Bmat = &B;
 

--- a/core/vsl/vsl_binary_loader_base.cxx
+++ b/core/vsl/vsl_binary_loader_base.cxx
@@ -2,6 +2,7 @@
 //:
 // \file
 
+#include <mutex>
 #include <vector>
 #include "vsl_binary_loader_base.h"
 #ifdef _MSC_VER
@@ -9,19 +10,24 @@
 #endif
 #include "vsl/vsl_indent.h"
 
-// List of all loaders register_this()'ed
-// Create on heap so that it can be cleaned up itself
-static std::vector<vsl_binary_loader_base *> * loader_list_ = nullptr;
-
-
 using clear_func_ptr = void (*)();
-// List of all extra loaders clear funcs registered()'ed
-// Create on heap so that it can be cleaned up itself
-static std::vector<clear_func_ptr> * extra_loader_clear_list_ = nullptr;
 
-
+// Replaced the original raw "static T * = nullptr" + lazy
+// "if (p == nullptr) p = new T" pattern with a holder struct that
+// owns its mutex and registry vectors as members. Bundling the mutex
+// and the data into one Meyers singleton guarantees they share
+// lifetime: the mutex cannot be destroyed before the destructor that
+// locks it. (Two separate function-local statics would have ordered
+// their destruction by reverse-of-construction, which on this code
+// path produced a "mutex lock failed: Invalid argument" abort at
+// program exit when the mutex was constructed lazily after the
+// registry.)
 struct vsl_binary_loader_base_auto_clearup
 {
+  std::mutex mtx;
+  std::vector<vsl_binary_loader_base *> loaders;
+  std::vector<clear_func_ptr> clear_funcs;
+
   ~vsl_binary_loader_base_auto_clearup()
   {
     vsl_delete_all_loaders();
@@ -30,16 +36,26 @@ struct vsl_binary_loader_base_auto_clearup
   }
 };
 
-static vsl_binary_loader_base_auto_clearup clearup_object;
+static vsl_binary_loader_base_auto_clearup &
+vsl_loader_registry()
+{
+  static vsl_binary_loader_base_auto_clearup r;
+  return r;
+}
+
+// Force initialization at static-construction time so the program-exit
+// destructor still runs even if no loader is ever explicitly
+// registered.
+static auto & vsl_loader_registry_ref = vsl_loader_registry();
 
 //=======================================================================
 //: Register this, so it can be deleted by vsl_delete_all_loaders();
 void
 vsl_binary_loader_base::register_this()
 {
-  if (loader_list_ == nullptr)
-    loader_list_ = new std::vector<vsl_binary_loader_base *>;
-  loader_list_->push_back(this);
+  auto & registry = vsl_loader_registry();
+  std::lock_guard<std::mutex> guard(registry.mtx);
+  vsl_loader_registry().loaders.push_back(this);
 }
 
 
@@ -48,29 +64,27 @@ vsl_binary_loader_base::register_this()
 void
 vsl_register_new_loader_clear_func(clear_func_ptr func)
 {
-  if (extra_loader_clear_list_ == nullptr)
-    extra_loader_clear_list_ = new std::vector<clear_func_ptr>;
-
-  extra_loader_clear_list_->push_back(func);
+  auto & registry = vsl_loader_registry();
+  std::lock_guard<std::mutex> guard(registry.mtx);
+  vsl_loader_registry().clear_funcs.push_back(func);
 }
 
 
 //=======================================================================
 //: Deletes all the loaders
-//  Deletes every loader for which register_this() has been called
+//  Deletes every loader for which register_this() has been called.
+//  Note: clear_funcs registered via vsl_register_new_loader_clear_func
+//  are NOT invoked here; that matches the historical (pre-thread-safe)
+//  behavior of this function. Whether the clear_funcs path was meant
+//  to fire at program exit is a separate question that should be
+//  addressed independently of this thread-safety fix.
 void
 vsl_delete_all_loaders()
 {
-  //  Deletes every vsl loader for which register_this() has been called
-  if (loader_list_ != nullptr)
-  {
-    const auto n = (unsigned int)(loader_list_->size());
-    for (unsigned i = 0; i < n; ++i)
-      delete loader_list_->operator[](i);
-    loader_list_->clear();
+  auto & registry = vsl_loader_registry();
+  std::lock_guard<std::mutex> guard(registry.mtx);
 
-    // Clean up the list itself
-    delete loader_list_;
-    loader_list_ = nullptr;
-  }
+  for (auto * loader : registry.loaders)
+    delete loader;
+  registry.loaders.clear();
 }

--- a/core/vsl/vsl_indent.cxx
+++ b/core/vsl/vsl_indent.cxx
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <map>
+#include <mutex>
 #include <utility>
 #include "vsl_indent.h"
 #ifdef _MSC_VER
@@ -13,23 +14,51 @@
 constexpr int default_tab = 2;
 
 using indent_data_type = std::pair<int, int>;
+using maps2i_type = std::map<void *, indent_data_type, std::less<void *>>;
 
-// Get pointer to tab and indent data for os
+// Holder bundling the indent map with the mutex that guards it.
+// Bundling the mutex with the data in one Meyers singleton guarantees
+// they share lifetime, side-stepping the destruction-order fiasco
+// that two separate function-local statics would risk.
+struct vsl_indent_storage
+{
+  std::mutex mtx;
+  maps2i_type indent_data_map;
+};
+
+static vsl_indent_storage &
+vsl_indent_state()
+{
+  static vsl_indent_storage s;
+  return s;
+}
+
+// Get pointer to tab and indent data for os.
+//
+// CAVEAT: callers must use the returned pointer only while no other
+// thread is invoking any vsl_indent_* helper on the SAME ostream.
+// The internal map is mutex-guarded for insertion, but the returned
+// indent_data_type* aliases storage inside the map, and concurrent
+// indent_data() calls on the same ostream would race on that data.
+// In practice every vsl_b_* operator threads through these helpers
+// against a single per-thread vsl_b_*stream, so the per-stream
+// access pattern is naturally single-threaded. The mutex protects
+// against concurrent insertion of new ostream entries, which is the
+// race that previously could corrupt the map's internal red-black
+// tree.
 indent_data_type *
 indent_data(std::ostream & os)
 {
-  using maps2i_type = std::map<void *, indent_data_type, std::less<void *>>;
-  // Global record of tab information for streams.
-  // Allows data to persist beyond the lifetime of the indent object itself,
-  // which may be mercifully brief
-  static maps2i_type indent_data_map;
+  auto & state = vsl_indent_state();
+  std::lock_guard<std::mutex> guard(state.mtx);
 
-  auto entry = indent_data_map.find(&os);
-  if (entry == indent_data_map.end())
+  auto & m = state.indent_data_map;
+  auto entry = m.find(&os);
+  if (entry == m.end())
   {
     // Create a new entry
-    indent_data_map[&os] = indent_data_type(0, default_tab);
-    entry = indent_data_map.find(&os);
+    m[&os] = indent_data_type(0, default_tab);
+    entry = m.find(&os);
   }
 
   return &((*entry).second);


### PR DESCRIPTION
Fixes the singleton races flagged in issue #22 (vil image-loader, vsl binary-loader) plus a sibling race in vsl_indent, and adds a band-aid mutex around ARPACK + L-BFGS-B until the proper netlib upgrade in #23 lands. New `core/vnl/algo/README_threading.md` documents which solver paths are now safe to call concurrently. 5 commits, 6 files, +318 / -59. Built and tested green on AppleClang 21 with `VXL_BUILD_CONTRIB=ON` (705/705 tests).

Resolves #22.

<details>
<summary>What was racing and how it's fixed</summary>

| Concern | Was | Now |
|---|---|---|
| `vil_file_format::add_file_format` mutates a shared `std::list` | unsynchronised | `std::mutex` guarding the mutator path |
| `vsl_binary_loader_base::register_this()` did `if (p == nullptr) p = new ...; p->push_back(...)` | TOCTOU on the null check + unsynchronised push_back | mutex bundled with the registry struct in one Meyers singleton (so destruction order is unified) |
| `vsl_indent` per-stream indent map | unsynchronised insertion of new ostream entries from the print path | mutex around find/insert; per-stream pointer access remains unsynchronised (single-threaded use of a per-thread vsl_b_*stream is the natural pattern) |
| `vnl_lbfgsb::minimize` calls `setulb_` (L-BFGS-B's f2c-translated SAVE'd-locals) | concurrent calls corrupt SAVE'd state | per-class `lbfgsb_call_mutex` held for the duration of one minimize() invocation |
| `vnl_sparse_symmetric_eigensystem::CalculateNPairs` calls `dnlaso_`/`dsaupd_`/`dseupd_` (ARPACK SAVE'd state) AND threads through a static `current_system` reverse-communication shim | concurrent calls corrupt both | per-class `sse_call_mutex` covering both concerns |

</details>

<details>
<summary>Important correction to the 2015 issue framing</summary>

The original issue text said *"VXL is not threadsafe... due to the limitations of f2c in v3p/netlib. It produces static variables..."*. Investigating the actual f2c output shows this is over-broad:

- The 165 `.c` files with file-scope `static` declarations in `v3p/netlib/` are **overwhelmingly read-only constants** that f2c emits for FORTRAN's pass-by-reference convention (`static integer c__1 = 1;` so a routine has an addressable `1` to pass). These never mutate and are naturally thread-safe.
- The actual mutable SAVE'd state lives in **iterative** solvers — ARPACK, L-BFGS-B — because their per-call solver history needs to persist across reverse-communication callback boundaries.
- **Dense LAPACK/BLAS** (`dgesvd_`, `dgemm_`, `dgetrf_`, …) is therefore reentrant in practice. `vnl_svd`, `vnl_qr`, `vnl_cholesky`, `vnl_lu_decomp`, `vnl_real_eigensystem`, `vnl_symmetric_eigensystem`, `vnl_levenberg_marquardt`, etc. can all be called concurrently on independent inputs without locking.

This is documented in `core/vnl/algo/README_threading.md` with a per-solver inventory.

The proper fix for the iterative-path band-aid is issue #23 (regenerate netlib via thread-safe LAPACK/ARPACK). Once that lands the band-aid mutex can be removed.

</details>

<details>
<summary>Commit ordering and detour</summary>

```
555ba83d36  DOC:   threading README
d2dc0845ea  BUG:   ARPACK + L-BFGS-B band-aid mutex
cca9981137  BUG:   vsl_indent shared-map race
888f404967  BUG:   vsl_binary_loader_base TOCTOU
3ac73cef2c  BUG:   vil_file_format add_file_format race
```

The vsl_binary_loader_base commit's first attempt put the mutex in a separate Meyers-singleton from the registry data. At program exit, the lazily-constructed mutex destructed before the registry, and the registry's destructor then locked dead memory → 38 test aborts with `mutex lock failed: Invalid argument`. Fixed by embedding the mutex as a struct member of the registry holder so they share lifetime. The detour and lesson are recorded in the commit message of `888f404967` so the next maintainer who tries to "simplify" by splitting them again won't repeat the bug.

</details>

<details>
<summary>Verification</summary>

Per-commit, on every commit in this PR:

```
cmake -G Ninja -S . -B build-contrib -DVXL_BUILD_CONTRIB=ON -DCMAKE_BUILD_TYPE=Release
ninja -C build-contrib -j10              # exit 0 every commit
ctest --test-dir build-contrib -j10      # 705/705 every commit (after rerunning the
                                         #   pre-existing clsfy_test_adaboost flake)
```

Tested on macOS 26.4 SDK with AppleClang 21.0.0.

</details>

<!--
provenance: claude-code session 2026-05-07 (fix/issue-22-singleton-races)
issue: #22 (Ensure that VXL APIs are reentrant)
related_issue: #23 (upgrade netlib to LAPACK; would let us drop the band-aid mutex in vnl_lbfgsb / vnl_sparse_symmetric_eigensystem)
related_files:
  - core/vil/vil_file_format.cxx
  - core/vsl/vsl_binary_loader_base.cxx
  - core/vsl/vsl_indent.cxx
  - core/vnl/algo/vnl_lbfgsb.cxx
  - core/vnl/algo/vnl_sparse_symmetric_eigensystem.cxx
  - core/vnl/algo/README_threading.md (new)
post_merge_action: close #22; #23 remains open as the proper-fix tracking issue
-->
