### PR TITLE
COMP: Drop redundant int cast in vnl_rnpoly_solve powr() calls

### DIFF
--- a/core/vnl/algo/vnl_rnpoly_solve.cxx
+++ b/core/vnl/algo/vnl_rnpoly_solve.cxx
@@ -195,8 +195,8 @@ initr(const std::vector<unsigned int> & ideg,
   r.resize(dim_);
   for (unsigned int j = 0; j < dim_; j++)
   {
-    pdg[j] = powr(static_cast<int>(ideg[j]), p[j]);
-    qdg[j] = powr(static_cast<int>(ideg[j]), q[j]);
+    pdg[j] = powr(ideg[j], p[j]);
+    qdg[j] = powr(ideg[j], q[j]);
     r[j] = q[j] / p[j];
   }
 }


### PR DESCRIPTION
Remove the redundant `static_cast<int>` in the two `powr()` calls in `vnl_rnpoly_solve.cxx::initr`.

`powr()` takes an `unsigned int` and `ideg` is `std::vector<unsigned int>`, so `static_cast<int>(ideg[j])` casts the value *down* to `int` only for it to implicitly widen back to `unsigned int` at the call — an unnecessary sign-conversion round-trip. Passing `ideg[j]` directly is the exact-type match.

<details>
<summary>Validation</summary>

`vnl_rnpoly_solve.cxx` compiles cleanly with the change (no sign-conversion warning).
</details>

<!--
Addresses the greptile P2 raised on the ITK VNL re-ingest
(InsightSoftwareConsortium/ITK#6423, review comment r3374378599):
"Unnecessary (wrong-direction) cast after signature change to unsigned int".
The same code is present in vxl/vxl master, so fixing it upstream means the
next ITK ingest carries the clean call.
-->
