### PR TITLE
BUILD: Require C++17 in VALID_CXX_STANDARDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,12 @@ endif()
 if(NOT CMAKE_CXX_EXTENSIONS)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
-set(VALID_CXX_STANDARDS "11" "14" "17" "20" "23")
+# VXL 7 requires C++17 or newer (inline constexpr variables, structured
+# bindings, ...), so reject the older standards rather than letting an
+# explicit CMAKE_CXX_STANDARD=11/14 pass validation and then fail to compile.
+set(VALID_CXX_STANDARDS "17" "20" "23")
 if(NOT CMAKE_CXX_STANDARD IN_LIST VALID_CXX_STANDARDS )
-   MESSAGE(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} not in known standards list\n ${VALID_CXX_STANDARDS}.")
+   MESSAGE(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} is not a supported C++ standard; VXL requires one of: ${VALID_CXX_STANDARDS}.")
 endif()
 
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
Drop `"11"` and `"14"` from `VALID_CXX_STANDARDS` so that VXL 7's C++17 minimum is actually enforced.

VXL 7 defaults `CMAKE_CXX_STANDARD` to `17` and uses C++17-only constructs (`inline constexpr` variables, structured bindings), but the validity list still accepted `11`/`14`. A build configured with an explicit `-DCMAKE_CXX_STANDARD=11` passed the check and then failed to compile. With this change such a configuration is rejected up front with a clear message.

<details>
<summary>Validation</summary>

- Default configure (`CMAKE_CXX_STANDARD=17`): succeeds.
- `-DCMAKE_CXX_STANDARD=11`: now fails at configure time with
  `CMAKE_CXX_STANDARD:STRING=11 is not a supported C++ standard; VXL requires one of: 17;20;23.`
</details>

<!--
Addresses the greptile P1 raised on the ITK VNL re-ingest
(InsightSoftwareConsortium/ITK#6423, review comment r3374378710):
"VALID_CXX_STANDARDS still accepts C++11/14 but the codebase now requires C++17".
Fixing it upstream means the next ITK ingest of vxl carries the corrected list.
-->
