### PR TITLE
Extend vil image to 8 planes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ foreach(p
 endforeach()
 
 project(VXL #Project name must be all caps to have properly generated VXL_VERSION_* variables
-    VERSION 7.0.0.0 # defines #MAJOR,MINOR,PATCH,TWEAK}; major bump signals C++17 minimum
+    VERSION 7.0.0.1 # defines #MAJOR,MINOR,PATCH,TWEAK}; major bump signals C++17 minimum
     DESCRIPTION "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding."
     LANGUAGES CXX C)
 

--- a/core/vil/file_formats/vil_tiff.cxx
+++ b/core/vil/file_formats/vil_tiff.cxx
@@ -356,8 +356,10 @@ vil_tiff_file_format::make_blocked_output_image(vil_stream * vs,
   // this constructor for h defines that the resource is to
   // be setup for writing
   auto * h = new vil_tiff_header(tss->tif, nx, ny, nplanes, format, size_block_i, size_block_j);
+
   if (!h->format_supported)
   {
+    std::cout << "FORMAT NOT SUPPORED " << nplanes << std::endl;
 #if HAS_GEOTIFF
     XTIFFClose(tss->tif);
 #else
@@ -1289,6 +1291,7 @@ vil_tiff_image::put_view(const vil_image_view_base & im, unsigned i0, unsigned j
     for (unsigned bj = bj_start; bj <= bj_end; ++bj)
       if (!this->put_block(bi, bj, i0, j0, im))
         return false;
+
   return true;
 }
 
@@ -1311,7 +1314,9 @@ vil_tiff_image::put_block(unsigned block_index_i, unsigned block_index_j, const 
 
   // write the block to the tiff file
   const bool good_write = write_block_to_file(block_index_i, block_index_j, bytes_per_block, block_buf);
+
   delete[] block_buf;
+
   return good_write;
 }
 

--- a/core/vil/file_formats/vil_tiff_header.cxx
+++ b/core/vil/file_formats/vil_tiff_header.cxx
@@ -112,6 +112,7 @@ vil_tiff_header::read_header()
 #ifdef DEBUG
   std::cout << date_and_time() << '\n';
 #endif
+
   //====
   // Determine the endian state of the file and machine
   file_is_big_endian_ = TIFFIsByteSwapped(tif_) > 0;
@@ -248,7 +249,6 @@ vil_tiff_header::read_header()
     for (uint32_t i = 0; i < count; ++i)
       no_data_value_.push_back(data[i]);
   }
-
   return this->compute_pixel_format();
   // int success = TIFFReadDirectory(tif_);
 }
@@ -388,7 +388,6 @@ vil_tiff_header::compute_pixel_format()
     pix_fmt = VIL_PIXEL_FORMAT_UNKNOWN;
     return false;
   }
-
   const vxl_uint_16 b = bits_per_sample.val;
   const vxl_uint_16 bbs = bytes_per_sample();
   nplanes = 1;
@@ -563,6 +562,9 @@ vil_tiff_header::compute_pixel_format()
                   pix_fmt = VIL_PIXEL_FORMAT_RGBA_UINT_16;
                 return true;
               }
+              case 8:
+                nplanes = 8;
+                return true;
               default:
                 pix_fmt = VIL_PIXEL_FORMAT_UNKNOWN;
                 return false;
@@ -772,6 +774,9 @@ vil_tiff_header::set_header(unsigned ni,
     case 4:
       photometric.val = 2;
       break;
+    case 8:
+      photometric.val = 2;
+      break;
     default:
       return false;
   }
@@ -821,7 +826,7 @@ vil_tiff_header::vil_tiff_header(TIFF * tif,
   , format_supported(this->set_header(ni, nj, nplanes, fmt, size_block_i, size_block_j))
 {
 
-
+  
   if (!format_supported)
     return;
   write_short_tag(tif_, TIFFTAG_PHOTOMETRIC, photometric);


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the vxl repository. This text will not
be part of the Pull Request. -->

<!--
Start vxl commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request
(https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically close a related issues using keywords
(https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->

 :no_entry_sign: --> Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
:no_entry_sign: --> Makes design changes to existing vxl/core\* API that requires semantic versioning increase
<!--
If either of the above two items is true,
    the vxl/CMakeLists.txt project VERSION needs to bumped to a higher version
    VERSION 2.0.2.0 # defines #VXL_VERSION{,MAJOR,MINOR,PATCH,TWEAK}
    Follow the conventions described at https://semver.org
-->
 :no_entry_sign: --> Makes changes to the contributed directory API DOES NOT require semantic versioning increase
 :no_entry_sign: --> Adds tests and baseline comparison (quantitative).
:no_entry_sign: --> Adds Documentation.


<!-- **Thanks for contributing to vxl!** -->
