### PR TITLE
BUILD: Export vxl_platform_math even when VXL_NO_EXPORT is ON

### DIFF
--- a/config/cmake/Modules/ConfigurePlatformMathTarget.cmake
+++ b/config/cmake/Modules/ConfigurePlatformMathTarget.cmake
@@ -2,14 +2,14 @@
 add_library(vxl_platform_math INTERFACE)
 # Ensure the interface target participates in the export set so that
 # exported libraries depending on it do not trigger CMake export errors.
-# INTERFACE libraries have no artifacts, but can and must be exported
-# if referenced by other exported targets.
-if(NOT VXL_NO_EXPORT)
-    # Participate in build-tree export
-    set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES vxl_platform_math)
-    # Participate in install-tree export
-    install(TARGETS vxl_platform_math EXPORT ${VXL_INSTALL_EXPORT_NAME})
-endif()
+# INTERFACE libraries have no artifacts, but can and must be exported if
+# referenced by other exported targets -- including when VXL_NO_EXPORT is ON.
+# In that mode VXL is embedded in a host project (e.g. ITK) that exports its
+# own targets; itkvcl/itkv3p_netlib link vxl_platform_math while being part of
+# the host's export set, so the interface target must join that set or
+# install(EXPORT ...) fails to generate.
+set_property(GLOBAL APPEND PROPERTY VXLTargets_MODULES vxl_platform_math)
+install(TARGETS vxl_platform_math EXPORT ${VXL_INSTALL_EXPORT_NAME})
 if(CMAKE_VERSION VERSION_LESS 3.14.0)
   # Revert to previous behavior of requiring libm
   target_link_libraries(vxl_platform_math INTERFACE m)


### PR DESCRIPTION
Export the `vxl_platform_math` INTERFACE target even when `VXL_NO_EXPORT` is ON, so that VXL can be embedded in a host project (ITK) that exports its own targets.

`config/cmake/Modules/ConfigurePlatformMathTarget.cmake` only added `vxl_platform_math` to the install export set under `if(NOT VXL_NO_EXPORT)`. But `VXL_NO_EXPORT=ON` is exactly the embedding mode: `itkvcl` and `itkv3p_netlib` link `vxl_platform_math` and are placed in the host's export set, so CMake requires the interface target to be in an export set too. With the guard, `install(EXPORT ...)` fails at generate time:

```
install(EXPORT "ITKTargets" ...) includes target "itkvcl" which requires
target "vxl_platform_math" that is not in any export set.
```

The fix removes the guard so the interface target is always exported. It has no artifacts, so this is a no-op for standalone builds.

<details>
<summary>Validation</summary>

- Standalone `cmake` generate succeeds with the change, both default and `-DVXL_NO_EXPORT=ON`.
- This is the same export-set arrangement already used successfully when this tree is embedded in ITK.
</details>

<!--
Unblocks the ITK VNL re-ingest: every install/export-enabled CI job on
InsightSoftwareConsortium/ITK#6423 (ARM, Pixi-Cxx, Linux.Python) fails at the
CMake generate step with the "vxl_platform_math ... not in any export set"
error; this patch is the upstream fix.
-->
