### PR TITLE
Guarded debug statements in vsph_unit_sphere

### DIFF
--- a/contrib/brl/bbas/vsph/vsph_unit_sphere.cxx
+++ b/contrib/brl/bbas/vsph/vsph_unit_sphere.cxx
@@ -245,7 +245,7 @@ void vsph_unit_sphere::add_uniform_views()
       }
     }
 
-    if (verbose_&&i%1000 ==0)
+    if (verbose_ && i % 1000 == 0)
       std::cout << '.' << std::flush;
 
     int idx0 = triangles[i][0];
@@ -268,9 +268,8 @@ void vsph_unit_sphere::add_uniform_views()
     else
       triangles_.emplace_back(sv2, sv1, sv0, coord_sys_);
   }
-  std::cout << '\n' << std::flush;
   if(verbose_)
-    std::cout << "finished refine\n"
+    std::cout << "\nfinished refine\n"
               << "start constructing edges from " << ntri << " triangles"
               << std::endl;
   delete verts;
@@ -307,7 +306,7 @@ void vsph_unit_sphere::add_uniform_views()
       if (!find_edge(e))
         this->insert_edge(e);
     }
-    if (i%1000 ==0)
+    if (verbose_ && i % 1000 == 0)
       std::cout << '+' << std::flush;
   }
   if(verbose_)


### PR DESCRIPTION
Guards _all_ debug statements in `vsph_unit_sphere` using the `verbose_` field of the class.

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
