### PR TITLE
COMP: add missing brdb_value_t<vpgl_camera_double_sptr> instantiation to bbas_pro (failure on RISC-V)

### DIFF
--- a/contrib/brl/bpro/core/bbas_pro/Templates/brdb_value_t+vpgl_camera_double_sptr-.cxx
+++ b/contrib/brl/bpro/core/bbas_pro/Templates/brdb_value_t+vpgl_camera_double_sptr-.cxx
@@ -1,0 +1,5 @@
+#include "vpgl/vpgl_camera_double_sptr.h"
+#include <vpgl/io/vpgl_io_camera.h>
+#include <brdb/brdb_value.hxx>
+
+BRDB_VALUE_INSTANTIATE(vpgl_camera_double_sptr, "vpgl_camera_double_sptr");


### PR DESCRIPTION

Several bbas_pro process files (bbas_camera_angles_process, bpgl_heightmap_from_disparity_process, bpgl_rectify_affine_image_pair_process) use vpgl_camera_double_sptr via brdb_value_t but the library lacks its own explicit template instantiation.

On other architectures the symbols are pulled in implicitly through transitive link dependencies, but on RISC-V the stricter --as-needed linker behavior exposes the missing instantiation, causing undefined reference errors for brdb_value_t<vpgl_camera_double_sptr> methods (assign, eq, lt, b_read_value, b_write_value, get_type_string) when linking libbbas_pro.so consumers such as bbgm_pro_test_all.

Assisted-by: Claude (Anthropic)

Closes: #948 


- :no_entry_sign: Makes breaking changes to the vxl/core/\* API that requires semantic versioning increase
- :no_entry_sign: Makes design changes to existing vxl/core\* API that requires semantic versioning increase

- :no_entry_sign: Makes changes to the contributed directory API DOES NOT require semantic versioning increase
- :no_entry_sign: Adds tests and baseline comparison (quantitative).
- :no_entry_sign: Adds Documentation.
