### PR TITLE
COMP: Validate size before narrowing in vnl_powell_1dfun delegating ctor

### DIFF
--- a/core/vnl/algo/vnl_powell.cxx
+++ b/core/vnl/algo/vnl_powell.cxx
@@ -24,6 +24,20 @@
 #  endif
 #endif
 
+namespace
+{
+//: Validate that a size_t fits in an int before narrowing, so the guard
+// runs before the conversion is used. A delegating constructor evaluates
+// its target's argument in the member-initializer, before its own body, so
+// the check cannot be written as an assert in the constructor body.
+inline int
+vnl_powell_checked_int(size_t n)
+{
+  assert(n <= static_cast<size_t>(std::numeric_limits<int>::max()));
+  return static_cast<int>(n);
+}
+} // namespace
+
 class vnl_powell_1dfun : public vnl_cost_function
 {
 public:
@@ -43,10 +57,8 @@ public:
     , tmpx_(n)
   {}
   vnl_powell_1dfun(size_t n, vnl_cost_function * func, vnl_powell * p)
-    : vnl_powell_1dfun(static_cast<int>(n), func, p)
-  {
-    assert(n <= static_cast<size_t>(std::numeric_limits<int>::max()));
-  }
+    : vnl_powell_1dfun(vnl_powell_checked_int(n), func, p)
+  {}
 
   void
   init(const vnl_vector<double> & x0, const vnl_vector<double> & dx)


### PR DESCRIPTION
Validate the size before narrowing `size_t` to `int` in the delegating `vnl_powell_1dfun` constructor, so the bounds check runs *before* the conversion.

The `size_t`-taking constructor delegated with `static_cast<int>(n)` in its member-initializer list, which is evaluated before the constructor body. The `assert(n <= INT_MAX)` therefore ran only after the narrowing had already happened: for `n > INT_MAX` the delegated `int` constructor was invoked with a wrapped value before the guard could fire. The fix moves the check into a small helper (`vnl_powell_checked_int`) that asserts and then converts, called from the initializer list.

<details>
<summary>Validation</summary>

`vnl_powell.cxx` compiles cleanly with the change.
</details>

<!--
Addresses the greptile P1 raised on the ITK VNL re-ingest
(InsightSoftwareConsortium/ITK#6423, review comment r3374378512):
"Assert fires after the narrowing cast, not before". The same delegating
constructor is present in vxl/vxl master, so fixing it upstream means the
next ITK ingest carries the corrected guard ordering.
-->
