### PR TITLE
BUG: Define vnl_math::sqrteps as exactly-representable 0x1p-26

### DIFF
--- a/core/vnl/vnl_math.h
+++ b/core/vnl/vnl_math.h
@@ -123,7 +123,7 @@ inline constexpr double euler = 0.57721566490153286061;            // http://oei
 
 //: IEEE double machine precision
 inline constexpr double eps = std::numeric_limits<double>::epsilon();
-inline constexpr double sqrteps = 1.490116119384766e-08;
+inline constexpr double sqrteps = 0x1p-26; // sqrt(eps) = sqrt(2^-52) = 2^-26, exactly representable
 //: IEEE single machine precision
 inline constexpr float float_eps = std::numeric_limits<float>::epsilon();
 inline constexpr float float_sqrteps = 3.4526698300e-4f;


### PR DESCRIPTION
Define `vnl_math::sqrteps` as the exactly-representable `0x1p-26` instead of the 1-ULP-high decimal literal `1.490116119384766e-08`.

<details>
<summary>Why 0x1p-26 is the correct value</summary>

`sqrteps` is `sqrt(eps)` where `eps = std::numeric_limits<double>::epsilon() = 2^-52`. Therefore `sqrteps = sqrt(2^-52) = 2^-26`, a power of two and exactly representable as a `double` (decimal `1.490116119384765625e-8`).

The previous literal `1.490116119384766e-08` is `3.75e-24` above that exact value, exceeding the half-ULP threshold (~`1.65e-24`), so it rounds to `2^-26 + 2^-78` — one ULP high. `0x1p-26` is the simplest unambiguous spelling and equals what IEEE-754 correctly-rounded `sqrt(eps)` returns at runtime (and what C++26 `constexpr std::sqrt(eps)` will yield).

`vgl` already relies on the exact value: `core/vgl/vgl_triangle_3d.cxx` computes `sqrteps = std::sqrt(std::numeric_limits<double>::epsilon())` at runtime, which is exactly `0x1p-26`.

</details>

<details>
<summary>Impact / testing</summary>

- No vnl test asserts the literal value — `core/vnl/tests/test_math.cxx` only takes `&vnl_math::sqrteps` (symbol-existence check).
- Existing consumers (`pdf1d`, `clsfy`) use `sqrteps` as a convergence/comparison tolerance, where a 1-ULP change is negligible.
- Verified locally: the hex literal compiles under C++17 and `0x1p-26 == std::sqrt(std::numeric_limits<double>::epsilon())`.

</details>

<!--
provenance: surfaced via greptile review on InsightSoftwareConsortium/ITK PR #6427
  https://github.com/InsightSoftwareConsortium/ITK/pull/6427#discussion_r3385019250
related: ITK decouples itk::Math from vnl_math (PR #6427); ITK applied the same fix in its vendored copy.
-->
